### PR TITLE
chore(storybook): remove cwc from root package.json

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,7 +9,6 @@
  */
 
 import { html } from 'lit';
-import '@carbon/web-components/es/components/skip-to-content/skip-to-content.js';
 import containerStyles from './_container.scss?inline';
 import { white, g10, g90, g100 } from '@carbon/themes';
 import { breakpoints } from '@carbon/layout';
@@ -165,9 +164,6 @@ export const decorators = [
     return html` <style>
         ${containerStyles}
       </style>
-      <cds-skip-to-content href="#main-content"
-        >Skip to main content</cds-skip-to-content
-      >
       <div
         id="main-content"
         name="main-content"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "@carbon/styles": "1.53.0",
-    "@carbon/web-components": "2.9.0",
     "lit": "^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9992,7 +9992,6 @@ __metadata:
     "@carbon/styles": "npm:1.53.0"
     "@carbon/themes": "npm:11.36.0"
     "@carbon/type": "npm:11.26.0"
-    "@carbon/web-components": "npm:2.9.0"
     "@commitlint/cli": "npm:^19.0.0"
     "@commitlint/config-conventional": "npm:^19.0.0"
     "@custom-elements-manifest/analyzer": "npm:^0.9.0"


### PR DESCRIPTION
Closes #

Removing `@carbon/web-components` package from root as we're only using it for the `skip-to-content` component in our storybook. 

