### PR TITLE
chore: add boilerplate web component

### DIFF
--- a/packages/web-components/src/components/example-button/CHANGELOG.md
+++ b/packages/web-components/src/components/example-button/CHANGELOG.md
@@ -1,0 +1,123 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.4.0](https://github.com/carbon-design-system/carbon-labs/compare/@carbon-labs/extended-button@0.4.0-rc.0...@carbon-labs/extended-button@0.4.0) (2024-04-19)
+
+**Note:** Version bump only for package @carbon-labs/extended-button
+
+
+
+
+
+# 0.4.0-rc.0 (2024-04-19)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @carbon/web-components to v2.1.1 ([#55](https://github.com/carbon-design-system/carbon-labs/issues/55)) ([19c0608](https://github.com/carbon-design-system/carbon-labs/commit/19c0608169b6e4926ac2683c10438739b9cccad9))
+* **deps:** update dependency @carbon/web-components to v2.1.2 ([#62](https://github.com/carbon-design-system/carbon-labs/issues/62)) ([4315bb6](https://github.com/carbon-design-system/carbon-labs/commit/4315bb63db52b727e32a828459ec126c46a869fb))
+* **deps:** update dependency @carbon/web-components to v2.2.0 ([#68](https://github.com/carbon-design-system/carbon-labs/issues/68)) ([c4a25c3](https://github.com/carbon-design-system/carbon-labs/commit/c4a25c3eccb25f8ffed182f9beb0937a07e3608e))
+* **deps:** update dependency @carbon/web-components to v2.7.0 ([#129](https://github.com/carbon-design-system/carbon-labs/issues/129)) ([bce2afe](https://github.com/carbon-design-system/carbon-labs/commit/bce2afec26d943769dfc72d85851606272200957))
+* **extended-button:** update to reference node_modules instead ([c9720fd](https://github.com/carbon-design-system/carbon-labs/commit/c9720fddf8e79d9ae4054fdf5047399ad456ccc8))
+
+
+### Features
+
+* **build:** remove custom rollup plugin and use alias plugin instead ([#56](https://github.com/carbon-design-system/carbon-labs/issues/56)) ([733b96d](https://github.com/carbon-design-system/carbon-labs/commit/733b96d275ea7a5509324c240494652c07296543))
+* **react:** add react wrapper components ([#57](https://github.com/carbon-design-system/carbon-labs/issues/57)) ([78a0ada](https://github.com/carbon-design-system/carbon-labs/commit/78a0ada5af1dea4df0159ece4941c4bc6b9b98f4))
+
+
+
+
+
+# [0.3.0](https://github.com/carbon-design-system/carbon-labs/compare/@carbon-labs/extended-button@0.3.0-rc.1...@carbon-labs/extended-button@0.3.0) (2024-04-12)
+
+**Note:** Version bump only for package @carbon-labs/extended-button
+
+
+
+
+
+# [0.3.0-rc.1](https://github.com/carbon-design-system/carbon-labs/compare/@carbon-labs/extended-button@0.3.0-rc.0...@carbon-labs/extended-button@0.3.0-rc.1) (2024-04-12)
+
+**Note:** Version bump only for package @carbon-labs/extended-button
+
+
+
+
+
+# 0.3.0-rc.0 (2024-04-12)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @carbon/web-components to v2.1.1 ([#55](https://github.com/carbon-design-system/carbon-labs/issues/55)) ([19c0608](https://github.com/carbon-design-system/carbon-labs/commit/19c0608169b6e4926ac2683c10438739b9cccad9))
+* **deps:** update dependency @carbon/web-components to v2.1.2 ([#62](https://github.com/carbon-design-system/carbon-labs/issues/62)) ([4315bb6](https://github.com/carbon-design-system/carbon-labs/commit/4315bb63db52b727e32a828459ec126c46a869fb))
+* **deps:** update dependency @carbon/web-components to v2.2.0 ([#68](https://github.com/carbon-design-system/carbon-labs/issues/68)) ([c4a25c3](https://github.com/carbon-design-system/carbon-labs/commit/c4a25c3eccb25f8ffed182f9beb0937a07e3608e))
+* **extended-button:** update to reference node_modules instead ([c9720fd](https://github.com/carbon-design-system/carbon-labs/commit/c9720fddf8e79d9ae4054fdf5047399ad456ccc8))
+
+
+### Features
+
+* **build:** remove custom rollup plugin and use alias plugin instead ([#56](https://github.com/carbon-design-system/carbon-labs/issues/56)) ([733b96d](https://github.com/carbon-design-system/carbon-labs/commit/733b96d275ea7a5509324c240494652c07296543))
+* **react:** add react wrapper components ([#57](https://github.com/carbon-design-system/carbon-labs/issues/57)) ([78a0ada](https://github.com/carbon-design-system/carbon-labs/commit/78a0ada5af1dea4df0159ece4941c4bc6b9b98f4))
+
+
+
+
+
+# [0.2.0](https://github.com/carbon-design-system/carbon-labs/compare/@carbon-labs/extended-button@0.2.0-rc.0...@carbon-labs/extended-button@0.2.0) (2024-03-19)
+
+**Note:** Version bump only for package @carbon-labs/extended-button
+
+
+
+
+
+# [0.2.0-rc.0](https://github.com/carbon-design-system/carbon-labs/compare/@carbon-labs/extended-button@0.1.0-rc.0...@carbon-labs/extended-button@0.2.0-rc.0) (2024-03-19)
+
+**Note:** Version bump only for package @carbon-labs/extended-button
+
+
+
+
+
+# 0.1.0-rc.0 (2024-03-19)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @carbon/web-components to v2.1.1 ([#55](https://github.com/carbon-design-system/carbon-labs/issues/55)) ([19c0608](https://github.com/carbon-design-system/carbon-labs/commit/19c0608169b6e4926ac2683c10438739b9cccad9))
+* **deps:** update dependency @carbon/web-components to v2.1.2 ([#62](https://github.com/carbon-design-system/carbon-labs/issues/62)) ([4315bb6](https://github.com/carbon-design-system/carbon-labs/commit/4315bb63db52b727e32a828459ec126c46a869fb))
+* **deps:** update dependency @carbon/web-components to v2.2.0 ([#68](https://github.com/carbon-design-system/carbon-labs/issues/68)) ([c4a25c3](https://github.com/carbon-design-system/carbon-labs/commit/c4a25c3eccb25f8ffed182f9beb0937a07e3608e))
+* **extended-button:** update to reference node_modules instead ([c9720fd](https://github.com/carbon-design-system/carbon-labs/commit/c9720fddf8e79d9ae4054fdf5047399ad456ccc8))
+
+
+### Features
+
+* **build:** remove custom rollup plugin and use alias plugin instead ([#56](https://github.com/carbon-design-system/carbon-labs/issues/56)) ([733b96d](https://github.com/carbon-design-system/carbon-labs/commit/733b96d275ea7a5509324c240494652c07296543))
+* **react:** add react wrapper components ([#57](https://github.com/carbon-design-system/carbon-labs/issues/57)) ([78a0ada](https://github.com/carbon-design-system/carbon-labs/commit/78a0ada5af1dea4df0159ece4941c4bc6b9b98f4))
+
+
+
+
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.0.1-rc.1 (2023-11-30)
+
+**Note:** Version bump only for package @carbon-labs/ai-extended-button
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.1-rc.0](https://github.com/carbon-design-system/carbon-labs/compare/@carbon-labs/ai-extended-button@0.0.1...@carbon-labs/ai-extended-button@0.0.1-rc.0) (2023-11-30)
+
+**Note:** Version bump only for package @carbon-labs/ai-extended-button

--- a/packages/web-components/src/components/example-button/__stories__/example-button.stories.js
+++ b/packages/web-components/src/components/example-button/__stories__/example-button.stories.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '../components/example-button/example-button';
+import { html } from 'lit';
+import ArrowRight16 from '@carbon/web-components/es/icons/arrow--right/16';
+
+/**
+ * More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
+ */
+export default {
+  title: 'Example Component/Example button',
+  tags: ['autodocs'],
+};
+
+/**
+ * More on writing stories with args: https://storybook.js.org/docs/web-components/writing-stories/args
+ *
+ * @type {{args: {label: string}, render: (function(*): TemplateResult<1>)}}
+ */
+export const Default = {
+  args: {
+    label: 'Example button',
+  },
+
+  /**
+   * Renders the template for Storybook
+   * @param {object} args Storybook arguments
+   * @returns {TemplateResult<1>}
+   */
+  render: (args) =>
+    html` <clabs-example-button>
+      ${args.label}${ArrowRight16({ slot: 'icon' })}
+    </clabs-example-button>`,
+};

--- a/packages/web-components/src/components/example-button/__tests__/__snapshots__/extended-button.test.snap.js
+++ b/packages/web-components/src/components/example-button/__tests__/__snapshots__/extended-button.test.snap.js
@@ -1,0 +1,17 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots[
+  'clabs-extended-button should render with cds-button minimum attributes'
+] = `<clabs-extended-button
+  has-main-content=""
+  kind="primary"
+  size="lg"
+  tooltip-alignment=""
+  tooltip-position="top"
+  type="button"
+>
+  button
+</clabs-extended-button>
+`;
+/* end snapshot clabs-extended-button should render with cds-button minimum attributes */

--- a/packages/web-components/src/components/example-button/__tests__/example-button.test.ts
+++ b/packages/web-components/src/components/example-button/__tests__/example-button.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html, fixture, expect } from '@open-wc/testing';
+import '@carbon-labs/ai-example-button/es/components/example-button/example-button.js';
+import CLABSExampleButton from '../components/example-button/example-button.js';
+
+describe('clabs-example-button', function () {
+  it('should render with cds-button minimum attributes', async () => {
+    const el = await fixture<CLABSExampleButton>(
+      html`<clabs-example-button> button </clabs-example-button>`
+    );
+
+    await expect(el).dom.to.equalSnapshot();
+    await expect(el).shadowDom.to.be.accessible();
+  });
+});

--- a/packages/web-components/src/components/example-button/components/example-button/example-button.ts
+++ b/packages/web-components/src/components/example-button/components/example-button/example-button.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { customElement } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
+import exampleButton from './src/example-button.template.js';
+
+const { stablePrefix: clabsPrefix } = settings;
+
+/**
+ * Component extending the @carbon/web-components' button
+ */
+@customElement(`${clabsPrefix}-example-button`)
+class CLABSExampleButton extends exampleButton {}
+
+export default CLABSExampleButton;

--- a/packages/web-components/src/components/example-button/components/example-button/src/example-button.scss
+++ b/packages/web-components/src/components/example-button/components/example-button/src/example-button.scss
@@ -1,0 +1,15 @@
+/**
+ * Copyright IBM Corp. 2023, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+$css--plex: true !default;
+
+@use '../../../../../globals/scss/vars' as *;
+@use '@carbon/web-components/scss/components/button/button';
+
+:host(#{$clabs-prefix}-example-button) {
+  @extend :host(#{$cds-prefix}-button);
+}

--- a/packages/web-components/src/components/example-button/components/example-button/src/example-button.template.ts
+++ b/packages/web-components/src/components/example-button/components/example-button/src/example-button.template.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import CDSButton from '@carbon/web-components/es/components/button/button';
+// @ts-ignore
+import styles from './example-button.scss?inline';
+
+/**
+ * Component extending the @carbon/web-components' button
+ */
+class exampleButton extends CDSButton {
+  static styles = styles;
+}
+
+export default exampleButton;

--- a/packages/web-components/src/components/example-button/index.ts
+++ b/packages/web-components/src/components/example-button/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './components/example-button/example-button.js';

--- a/packages/web-components/src/components/example-button/package.json
+++ b/packages/web-components/src/components/example-button/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@carbon-labs/web-components-example-button",
+  "version": "0.4.0",
+  "private": true,
+  "description": "Carbon Labs - example-button component",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/carbon-labs",
+    "directory": "packages/example-button"
+  },
+  "main": "./src/index.js",
+  "module": "./src/index.js",
+  "exports": {
+    ".": {
+      "default": "./src/index.js"
+    },
+    "./es/": "./es/"
+  },
+  "files": [
+    "**/*.d.ts",
+    "**/*.js",
+    "**/*.js.map",
+    "custom-elements.json"
+  ],
+  "types": "./src/index.d.ts",
+  "customElements": "custom-elements.json",
+  "scripts": {
+    "build": "gulp build --option example-button",
+    "//build:dist": "rm -rf dist && rollup --config ../../tools/rollup.config.dist.js",
+    "//build:dist:canary": "rm -rf dist && rollup --config ../../tools/rollup.config.dist.js --configCanary"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.23.2",
+    "@carbon-labs/utilities": "0.14.0",
+    "@carbon/web-components": "2.18.0"
+  }
+}

--- a/packages/web-components/src/components/example-button/react/example-button.ts
+++ b/packages/web-components/src/components/example-button/react/example-button.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createComponent } from '@lit/react';
+import ExampleButton from '../components/example-button/example-button.js';
+
+export const CLABSExampleButton = createComponent({
+  tagName: 'clabs-example-button',
+  elementClass: ExampleButton,
+  react: React,
+  events: {},
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,6 +2723,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon-labs/web-components-example-button@workspace:packages/web-components/src/components/example-button":
+  version: 0.0.0-use.local
+  resolution: "@carbon-labs/web-components-example-button@workspace:packages/web-components/src/components/example-button"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.2"
+    "@carbon-labs/utilities": "npm:0.14.0"
+    "@carbon/web-components": "npm:2.18.0"
+  languageName: unknown
+  linkType: soft
+
 "@carbon/colors@npm:^11.28.0":
   version: 11.28.0
   resolution: "@carbon/colors@npm:11.28.0"


### PR DESCRIPTION
Closes #264 

Adds back boilerplate component to the web-components package, `example-button`

#### Changelog

**New**

- adds component package for boilerplate component (`example-button`)
- commented out the commands for CDN generation as we don't need it to be uploaded
- storybook 

#### Testing / Reviewing

ci-checks passing