### PR TITLE
chore(codeowners): adding CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the
+# repo. Unless a later match takes precedence, this team will
+# be requested for review when someone opens a pull request.
+* @carbon-design-system/developers-system-reviewers
+
+# Carbon AI Chat
+/packages/chat      @carbon-design-system/carbon-ai-chat-admins @carbon-design-system/developers-system-reviewers
+
+# Admins should be notified of changes to CI/CD workflows
+# codeowners, and any other config present in .github.
+# This should always be the last entry in this file.
+/.github/           @carbon-design-system/developers-system-admins
+/.github/CODEOWNERS @carbon-design-system/developers-system-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 * @carbon-design-system/developers-system-reviewers
 
 # Carbon AI Chat
-/packages/chat      @carbon-design-system/carbon-ai-chat-admins @carbon-design-system/developers-system-reviewers
+/packages/web-components/src/components/chat      @carbon-design-system/carbon-ai-chat-admins @carbon-design-system/developers-system-reviewers
 
 # Admins should be notified of changes to CI/CD workflows
 # codeowners, and any other config present in .github.


### PR DESCRIPTION
This adds codeowners so that specific components can be owned by maintainer library teams

#### Changelog

**New**

- CODEOWNERS file
