### PR TITLE
chore: move shared dependencies to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@commitlint/config-conventional": "^19.0.0",
     "@open-wc/testing": "^4.0.0",
     "@playwright/test": "^1.39.0",
+    "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.3",
     "@types/react": "^18.2.36",
     "@types/sinon": "^17.0.0",
@@ -42,9 +43,13 @@
     "@web/test-runner-commands": "^0.9.0",
     "@web/test-runner-playwright": "^0.11.0",
     "babel-preset-carbon": "^0.0.14",
+    "chalk": "^5.4.1",
+    "change-case": "^5.4.4",
     "doctoc": "^2.2.1",
     "eslint": "^8.57.0",
     "eslint-config-carbon": "^3.11.0",
+    "fs-extra": "^11.2.0",
+    "glob": "^11.0.0",
     "globby": "^14.0.0",
     "gulp": "^5.0.0",
     "gulp-babel": "^8.0.0",
@@ -67,7 +72,8 @@
     "rollup-plugin-postcss-lit": "^2.1.0",
     "strip-comments": "^2.0.1",
     "stylelint": "15.11.0",
-    "stylelint-config-carbon": "1.17.0"
+    "stylelint-config-carbon": "1.17.0",
+    "yargs": "^17.7.2"
   },
   "packageManager": "yarn@4.5.3"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,7 +52,6 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",
-    "@types/fs-extra": "^11",
     "@types/jest": "^29.0.0",
     "@types/node": "^16.18.121",
     "@types/prop-types": "^15",
@@ -62,11 +61,7 @@
     "babel-jest": "^29.7.0",
     "babel-plugin-dev-expression": "^0.2.3",
     "browserslist-config-carbon": "^11.2.0",
-    "chalk": "^4.1.2",
-    "change-case": "4.1.2",
     "css-loader": "^7.1.2",
-    "fs-extra": "^11.2.0",
-    "glob": "^11.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "mini-css-extract-plugin": "^2.9.2",
@@ -83,7 +78,6 @@
     "ts-jest": "^29.2.5",
     "typescript": "^5.2.2",
     "typescript-config-carbon": "^0.3.0",
-    "webpack": "^5.97.0",
-    "yargs": "^17.7.2"
+    "webpack": "^5.97.0"
   }
 }

--- a/packages/react/tasks/generate/index.js
+++ b/packages/react/tasks/generate/index.js
@@ -9,7 +9,7 @@ import fs from 'fs';
 import chalk from 'chalk';
 import { outputFileSync } from 'fs-extra/esm';
 import { sync } from 'glob';
-import { paramCase, pascalCase, capitalCase } from 'change-case';
+import { kebabCase, pascalCase, capitalCase } from 'change-case';
 import path, { join, relative, resolve } from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -36,7 +36,7 @@ const substitutions = {
   DISPLAY_NAME: pascalCase(name),
   FULL_YEAR: new Date().getFullYear(),
   TITLE_NAME: capitalCase(name),
-  STYLE_NAME: paramCase(name),
+  STYLE_NAME: kebabCase(name),
 };
 
 /**

--- a/packages/web-components/tasks/generate/index.js
+++ b/packages/web-components/tasks/generate/index.js
@@ -9,7 +9,7 @@ import fs from 'fs';
 import chalk from 'chalk';
 import { outputFileSync } from 'fs-extra/esm';
 import { sync } from 'glob';
-import { pascalCase, paramCase, camelCase, capitalCase } from 'change-case';
+import { pascalCase, kebabCase, camelCase, capitalCase } from 'change-case';
 import path, { join, relative, resolve } from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -33,7 +33,7 @@ if (!name) {
 }
 
 const substitutions = {
-  DISPLAY_NAME: paramCase(name),
+  DISPLAY_NAME: kebabCase(name),
   CAMEL_CASE: camelCase(name),
   PASCAL_CASE: pascalCase(name),
   FULL_YEAR: new Date().getFullYear(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2731,7 +2731,6 @@ __metadata:
     "@testing-library/user-event": "npm:^14.5.2"
     "@types/babel__core": "npm:^7"
     "@types/babel__preset-env": "npm:^7"
-    "@types/fs-extra": "npm:^11"
     "@types/jest": "npm:^29.0.0"
     "@types/node": "npm:^16.18.121"
     "@types/prop-types": "npm:^15"
@@ -2741,11 +2740,7 @@ __metadata:
     babel-jest: "npm:^29.7.0"
     babel-plugin-dev-expression: "npm:^0.2.3"
     browserslist-config-carbon: "npm:^11.2.0"
-    chalk: "npm:^4.1.2"
-    change-case: "npm:4.1.2"
     css-loader: "npm:^7.1.2"
-    fs-extra: "npm:^11.2.0"
-    glob: "npm:^11.0.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
     mini-css-extract-plugin: "npm:^2.9.2"
@@ -2765,7 +2760,6 @@ __metadata:
     typescript: "npm:^5.2.2"
     typescript-config-carbon: "npm:^0.3.0"
     webpack: "npm:^5.97.0"
-    yargs: "npm:^17.7.2"
   peerDependencies:
     react: ^16.8.6 || ^17.0.1 || ^18.2.0
     react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
@@ -7900,7 +7894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/fs-extra@npm:^11":
+"@types/fs-extra@npm:^11.0.4":
   version: 11.0.4
   resolution: "@types/fs-extra@npm:11.0.4"
   dependencies:
@@ -10801,17 +10795,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"capital-case@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "capital-case@npm:1.0.4"
-  dependencies:
-    no-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-    upper-case-first: "npm:^2.0.2"
-  checksum: 10c0/6a034af73401f6e55d91ea35c190bbf8bda21714d4ea8bb8f1799311d123410a80f0875db4e3236dc3f97d74231ff4bf1c8783f2be13d7733c7d990c57387281
-  languageName: node
-  linkType: hard
-
 "carbon-labs@workspace:.":
   version: 0.0.0-use.local
   resolution: "carbon-labs@workspace:."
@@ -10820,6 +10803,7 @@ __metadata:
     "@commitlint/config-conventional": "npm:^19.0.0"
     "@open-wc/testing": "npm:^4.0.0"
     "@playwright/test": "npm:^1.39.0"
+    "@types/fs-extra": "npm:^11.0.4"
     "@types/mocha": "npm:^10.0.3"
     "@types/react": "npm:^18.2.36"
     "@types/sinon": "npm:^17.0.0"
@@ -10827,9 +10811,13 @@ __metadata:
     "@web/test-runner-commands": "npm:^0.9.0"
     "@web/test-runner-playwright": "npm:^0.11.0"
     babel-preset-carbon: "npm:^0.0.14"
+    chalk: "npm:^5.4.1"
+    change-case: "npm:^5.4.4"
     doctoc: "npm:^2.2.1"
     eslint: "npm:^8.57.0"
     eslint-config-carbon: "npm:^3.11.0"
+    fs-extra: "npm:^11.2.0"
+    glob: "npm:^11.0.0"
     globby: "npm:^14.0.0"
     gulp: "npm:^5.0.0"
     gulp-babel: "npm:^8.0.0"
@@ -10853,6 +10841,7 @@ __metadata:
     strip-comments: "npm:^2.0.1"
     stylelint: "npm:15.11.0"
     stylelint-config-carbon: "npm:1.17.0"
+    yargs: "npm:^17.7.2"
   languageName: unknown
   linkType: soft
 
@@ -10969,23 +10958,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"change-case@npm:4.1.2":
-  version: 4.1.2
-  resolution: "change-case@npm:4.1.2"
-  dependencies:
-    camel-case: "npm:^4.1.2"
-    capital-case: "npm:^1.0.4"
-    constant-case: "npm:^3.0.4"
-    dot-case: "npm:^3.0.4"
-    header-case: "npm:^2.0.4"
-    no-case: "npm:^3.0.4"
-    param-case: "npm:^3.0.4"
-    pascal-case: "npm:^3.1.2"
-    path-case: "npm:^3.0.4"
-    sentence-case: "npm:^3.0.4"
-    snake-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/95a6e48563cd393241ce18470c7310a8a050304a64b63addac487560ab039ce42b099673d1d293cc10652324d92060de11b5d918179fe3b5af2ee521fb03ca58
+"chalk@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "chalk@npm:5.4.1"
+  checksum: 10c0/b23e88132c702f4855ca6d25cb5538b1114343e41472d5263ee8a37cccfccd9c4216d111e1097c6a27830407a1dc81fecdf2a56f2c63033d4dbbd88c10b0dcef
+  languageName: node
+  linkType: hard
+
+"change-case@npm:^5.4.4":
+  version: 5.4.4
+  resolution: "change-case@npm:5.4.4"
+  checksum: 10c0/2a9c2b9c9ad6ab2491105aaf506db1a9acaf543a18967798dcce20926c6a173aa63266cb6189f3086e3c14bf7ae1f8ea4f96ecc466fcd582310efa00372f3734
   languageName: node
   linkType: hard
 
@@ -11670,17 +11653,6 @@ __metadata:
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 10c0/7ab51d30b52d461412cd467721bb82afe695da78fff8f29fe6f6b9cbaac9a2328e27a22a966014df9532100f6dd85370460be8130b9c677891ba36d96a343f50
-  languageName: node
-  linkType: hard
-
-"constant-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "constant-case@npm:3.0.4"
-  dependencies:
-    no-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-    upper-case: "npm:^2.0.2"
-  checksum: 10c0/91d54f18341fcc491ae66d1086642b0cc564be3e08984d7b7042f8b0a721c8115922f7f11d6a09f13ed96ff326eabae11f9d1eb0335fa9d8b6e39e4df096010e
   languageName: node
   linkType: hard
 
@@ -16575,16 +16547,6 @@ __metadata:
   bin:
     he: bin/he
   checksum: 10c0/a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
-  languageName: node
-  linkType: hard
-
-"header-case@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "header-case@npm:2.0.4"
-  dependencies:
-    capital-case: "npm:^1.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/c9f295d9d8e38fa50679281fd70d80726962256e888a76c8e72e526453da7a1832dcb427caa716c1ad5d79841d4537301b90156fa30298fefd3d68f4ea2181bb
   languageName: node
   linkType: hard
 
@@ -22487,16 +22449,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "path-case@npm:3.0.4"
-  dependencies:
-    dot-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/b6b14637228a558793f603aaeb2fcd981e738b8b9319421b713532fba96d75aa94024b9f6b9ae5aa33d86755144a5b36697d28db62ae45527dbd672fcc2cf0b7
-  languageName: node
-  linkType: hard
-
 "path-data-parser@npm:0.1.0, path-data-parser@npm:^0.1.0":
   version: 0.1.0
   resolution: "path-data-parser@npm:0.1.0"
@@ -25461,17 +25413,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sentence-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "sentence-case@npm:3.0.4"
-  dependencies:
-    no-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-    upper-case-first: "npm:^2.0.2"
-  checksum: 10c0/9a90527a51300cf5faea7fae0c037728f9ddcff23ac083883774c74d180c0a03c31aab43d5c3347512e8c1b31a0d4712512ec82beb71aa79b85149f9abeb5467
-  languageName: node
-  linkType: hard
-
 "serialize-javascript@npm:^6.0.1":
   version: 6.0.2
   resolution: "serialize-javascript@npm:6.0.2"
@@ -25729,16 +25670,6 @@ __metadata:
   version: 1.4.1
   resolution: "smob@npm:1.4.1"
   checksum: 10c0/89601485b35a3d785b701a79138de311448cf7fe18fef653013944d4e4fdcce78ae7bc8e1f8f58edac2d6b1979d95676b6f41e528ba855ef0f600ae35abb8756
-  languageName: node
-  linkType: hard
-
-"snake-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "snake-case@npm:3.0.4"
-  dependencies:
-    dot-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/ab19a913969f58f4474fe9f6e8a026c8a2142a01f40b52b79368068343177f818cdfef0b0c6b9558f298782441d5ca8ed5932eb57822439fad791d866e62cecd
   languageName: node
   linkType: hard
 
@@ -28103,24 +28034,6 @@ __metadata:
   version: 0.3.3
   resolution: "update-section@npm:0.3.3"
   checksum: 10c0/1341622eca3ea617750ee1245bb796c0fdc32e4fef4b279a5658b0c61b98aa28e30d6943f9c787d6a409c096ff02e4949a0e04d2d62deab363551ecc4500c11a
-  languageName: node
-  linkType: hard
-
-"upper-case-first@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "upper-case-first@npm:2.0.2"
-  dependencies:
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/ccad6a0b143310ebfba2b5841f30bef71246297385f1329c022c902b2b5fc5aee009faf1ac9da5ab3ba7f615b88f5dc1cd80461b18a8f38cb1d4c3eb92538ea9
-  languageName: node
-  linkType: hard
-
-"upper-case@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "upper-case@npm:2.0.2"
-  dependencies:
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/5ac176c9d3757abb71400df167f9abb46d63152d5797c630d1a9f083fbabd89711fb4b3dc6de06ff0138fe8946fa5b8518b4fcdae9ca8a3e341417075beae069
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Moves the shared dependencies used for the `generate` script in both web-components and React packages to the root package.json
