### PR TITLE
fix(ghactions): fix name of gh token env var name

### DIFF
--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release - minor
 
 ## on every merge to the main branch, lerna will publish a minor version for packages that have been modified
 on:
@@ -41,4 +41,4 @@ jobs:
         run: |
           yarn lerna publish minor --dist-tag latest --yes --message 'chore: release'
         env:
-          GITHUB_TOKEN: ${{ secrets.MERGE_ACTION }}
+          GH_TOKEN: ${{ secrets.MERGE_ACTION }}


### PR DESCRIPTION
This fixes the name of the GH token in env variables being used by the release github action.