### PR TITLE
chore(feedback): add stackblitz example for feedback component

### DIFF
--- a/globals/internal/storybook-cdn.ts
+++ b/globals/internal/storybook-cdn.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2024
+ * Copyright IBM Corp. 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/globals/internal/storybook-cdn.ts
+++ b/globals/internal/storybook-cdn.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Renders the component(s) script tag content and returns back the string
+ *
+ * @param {Array} components array of component names
+ * @param {string} version version
+ */
+function _renderScript(components, version) {
+  let scripts = '';
+  components.forEach((component) => {
+    scripts += `<script type="module" src="https://1.www.s81c.com/common/carbon/labs/${component}/${version}/index.min.js"></script>\n`;
+  });
+  return scripts;
+}
+
+/**
+ * This is the markdown block for JS via CDN
+ *
+ * @param {Array} components array of components to render
+ * @param {Array} components.components components to render
+ * @param {Object} packageJson package.json object
+ */
+export const cdnJs = ({ components }, packageJson) => {
+  return `
+### JS (via CDN)
+
+ > NOTE: Only one version of artifacts should be used. Mixing versions will cause rendering issues.
+
+ \`\`\`html
+ // SPECIFIC VERSION (available starting v2.0.0)
+ ${_renderScript(components, `v${packageJson.version}`)}
+ \`\`\`
+   `;
+};
+
+/**
+ * This is the markdown block for CSS via CDN
+ */
+export const cdnCss = () => {
+  return `
+### Carbon CDN style helpers (optional)
+
+There are optional CDN artifacts available that can assist with global Carbon
+styles in lieu of including into your specific application bundle.
+
+[Click here to learn more](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/packages/web-components/docs/carbon-cdn-style-helpers.md)\n\n
+  `;
+};

--- a/packages/feedback/__stories__/feedback.mdx
+++ b/packages/feedback/__stories__/feedback.mdx
@@ -34,7 +34,7 @@ You'll also need to import the theming tokens from `@carbon/styles` either from
 npm or from our CDN helpers. Checkout our Stackblitz example above to see how
 that is implemented.
 
-<Markdown>{`${cdnJs({ components: ['button'] }, packageJson)}`}</Markdown>
+<Markdown>{`${cdnJs({ components: ['feedback'] }, packageJson)}`}</Markdown>
 <Markdown>{`${cdnCss()}`}</Markdown>
 
 ### HTML

--- a/packages/feedback/__stories__/feedback.mdx
+++ b/packages/feedback/__stories__/feedback.mdx
@@ -1,0 +1,64 @@
+import { ArgTypes, Markdown, Meta } from '@storybook/blocks';
+import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
+import * as FeedbackStories from './feedback.stories';
+import packageJson from '../package.json';
+
+<Meta of={FeedbackStories} />
+
+# Feedback
+
+> 💡 Check our
+> [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-labs/tree/main/packages/feedback/examples/feedback)
+> example implementation.
+
+[![Edit carbon-labs](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-labs/tree/main/packages/feedback/examples/feedback)
+
+## Overview
+
+The feedback component allows the user to highlight parts from the generated AI
+content and submit feedback.
+
+## Getting started
+
+Here's a quick example to get you started.
+
+### JS (via import)
+
+```javascript
+import '@carbon-labs/ai-feedback/es/index.js';
+```
+
+### Styles
+
+You'll also need to import the theming tokens from `@carbon/styles` either from
+npm or from our CDN helpers. Checkout our Stackblitz example above to see how
+that is implemented.
+
+<Markdown>{`${cdnJs({ components: ['button'] }, packageJson)}`}</Markdown>
+<Markdown>{`${cdnCss()}`}</Markdown>
+
+### HTML
+
+```html
+<clabs-feedback model="llama2">
+  <svg
+    focusable="false"
+    preserveAspectRatio="xMidYMid meet"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    aria-hidden="true"
+    width="24"
+    height="24"
+    viewBox="0 0 32 32"
+    slot="icon">
+    <path d="M6,30H4V2H28l-5.8,9L28,20H6ZM6,18H24.33L19.8,11l4.53-7H6Z"></path>
+  </svg>
+  The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for
+  those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et
+  Malorum" by Cicero are also reproduced in their exact original form,
+  accompanied by English versions from the 1914 translation by H.
+  Rackham.</clabs-feedback
+>
+```
+
+<ArgTypes of="clabs-feedback" />

--- a/packages/feedback/__stories__/feedback.stories.js
+++ b/packages/feedback/__stories__/feedback.stories.js
@@ -6,7 +6,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import '../feedback';
+import '../components/feedback/feedback';
 import Flag24 from '@carbon/web-components/es/icons/flag/24.js';
 import { html } from 'lit';
 /**
@@ -15,7 +15,6 @@ import { html } from 'lit';
 
 export default {
   title: 'Components/Feedback/Feedback',
-  tags: ['autodocs'],
 };
 
 const defaultArgs = {

--- a/packages/feedback/examples/feedback/.gitignore
+++ b/packages/feedback/examples/feedback/.gitignore
@@ -1,0 +1,22 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.cache
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/feedback/examples/feedback/cdn.html
+++ b/packages/feedback/examples/feedback/cdn.html
@@ -1,0 +1,61 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+  <head>
+    <title>@carbon-labs/ai-feedback example</title>
+    <meta charset="UTF-8" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/themes.css"
+    />
+    <style>
+      /* Suppress custom element until styles are loaded */
+      clabs-feedback:not(:defined) {
+        display: none;
+      }
+    </style>
+    <script
+      type="module"
+      src="https://1.www.s81c.com/common/carbon/labs/feedback/v0.3.0/index.min.js"
+    ></script>
+  </head>
+  <body class="cds-theme-zone-white">
+    <clabs-feedback model="llama-2"
+      ><svg
+        focusable="false"
+        preserveAspectRatio="xMidYMid meet"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="currentColor"
+        aria-hidden="true"
+        width="24"
+        height="24"
+        viewBox="0 0 32 32"
+        slot="icon"
+      >
+        <!--?lit$372005272$-->
+        <path
+          d="M6,30H4V2H28l-5.8,9L28,20H6ZM6,18H24.33L19.8,11l4.53-7H6Z"
+        ></path></svg
+      >The standard chunk of Lorem Ipsum used since the 1500s is reproduced
+      below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus
+      Bonorum et Malorum" by Cicero are also reproduced in their exact original
+      form, accompanied by English versions from the 1914 translation by H.
+      Rackham.</clabs-feedback
+    >
+  </body>
+</html>

--- a/packages/feedback/examples/feedback/index.html
+++ b/packages/feedback/examples/feedback/index.html
@@ -1,0 +1,44 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+  <head>
+    <title>@carbon/ibmdotcom-web-components example</title>
+    <meta charset="UTF-8" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
+    />
+    <link rel="stylesheet" href="src/styles.scss" />
+    <script type="module" src="src/index.js"></script>
+  </head>
+  <body>
+    <clabs-feedback model="llama-2"
+      ><svg
+        focusable="false"
+        preserveAspectRatio="xMidYMid meet"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="currentColor"
+        aria-hidden="true"
+        width="24"
+        height="24"
+        viewBox="0 0 32 32"
+        slot="icon"
+      >
+        <path
+          d="M6,30H4V2H28l-5.8,9L28,20H6ZM6,18H24.33L19.8,11l4.53-7H6Z"
+        ></path></svg
+      >The standard chunk of Lorem Ipsum used since the 1500s is reproduced
+      below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus
+      Bonorum et Malorum" by Cicero are also reproduced in their exact original
+      form, accompanied by English versions from the 1914 translation by H.
+      Rackham.</clabs-feedback
+    >
+  </body>
+</html>

--- a/packages/feedback/examples/feedback/package.json
+++ b/packages/feedback/examples/feedback/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "carbon-labs-ai-feedback-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "clean": "rimraf node_modules dist .cache",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2",
+    "sass": "^1.55.0",
+    "vite": "^3.2.2"
+  },
+  "dependencies": {
+    "@carbon/styles": "^1.53.0",
+    "@carbon-labs/ai-feedback": "0.3.0"
+  }
+}

--- a/packages/feedback/examples/feedback/src/index.js
+++ b/packages/feedback/examples/feedback/src/index.js
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '@carbon-labs/ai-feedback/es/index.js';

--- a/packages/feedback/examples/feedback/src/styles.scss
+++ b/packages/feedback/examples/feedback/src/styles.scss
@@ -1,0 +1,17 @@
+//
+// Copyright IBM Corp. 2024
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}


### PR DESCRIPTION
Contributes to #98 

Adds `feedback.mdx` file for documentation which includes the link to the stackblitz example. 

Adds example folder for `feedback` containing stackblitz files

<img width="1135" alt="Screenshot 2024-04-12 at 7 03 26 PM" src="https://github.com/carbon-design-system/carbon-labs/assets/54281166/f4be1911-528a-4956-8fe0-b7278bf3593b">

#### Changelog

**New**

- `feedback.mdx` with link to Stackblitz example which is also added in this PR
- `storybook-cdn` file added to global to generate the cdn links

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
