### PR TITLE
feat(actions): rename github action secrets to labs

### DIFF
--- a/.github/workflows/storybook-publish-production.yml
+++ b/.github/workflows/storybook-publish-production.yml
@@ -37,9 +37,9 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks
         env:
-          AWS_S3_BUCKET: ${{ secrets.C4AI_COS_BUCKET_PRODUCTION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.C4AI_COS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.C4AI_COS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.C4AI_COS_REGION }}
-          AWS_S3_ENDPOINT: https://${{ secrets.C4AI_COS_ENDPOINT }}
+          AWS_S3_BUCKET: ${{ secrets.CLABS_COS_BUCKET_PRODUCTION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLABS_COS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLABS_COS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.CLABS_COS_REGION }}
+          AWS_S3_ENDPOINT: https://${{ secrets.CLABS_COS_ENDPOINT }}
           SOURCE_DIR: 'storybook-static'

--- a/.github/workflows/storybook-publish-staging.yml
+++ b/.github/workflows/storybook-publish-staging.yml
@@ -37,9 +37,9 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks
         env:
-          AWS_S3_BUCKET: ${{ secrets.C4AI_COS_BUCKET_STAGING }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.C4AI_COS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.C4AI_COS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.C4AI_COS_REGION }}
-          AWS_S3_ENDPOINT: https://${{ secrets.C4AI_COS_ENDPOINT }}
+          AWS_S3_BUCKET: ${{ secrets.CLABS_COS_BUCKET_STAGING }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLABS_COS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLABS_COS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.CLABS_COS_REGION }}
+          AWS_S3_ENDPOINT: https://${{ secrets.CLABS_COS_ENDPOINT }}
           SOURCE_DIR: 'storybook-static'


### PR DESCRIPTION
Closes #

With the renaming of `Carbon for AI` to `Carbon Labs` we are renaming the github action secrets to be consistent

#### Changelog

**Changed**

- Change prefix of github action secrets to `CLABS` for the storybook env workflows
