### PR TITLE
chore(docs): add initiative information to component documentation

### DIFF
--- a/packages/chat/components/cardElement/__stories__/docs.mdx
+++ b/packages/chat/components/cardElement/__stories__/docs.mdx
@@ -5,7 +5,13 @@ import packageJson from '../../../package.json';
 
 <Meta of={cardElementStories} />
 
-# Carbon-Labs Card Handbook
+# Carbon AI Chat: Card
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`
 
 ## Table of Contents
 
@@ -17,31 +23,31 @@ import packageJson from '../../../package.json';
   - [JS via import](#js-via-import)
 - [Styles](#styles)
 
-## Overview 
+## Overview
 <a id="overview"></a>
 
 The Chat component is a collaboration between the **IBM Research Visual AI Lab (VAIL)** and the **Carbon Design Team** to provide an open-source, easily expandable chat interface to interact with large language models. Our core values are: open-source collaboration, universal support, ease of use and the in-depth customization Carbon is known for.
 
 The **Carbon Labs Card** component aims to render any HTTP url provided by users or LLM and display a flexible and informative Card component.
 
-### Troubleshooting 
-<a id="troubleshooting"></a> 
+### Troubleshooting
+<a id="troubleshooting"></a>
 
 Contact **Owen Cornec** on Slack or at **o.cornec@ibm.com** for requests regarding general information, installation, trouble-shooting and custom features.
 
-## Installation 
+## Installation
 <a id="installation"></a>
 
 Here's a quick example to get you started.
 
-### JS via import 
+### JS via import
 <a id="js-via-import"></a>
 
 ```javascript
 import '@carbon-labs/ai-chat-card/es/index.js';
 ```
 
-## Attributes and Properties 
+## Attributes and Properties
 <a id="attributes-and-properties"></a>
 <table>
   <thead>
@@ -83,9 +89,9 @@ import '@carbon-labs/ai-chat-card/es/index.js';
 ## Basic usage
 
 ### `content` only
-When only a url is specified, `type` is automatically detected based on the ending of the url string. 
+When only a url is specified, `type` is automatically detected based on the ending of the url string.
 ```html
-<clabs-chat-card 
+<clabs-chat-card
     content="htttp://www.google.com">
 </clabs-chat-card>
 ```
@@ -93,7 +99,7 @@ When only a url is specified, `type` is automatically detected based on the endi
 ### `content` + `api-url`
 When only a url is specified with an api, a proxy fetch will be attempted to attain the title, preview image url and description. if unsuccessful, these fields will be auto-populated solely on the url given:
 ```html
-<clabs-chat-card 
+<clabs-chat-card
     content="htttp://www.google.com"
     api-url="localhost:5000/preview_link">
 </clabs-chat-card>
@@ -102,7 +108,7 @@ When only a url is specified with an api, a proxy fetch will be attempted to att
 ### `content` + `type`
 If `type` is specified the Card will render as specified, for example `video` with create a custom video player and attempt to load the `content` as is:
 ```html
-<clabs-chat-card 
+<clabs-chat-card
     content="htttp://www.google.com"
     type="video">
 </clabs-chat-card>
@@ -111,7 +117,7 @@ If `type` is specified the Card will render as specified, for example `video` wi
 ## Advanced usage with custom cardElements JSON
 Specify a 'cardElements' JSON object in the card component to render as-is:
 ```html
-<clabs-chat-card 
+<clabs-chat-card
     card-elements={JSONobject}>
 </clabs-chat-card>
 ```

--- a/packages/chat/components/carouselElement/__stories__/carouselElement.stories.js
+++ b/packages/chat/components/carouselElement/__stories__/carouselElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Carousel',
-  tags: ['autodocs'],
 };
 
 const carouselExamples = [

--- a/packages/chat/components/carouselElement/__stories__/docs.mdx
+++ b/packages/chat/components/carouselElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as carouselElementStories from './carouselElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={carouselElementStories} />
+
+# Carbon AI Chat: Carousel
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/chartElement/__stories__/docs.mdx
+++ b/packages/chat/components/chartElement/__stories__/docs.mdx
@@ -7,6 +7,11 @@ import packageJson from '../../../package.json';
 
 # Chart Handbook
 <br/>
+* Status: Draft
+* Lab owner(s): Owen Cornec (o.cornec@ibm.com)
+* Target library: TBD
+* Target library Support channel: N/A
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -26,7 +31,7 @@ import packageJson from '../../../package.json';
   - [Vega as the back bone, Carbon as the output](#vega-and-carbon)
   - [Advantages](#advantages)
   - [Disadvantages](#disadvantages)
-  
+
 
 ## Overview
 <a id="overview"></a>
@@ -35,7 +40,7 @@ import packageJson from '../../../package.json';
 Like all components in Carbon Labs, Charts are invoked inside the core Chat component but can easily be imported separately and used independently. By default the `carbonify` attribute is enabled which extensively edits the specification styling in order to recreate Carbon Charts styling. This overrides and edits all axis/legend/title/encoding/gradient/colorscale values to display the specification as a clone of classic Carbon Charts.
 
 * Vega-lite reference: [vega.github.io](https://vega.github.io/vega-lite/)
-* Carbon Charts reference: 
+* Carbon Charts reference:
 [charts.carbondesignsystem.com](https://charts.carbondesignsystem.com/?path=/story/docs--welcome)
 
 **Feel free to contact Owen Cornec (on Slack or o.cornec@ibm.com) if you have any issues/questions**
@@ -56,15 +61,15 @@ import '@carbon-labs/ai-chat-chart/es/index.js';
 <a id="independent-usage"></a>
 ```html
 <clabs-chat-chart
-  content = "{ ... }" 
-  container-height = "500px" 
-  container-width = "100%" 
-  theme = "g100" 
+  content = "{ ... }"
+  container-height = "500px"
+  container-width = "100%"
+  theme = "g100"
 >
 </clabs-chat-chart>
 ```
 
-### &lt;clabs-chat-chart&gt; attributes 
+### &lt;clabs-chat-chart&gt; attributes
 <a id="chart-attributes"></a>
 <table><thead><tr><td>**Attribute**</td><td>**Type**</td><td>**Default**</td><td>**Description**</td></tr></thead><tbody><tr><td>`content`</td><td>string</td><td>empty</td><td>stringified JSON object defining a Vega-lite V5 chart specification. Specifications must contain $schema, data and encoding</td></tr><tr><td>`debug`</td><td>boolean</td><td>false</td><td>shows specification editor button and displays all errors in component when in error mode, otherwise show: Chart failed to render, see console for more details</td></tr><tr><td>`container-height`</td><td>string</td><td>&quot;300px&quot;</td><td>valid CSS string to define chart height, applied to chart container while specification fills the parent container height</td></tr><tr><td>`container-width`</td><td>string</td><td>&quot;100%&quot;</td><td>same as container-height, a CSS string to define the width, applied to chart container</td></tr><tr><td>`render-method`</td><td>string</td><td>&quot;canvas&quot;</td><td>render using &quot;svg&quot; (easier to inspect in the DOM) or &quot;canvas&quot; (better performance)</td></tr><tr><td>`theme`</td><td>string</td><td>&quot;g100&quot;</td><td>this value is either &quot;g100&quot; or &quot;white&quot; and displays the chart using Carbon Chart theme colors.</td></tr><tr><td>`carbonify`</td><td>boolean</td><td>true</td><td>extensively redefine the &quot;config&quot; field of the specification to apply Carbon Chart styling to chart defined in the specification</td></tr><tr><td>`enable-legend-filtering`</td><td>boolean</td><td>false</td><td>enable filtering of data points when clicking legend</td></tr><tr><td>`enable-tooltip`</td><td>boolean</td><td>false</td><td>enable tooltip in the chart component</td></tr><tr><td>`enable-zooming`</td><td>boolean</td><td>false</td><td>enable user-zooming in the chart component</td></tr><tr><td>`enable-brushing`</td><td>boolean</td><td>false</td><td>enable user-brush selection to fetch groups of elements</td></tr><tr><td>`disable-options`</td><td>boolean</td><td>false</td><td>disable all chart option buttons, supercedes all other individual button options below</td></tr><tr><td>`disable-fullscreen`</td><td>boolean</td><td>false</td><td>hide fullscreen button</td></tr><tr><td>`disable-editor`</td><td>boolean</td><td>false</td><td>hide vega editor button</td></tr><tr><td>`disable-export`</td><td>boolean</td><td>false</td><td>hide PNG export button</td></tr><tr><td>`disable-code-inspector`</td><td>boolean</td><td>false</td><td>hide spec viewer button</td></tr><tr><td>`loading`</td><td>boolean</td><td>true</td><td>show loading animation. When content is provided chart will auto-render and this will false. If streaming: raw data is incrementally displayed until complete and rendered</td></tr></tbody></table>
 
@@ -140,7 +145,7 @@ Enabled by default, the `carbonify` field in &lt;clabs-chat-chart&gt; will appen
 
 ### Usage inside Chat within the JSON conversation object:
 <a id="usage-with-json"></a>
-If specified within a valid JSON `conversation` attribute: 
+If specified within a valid JSON `conversation` attribute:
 
 ```html
 <clabs-chat
@@ -169,7 +174,7 @@ With the `conversationJSON` object as follows:
         {"type": "chart", "content": ChartJSONString }
       ]
   }
-] 
+]
 ```
 With `ChartJSONString` as follows:
 ```json
@@ -202,13 +207,13 @@ conversation = [
 
 ### Choice of Vega-lite
 <a id="choice-of-vega"></a>
-Countless visualization libraries are available and provide many features to generate and visualize charts. Many were tested by the Visual AI Lab with a variety of models. 
+Countless visualization libraries are available and provide many features to generate and visualize charts. Many were tested by the Visual AI Lab with a variety of models.
 
 Vega-lite was chosen due to it's **longevity**, **succinctness** and **common usage**, most LLMs have a large training corpus on a variety of Vega-lite specifications. We found this greatly improved reliability during LLM generation, as hallucinations and formatting/versioning errors are common in this space. Additionally, Vega only requires a single JSON object to display any type of chart, which forgoes the need for multiple context-dependent calls.
 
 ### Vega as the back bone, Carbon as the output
 <a id="vega-and-carbon"></a>
-Carbon Charts is an excellently designed, robust and production-ready library following core Carbon design guidelines. Regrettably without fine-tuning, generation accuracy is insufficient due to a lack of examples in common training data. Carbon Charts also requires a predefined HTML chart tag (such as &lt;AreaChart&gt; &lt;SimpleBarChart&gt; etc) as well as separate `options` and `data` fields. This requires multiple queries, with the additional complexity of shared context and custom doctoring/sanitization. 
+Carbon Charts is an excellently designed, robust and production-ready library following core Carbon design guidelines. Regrettably without fine-tuning, generation accuracy is insufficient due to a lack of examples in common training data. Carbon Charts also requires a predefined HTML chart tag (such as &lt;AreaChart&gt; &lt;SimpleBarChart&gt; etc) as well as separate `options` and `data` fields. This requires multiple queries, with the additional complexity of shared context and custom doctoring/sanitization.
 
 Yet despite it's generative edge, standard Vega styling is ill-fitting in any Carbon environment which prohibits any product-side adoption. This led us to adopt a hybrid approach, using Vega-lite as a boilerplate for querying LLMs then programmatically adding and editing styles/interactions/scaling. **This component is not a replacement for Carbon Charts**: it is primarily meant to reliably handle highly-variable LLM-generated content and allow creation and editing through conversation.
 

--- a/packages/chat/components/chartElement/__stories__/docs.mdx
+++ b/packages/chat/components/chartElement/__stories__/docs.mdx
@@ -7,10 +7,11 @@ import packageJson from '../../../package.json';
 
 # Chart Handbook
 <br/>
-* Status: Draft
-* Lab owner(s): Owen Cornec (o.cornec@ibm.com)
-* Target library: TBD
-* Target library Support channel: N/A
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** TBD
+* **Target library maintainer(s) / PR Reviewer(s):** N/A
+* **Support channel:** `#carbon-labs`
 
 ## Table of Contents
 

--- a/packages/chat/components/chat/__stories__/chat.mdx
+++ b/packages/chat/components/chat/__stories__/chat.mdx
@@ -5,7 +5,13 @@ import packageJson from '../../../package.json';
 
 
 <Meta of={ChatStories} />
-# Chat Handbook
+# Carbon AI Chat
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`
 
 ## Table of Contents
 
@@ -26,12 +32,12 @@ import packageJson from '../../../package.json';
  - [Localization](#localization)
  - [Styles](#styles)
 
-## Overview 
+## Overview
 <a id="overview"></a>
 
 The Chat component is a collaboration between the **IBM Research Visual AI Lab (VAIL)** and the **Carbon Design Team** to provide an open-source, easily expandable chat interface to interact with large language models. Our core values are: **open-source collaboration**, **universal support**, **compasability** and the **in-depth customization** Carbon is known for.
 
-It is part of **Carbon Labs**, a test bed to let anyone experiment with novel LLM-enabled components. We chose **LIT web-components** as these are the bedrock of the web and guarantee longevity, thus can be used instantly in **Vanilla**, **Svelte** and **Vue**. Meanwhile **React** requires on simple step, [see here](#react-implementation) 
+It is part of **Carbon Labs**, a test bed to let anyone experiment with novel LLM-enabled components. We chose **LIT web-components** as these are the bedrock of the web and guarantee longevity, thus can be used instantly in **Vanilla**, **Svelte** and **Vue**. Meanwhile **React** requires on simple step, [see here](#react-implementation)
 
 Our primary goal is to provide a space for novel and experimental features/components to be used in and out of Chat interfaces. By fully adhering to the latest design/safety/formatting guidelines, **Labs** can accelerate and streamline adoption across IBM to respond to the fast-moving field of AI and Large Language Models.
 
@@ -47,7 +53,7 @@ All children components (Text, Code, Charts, Carousel etc) can be imported indiv
 
 
 
-### Attributes and Properties 
+### Attributes and Properties
 <a id="attributes-and-properties"></a>
 
 <table>
@@ -89,7 +95,7 @@ All children components (Text, Code, Charts, Carousel etc) can be imported indiv
 </tbody>
 </table>
 
-### Events 
+### Events
 <a id="events"></a>
 
 <table>
@@ -129,28 +135,28 @@ All children components (Text, Code, Charts, Carousel etc) can be imported indiv
   </tbody>
 </table>
 
-### Troubleshooting 
-<a id="troubleshooting"></a> 
+### Troubleshooting
+<a id="troubleshooting"></a>
 
 Contact **Owen Cornec** on Slack or at **o.cornec@ibm.com** for requests regarding general information, installation, trouble-shooting and custom features.
 
 
-## Installation 
+## Installation
 <a id="installation"></a>
 
 Here's a quick example to get you started.
 
-### JS via import 
+### JS via import
 <a id="js-via-import"></a>
 
 ```javascript
 import '@carbon-labs/ai-chat/es/index.js';
 ```
 
-## Implementation 
+## Implementation
 <a id="inplementation"></a>
 
-### Preface 
+### Preface
 <a id="preface"></a>
 
 There are three ways to implement Chat: Add an API and directly auto-parse raw LLM responses, ingest your own conversation object from a parent application or specify every layer of the chat component and slot in custom components
@@ -240,13 +246,13 @@ const conversationExample = [] //place your message structure here
 
 function App() {
   return (
-      <Chat conversation={conversationExample}> 
+      <Chat conversation={conversationExample}>
   );
 }
 export default App;
 ```
 
-### 1: Auto-rendering with an API 
+### 1: Auto-rendering with an API
 <a id="render-with-any-api"></a>
 
 #### Basic usage
@@ -321,7 +327,7 @@ If API returns a `reply` of type `object/json`, objects are rendered as-is in or
 </clabs-chat>
 ```
 
-### 2: API-less control with JSON object 
+### 2: API-less control with JSON object
 <a id="render-from-parent"></a>
 
 #### Specifiy a **conversation** object and specify the loading state and every interaction outside the chat, then update the **conversation** object to see an update:
@@ -409,10 +415,10 @@ As such you need to:
 const deletionIndex = event.detail.cutConversationIndex;
 const previousMessage = conversation[deletionIndex].text;
 displayConversation = conversation.slice(0, deletionIndex+1);
-postMessage(previousMessage); //handle mimicking a real user request here to fetch the response from your chosen API 
+postMessage(previousMessage); //handle mimicking a real user request here to fetch the response from your chosen API
 ````
 
-### Full Customization with Slotting 
+### Full Customization with Slotting
 <a id="full-customization-with-slotting"></a>
 
 ```html
@@ -468,7 +474,7 @@ Specify feedback form options like so:
 
 #### Importing into Chat
 ```html
-<clabs-chat 
+<clabs-chat
   enable-complex-feedback
   feedbackDefinitions={feedbackDefinitionsJSON}
 />
@@ -508,7 +514,7 @@ Specify any and all label values like so:
 
 ### Importing into Chat
 ```html
-<clabs-chat 
+<clabs-chat
   customLabels={customLabelsJSON}
 />
 ```

--- a/packages/chat/components/codeElement/__stories__/docs.mdx
+++ b/packages/chat/components/codeElement/__stories__/docs.mdx
@@ -5,7 +5,13 @@ import packageJson from '../../../package.json';
 
 <Meta of={CodeElementStories} />
 
-# Carbon-Labs Code Handbook
+# Carbon AI Chat: Code
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`
 
 ## Table of Contents
 
@@ -17,14 +23,14 @@ import packageJson from '../../../package.json';
   - [JS via import](#js-via-import)
 - [Styles](#styles)
 
-## Overview 
+## Overview
 <a id="overview"></a>
 
 The Chat component is a collaboration between the **IBM Research Visual AI Lab (VAIL)** and the **Carbon Design Team** to provide an open-source, easily expandable chat interface to interact with large language models. Our core values are: open-source collaboration, universal support, ease of use and the in-depth customization Carbon is known for.
 
 The **Carbon Labs Code** component aims to expand upon the **Carbon CodeSnippet** component with more flexibility, dynamic line marks, colored text and editing functions.
 
-### Attributes and Properties 
+### Attributes and Properties
 <a id="attributes-and-properties"></a>
 <table>
   <thead>
@@ -78,18 +84,18 @@ The **Carbon Labs Code** component aims to expand upon the **Carbon CodeSnippet*
   </tbody>
 </table>
 
-### Troubleshooting 
-<a id="troubleshooting"></a> 
+### Troubleshooting
+<a id="troubleshooting"></a>
 
 Contact **Owen Cornec** on Slack or at **o.cornec@ibm.com** for requests regarding general information, installation, trouble-shooting and custom features.
 
 
-## Installation 
+## Installation
 <a id="installation"></a>
 
 Here's a quick example to get you started.
 
-### JS via import 
+### JS via import
 <a id="js-via-import"></a>
 
 ```javascript

--- a/packages/chat/components/diagramElement/__stories__/diagramElement.stories.js
+++ b/packages/chat/components/diagramElement/__stories__/diagramElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Diagram',
-  tags: ['autodocs'],
 };
 
 const examples = [

--- a/packages/chat/components/diagramElement/__stories__/docs.mdx
+++ b/packages/chat/components/diagramElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './diagramElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Diagram
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/editableTextElement/__stories__/docs.mdx
+++ b/packages/chat/components/editableTextElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './editableTextElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Editable Text
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/editableTextElement/__stories__/editableTextElement.stories.js
+++ b/packages/chat/components/editableTextElement/__stories__/editableTextElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/EditableText',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/errorElement/__stories__/docs.mdx
+++ b/packages/chat/components/errorElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './errorElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Error
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/errorElement/__stories__/errorElement.stories.js
+++ b/packages/chat/components/errorElement/__stories__/errorElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Error',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/feedbackElement/__stories__/docs.mdx
+++ b/packages/chat/components/feedbackElement/__stories__/docs.mdx
@@ -5,7 +5,13 @@ import packageJson from '../../../package.json';
 
 <Meta of={feedbackElementStories} />
 
-# Carbon-Labs feedback Handbook
+# Carbon Ai Chat: Feedback
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`
 
 ## Table of Contents
 
@@ -17,31 +23,31 @@ import packageJson from '../../../package.json';
   - [JS via import](#js-via-import)
 - [Styles](#styles)
 
-## Overview 
+## Overview
 <a id="overview"></a>
 
 The Chat component is a collaboration between the **IBM Research Visual AI Lab (VAIL)** and the **Carbon Design Team** to provide an open-source, easily expandable chat interface to interact with large language models. Our core values are: open-source collaboration, universal support, ease of use and the in-depth customization Carbon is known for.
 
 The **Carbon Labs popup** component aims to render any JSON defintiion provided by the parent to display an informative popup component which provides detailed feedback about the target response/content.
 
-### Troubleshooting 
-<a id="troubleshooting"></a> 
+### Troubleshooting
+<a id="troubleshooting"></a>
 
 Contact **Owen Cornec** on Slack or at **o.cornec@ibm.com** for requests regarding general information, installation, trouble-shooting and custom features.
 
-## Installation 
+## Installation
 <a id="installation"></a>
 
 Here's a quick example to get you started.
 
-### JS via import 
+### JS via import
 <a id="js-via-import"></a>
 
 ```javascript
 import '@carbon-labs/ai-chat-feedback/es/index.js';
 ```
 
-## Attributes and Properties 
+## Attributes and Properties
 <a id="attributes-and-properties"></a>
 ### Setting values as attributes
 ```html

--- a/packages/chat/components/feedbackElement/__stories__/feedbackElement.stories.js
+++ b/packages/chat/components/feedbackElement/__stories__/feedbackElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Feedback',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/fileUploadElement/__stories__/docs.mdx
+++ b/packages/chat/components/fileUploadElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './fileUploadElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: File Upload
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/fileUploadElement/__stories__/fileUploadElement.stories.js
+++ b/packages/chat/components/fileUploadElement/__stories__/fileUploadElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/File Upload',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/footer/__stories__/docs.mdx
+++ b/packages/chat/components/footer/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './footer.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Footer
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/footer/__stories__/footer.stories.js
+++ b/packages/chat/components/footer/__stories__/footer.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Footer',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/formulaElement/__stories__/docs.mdx
+++ b/packages/chat/components/formulaElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './formulaElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Formula
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** TBD
+* **Target library maintainer(s) / PR Reviewer(s):** N/A
+* **Support channel:** `#carbon-labs`

--- a/packages/chat/components/formulaElement/__stories__/formulaElement.stories.js
+++ b/packages/chat/components/formulaElement/__stories__/formulaElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Formula',
-  tags: ['autodocs'],
 };
 
 const mathExamples = [

--- a/packages/chat/components/header/__stories__/docs.mdx
+++ b/packages/chat/components/header/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './header.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Header
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/header/__stories__/header.stories.js
+++ b/packages/chat/components/header/__stories__/header.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Header',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/historyViewer/__stories__/docs.mdx
+++ b/packages/chat/components/historyViewer/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './historyViewer.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: History viewer
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** TBD
+* **Target library maintainer(s) / PR Reviewer(s):** N/A
+* **Support channel:** `#carbon-labs`

--- a/packages/chat/components/historyViewer/__stories__/historyViewer.stories.js
+++ b/packages/chat/components/historyViewer/__stories__/historyViewer.stories.js
@@ -13,7 +13,6 @@ import examples from './example.json';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/History Viewer',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/imageElement/__stories__/docs.mdx
+++ b/packages/chat/components/imageElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './imageElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Image
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/imageElement/__stories__/imageElement.stories.js
+++ b/packages/chat/components/imageElement/__stories__/imageElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Image',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/linkListElement/__stories__/docs.mdx
+++ b/packages/chat/components/linkListElement/__stories__/docs.mdx
@@ -5,7 +5,13 @@ import packageJson from '../../../package.json';
 
 <Meta of={linkListElementStories} />
 
-# Carbon-Labs linkList Handbook
+# Carbon AI Chat: Link list
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`
 
 ## Table of Contents
 
@@ -16,13 +22,13 @@ import packageJson from '../../../package.json';
   - [JS via import](#js-via-import)
 - [Styles](#styles)
 
-## Overview 
+## Overview
 <a id="overview"></a>
 
 The Chat component is a collaboration between the **IBM Research Visual AI Lab (VAIL)** and the **Carbon Design Team** to provide an open-source, easily expandable chat interface to interact with large language models. Our core values are: open-source collaboration, universal support, ease of use and the in-depth customization Carbon is known for.
 
 
-## Simple Usage 
+## Simple Usage
 <a id="simple-usage"></a>
 The linkList component receives LLM generated lists of urls and displays them, it accepts two types of formats:
 
@@ -43,18 +49,18 @@ Note: markdown text must be seperated by commas
 Note: In this case, the link title will be auto-extracted from the URL, results may vary
 
 
-### Troubleshooting 
-<a id="troubleshooting"></a> 
+### Troubleshooting
+<a id="troubleshooting"></a>
 
 Contact **Owen Cornec** on Slack or at **o.cornec@ibm.com** for requests regarding general information, installation, trouble-shooting and custom features.
 
 
-## Installation 
+## Installation
 <a id="installation"></a>
 
 Here's a quick example to get you started.
 
-### JS via import 
+### JS via import
 <a id="js-via-import"></a>
 
 ```javascript

--- a/packages/chat/components/linkListElement/__stories__/linkListElement.stories.js
+++ b/packages/chat/components/linkListElement/__stories__/linkListElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/LinkList',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/listElement/__stories__/docs.mdx
+++ b/packages/chat/components/listElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './listElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: List
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/listElement/__stories__/listElement.stories.js
+++ b/packages/chat/components/listElement/__stories__/listElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/BulletList',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/loadingElement/__stories__/docs.mdx
+++ b/packages/chat/components/loadingElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './loadingElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Loading
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/loadingElement/__stories__/loadingElement.stories.js
+++ b/packages/chat/components/loadingElement/__stories__/loadingElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Loading',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/message/__stories__/docs.mdx
+++ b/packages/chat/components/message/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './message.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Message
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/message/__stories__/message.stories.js
+++ b/packages/chat/components/message/__stories__/message.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Message',
-  tags: ['autodocs'],
 };
 
 const elements = [

--- a/packages/chat/components/messages/__stories__/docs.mdx
+++ b/packages/chat/components/messages/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './messages.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Messages
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/messages/__stories__/messages.stories.js
+++ b/packages/chat/components/messages/__stories__/messages.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Messages',
-  tags: ['autodocs'],
 };
 
 const messages = [

--- a/packages/chat/components/molecularElement/__stories__/docs.mdx
+++ b/packages/chat/components/molecularElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './molecularElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Molecule
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** TBD
+* **Target library maintainer(s) / PR Reviewer(s):** N/A
+* **Support channel:** `#carbon-labs`

--- a/packages/chat/components/molecularElement/__stories__/molecularElement.stories.js
+++ b/packages/chat/components/molecularElement/__stories__/molecularElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Molecule',
-  tags: ['autodocs'],
 };
 
 const examples = [

--- a/packages/chat/components/popupElement/__stories__/popup.mdx
+++ b/packages/chat/components/popupElement/__stories__/popup.mdx
@@ -5,7 +5,13 @@ import packageJson from '../../../package.json';
 
 <Meta of={popupElementStories} />
 
-# Carbon-Labs popup Handbook
+# Carbon AI ChatL: Popup
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`
 
 ## Table of Contents
 
@@ -17,31 +23,31 @@ import packageJson from '../../../package.json';
   - [JS via import](#js-via-import)
 - [Styles](#styles)
 
-## Overview 
+## Overview
 <a id="overview"></a>
 
 The Chat component is a collaboration between the **IBM Research Visual AI Lab (VAIL)** and the **Carbon Design Team** to provide an open-source, easily expandable chat interface to interact with large language models. Our core values are: open-source collaboration, universal support, ease of use and the in-depth customization Carbon is known for.
 
 The **Carbon Labs popup** component aims to render any JSON defintiion provided by the parent to display an informative popup component which provides detailed feedback about the target response/content.
 
-### Troubleshooting 
-<a id="troubleshooting"></a> 
+### Troubleshooting
+<a id="troubleshooting"></a>
 
 Contact **Owen Cornec** on Slack or at **o.cornec@ibm.com** for requests regarding general information, installation, trouble-shooting and custom features.
 
-## Installation 
+## Installation
 <a id="installation"></a>
 
 Here's a quick example to get you started.
 
-### JS via import 
+### JS via import
 <a id="js-via-import"></a>
 
 ```javascript
 import '@carbon-labs/ai-chat-popup/es/index.js';
 ```
 
-## Attributes and Properties 
+## Attributes and Properties
 <a id="attributes-and-properties"></a>
 ### Setting values as attributes
 ```html

--- a/packages/chat/components/popupElement/__stories__/popupElement.stories.js
+++ b/packages/chat/components/popupElement/__stories__/popupElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Popup',
-  tags: ['autodocs'],
 };
 
 const slugContent = {

--- a/packages/chat/components/tableElement/__stories__/docs.mdx
+++ b/packages/chat/components/tableElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './tableElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Table
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/tableElement/__stories__/tableElement.stories.js
+++ b/packages/chat/components/tableElement/__stories__/tableElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/Table',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/tagListElement/__stories__/docs.mdx
+++ b/packages/chat/components/tagListElement/__stories__/docs.mdx
@@ -1,0 +1,13 @@
+import { Markdown, Meta} from '@storybook/blocks';
+import * as elementStories from './tagListElement.stories';
+import packageJson from '../../../package.json';
+
+<Meta of={elementStories} />
+
+# Carbon AI Chat: Tag list
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`

--- a/packages/chat/components/tagListElement/__stories__/tagListElement.stories.js
+++ b/packages/chat/components/tagListElement/__stories__/tagListElement.stories.js
@@ -13,7 +13,6 @@ import { html } from 'lit';
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Components/Chat/TagList',
-  tags: ['autodocs'],
 };
 
 export const Default = {

--- a/packages/chat/components/textElement/__stories__/docs.mdx
+++ b/packages/chat/components/textElement/__stories__/docs.mdx
@@ -5,7 +5,13 @@ import packageJson from '../../../package.json';
 
 <Meta of={TextElementStories} />
 
-# Carbon-Labs Text Handbook
+# Carbon AI Chat: Text
+
+* **Initiative owner(s):** Owen Cornec
+* **Status:** Draft
+* **Target library:** `Carbon AI Chat`
+* **Target library maintainer(s) / PR Reviewer(s):** Ethan Winters, Damon Lundin
+* **Support channel:** `#carbon-ai-chat`
 
 ## Table of Contents
 
@@ -17,14 +23,14 @@ import packageJson from '../../../package.json';
   - [JS via import](#js-via-import)
 - [Styles](#styles)
 
-## Overview 
+## Overview
 <a id="overview"></a>
 
 The Chat component is a collaboration between the **IBM Research Visual AI Lab (VAIL)** and the **Carbon Design Team** to provide an open-source, easily expandable chat interface to interact with large language models. Our core values are: open-source collaboration, universal support, ease of use and the in-depth customization Carbon is known for.
 
 The **Carbon Labs Text** component aims to provide a simple text element that can accept plain text, annotated text with markdown and html.
 
-### Attributes and Properties 
+### Attributes and Properties
 <a id="attributes-and-properties"></a>
 <table>
   <thead>
@@ -75,18 +81,18 @@ The **Carbon Labs Text** component aims to provide a simple text element that ca
   </tbody>
 </table>
 
-### Troubleshooting 
-<a id="troubleshooting"></a> 
+### Troubleshooting
+<a id="troubleshooting"></a>
 
 Contact **Owen Cornec** on Slack or at **o.cornec@ibm.com** for requests regarding general information, installation, trouble-shooting and custom features.
 
 
-## Installation 
+## Installation
 <a id="installation"></a>
 
 Here's a quick example to get you started.
 
-### JS via import 
+### JS via import
 <a id="js-via-import"></a>
 
 ```javascript

--- a/packages/network-graph/__stories__/network-graph.story-mdx
+++ b/packages/network-graph/__stories__/network-graph.story-mdx
@@ -7,6 +7,12 @@ import packageJson from '../package.json';
 
 # Network Graph
 
+* **Initiative owner(s):** Priyanshu Rai, Daniel Karl I. Weidele
+* **Status:** Draft
+* **Target library:** TBD
+* **Target library maintainer(s) / PR Reviewer(s):** N/A
+* **Support channel:** `#carbon-labs`
+
 > 💡 Check our
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-labs/tree/main/packages/network-graph/examples/network-graph)
 > example implementation.

--- a/packages/tag/__stories__/tag.mdx
+++ b/packages/tag/__stories__/tag.mdx
@@ -7,6 +7,12 @@ import packageJson from '../package.json';
 
 # Tag
 
+* **Initiative owner(s):** Lily Peng, Daniel Karl I. Weidele
+* **Status:** Draft
+* **Target library:** TBD
+* **Target library maintainer(s) / PR Reviewer(s):** N/A
+* **Support channel:** `#carbon-labs`
+
 > 💡 Check our
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-labs/tree/main/packages/tag/examples/tag)
 > example implementation.

--- a/packages/ux-control/__stories__/ux-control.story-mdx
+++ b/packages/ux-control/__stories__/ux-control.story-mdx
@@ -7,6 +7,12 @@ import packageJson from '../package.json';
 
 # UX Control
 
+* **Initiative owner(s):** Lily Peng
+* **Status:** Draft
+* **Target library:** TBD
+* **Target library maintainer(s) / PR Reviewer(s):** N/A
+* **Support channel:** `#carbon-labs`
+
 > 💡 Check our
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-labs/tree/main/packages/ux-control/examples/ux-control)
 > example implementation.


### PR DESCRIPTION
This adds initiative information across components, which include:
- Initiative owner(s)
- Status (draft / preview candidate)
- target library
- target library maintainers / PR reviewers
- support channel

#### Changelog

**Changed**

- Added component information across all docs
- removed autodocs where not needed

