### PR TITLE
feat(SideNav): add header menu button functionality at desktop

### DIFF
--- a/examples/react/UIShell/src/App.tsx
+++ b/examples/react/UIShell/src/App.tsx
@@ -9,9 +9,87 @@
 
 import React from 'react';
 import { SideNav } from '@carbon-labs/react-ui-shell/es/index';
+import {
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SkipToContent,
+  HeaderContainer,
+  Header,
+  HeaderName,
+  Theme,
+  HeaderMenuButton,
+  SideNavDivider,
+} from '@carbon/react';
+import { Fade } from '@carbon/icons-react';
 
 function App() {
-  return <SideNav />;
+  return (
+    <Theme theme="g100">
+      <HeaderContainer
+        render={({ isSideNavExpanded, onClickSideNavExpand }) => (
+          <>
+            <Header aria-label="IBM Platform Name">
+              <SkipToContent />
+              <HeaderMenuButton
+                aria-label={isSideNavExpanded ? 'Close menu' : 'Open menu'}
+                onClick={onClickSideNavExpand}
+                isActive={isSideNavExpanded}
+                aria-expanded={isSideNavExpanded}
+                isCollapsible //shows hamburger menu at desktop
+                isFixedNav
+              />
+              <HeaderName href="#" prefix="IBM">
+                [Platform]
+              </HeaderName>
+            </Header>
+            <SideNav
+              aria-label="Side navigation1"
+              expanded={isSideNavExpanded}
+              onSideNavBlur={onClickSideNavExpand}
+              isCollapsible
+              className="nav--global">
+              <SideNavItems>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavDivider />
+                <SideNavLink renderIcon={Fade} href="#">
+                  Link
+                </SideNavLink>
+                <SideNavLink renderIcon={Fade} href="#">
+                  Link
+                </SideNavLink>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+              </SideNavItems>
+            </SideNav>
+            <Theme theme="white">
+              <p>Content</p>
+            </Theme>
+          </>
+        )}
+      />
+    </Theme>
+  );
 }
 
 export default App;

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -5,10 +5,10 @@ import * as UIShellStories from './UIShell.stories';
 
 # UIShell
 
-- **Initiative owner(s):** FILL THIS LINE
+- **Initiative owner(s):** Carbon
 - **Status:** Draft
-- **Target library:** TBD
-- **Target library maintainer(s) / PR Reviewer(s):** N/A
+- **Target library:** @carbon/react
+- **Target library maintainer(s) / PR Reviewer(s):** Carbon
 - **Support channel:** `#carbon-labs`
 
 {/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> */}
@@ -29,9 +29,9 @@ import * as UIShellStories from './UIShell.stories';
 
 ## Overview
 
-Add description of component here
+Enhancements to core Carbon UIShell components
 
-<Canvas of={UIShellStories.FixedSideNav} />
+<Canvas of={UIShellStories.Default} />
 
 ## Getting started
 

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -29,7 +29,10 @@ import * as UIShellStories from './UIShell.stories';
 
 ## Overview
 
-Enhancements to core Carbon UIShell components
+Enhancements to core Carbon UIShell components. Components included in this
+package:
+
+- `SideNav`
 
 <Canvas of={UIShellStories.Default} />
 

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -16,31 +16,25 @@ import {
   SideNavMenuItem,
   SideNavLink,
   SkipToContent,
+  HeaderContainer,
   Header,
   HeaderName,
-  Button,
-  Modal,
-  Content,
   Theme,
+  HeaderMenuButton,
+  SideNavDivider,
+  Content,
 } from '@carbon/react';
+import { Fade } from '@carbon/icons-react';
+import '../components/ui-shell.scss';
 
 /**
  * Story content
- * @param {boolean} useResponsiveOffset - `true` if the responsive offset should be used.
  * @returns {React.ReactElement} The JSX for the story
  */
-const StoryContent = ({ useResponsiveOffset = false }) => {
-  const [open, setOpen] = useState(false);
-  const classNameFirstColumn = {
-    'cds--col-lg-13': true,
-    'cds--offset-lg-3': useResponsiveOffset,
-  };
-  const classnameString = Object.entries(classNameFirstColumn)
-    .reduce((acc, [key, value]) => (value ? `${acc} ${key}` : acc), '')
-    .trim();
+const StoryContent = () => {
   const content = (
-    <div className={classnameString}>
-      <h2 style={{ margin: '0 0 30px' }}>Purpose and function</h2>
+    <div>
+      <h2 style={{ margin: '30px 0' }}>Purpose and function</h2>
       <p>
         The shell is perhaps the most crucial piece of any UI built with
         <a href="www.carbondesignsystem.com"> Carbon</a>. It contains the shared
@@ -82,29 +76,11 @@ const StoryContent = ({ useResponsiveOffset = false }) => {
         used per product section. If tabs are needed on a page when using a
         side-nav, then the tabs are secondary in hierarchy to the side-nav.
       </p>
-      <Button onClick={() => setOpen(true)}>Launch modal</Button>
-      <Modal
-        modalHeading="Add a custom domain"
-        modalLabel="Account resources"
-        primaryButtonText="Add"
-        secondaryButtonText="Cancel"
-        open={open}
-        onRequestClose={() => setOpen(false)}>
-        <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
-        </p>
-      </Modal>
     </div>
   );
   const style = {
     height: '100%',
   };
-  if (useResponsiveOffset) {
-    style.margin = '0';
-    style.width = '100%';
-  }
   return (
     <Content id="main-content" style={style}>
       {content}
@@ -123,122 +99,122 @@ export default {
 };
 
 /**
- * Story for UIShell
+ * Story for SideNav
  * @returns {React.ReactElement} The JSX for the story
  */
-export const UIShell = () => (
-  <>
-    <Header aria-label="IBM Platform Name">
-      <SkipToContent />
-      <HeaderName href="#" prefix="IBM">
-        [Platform]
-      </HeaderName>
-    </Header>
-    <SideNav
-      isFixedNav
-      expanded={true}
-      isChildOfHeader={false}
-      aria-label="Side navigation">
-      <SideNavItems>
-        <SideNavMenu title="L0 menu">
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-            L0 menu item
-          </SideNavMenuItem>
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-            L0 menu item
-          </SideNavMenuItem>
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-            L0 menu item
-          </SideNavMenuItem>
-        </SideNavMenu>
-        <SideNavMenu title="L0 menu" isActive={true}>
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-            L0 menu item
-          </SideNavMenuItem>
-          <SideNavMenuItem
-            aria-current="page"
-            href="https://www.carbondesignsystem.com/">
-            L0 menu item
-          </SideNavMenuItem>
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-            L0 menu item
-          </SideNavMenuItem>
-        </SideNavMenu>
-        <SideNavMenu title="L0 menu">
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-            L0 menu item
-          </SideNavMenuItem>
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-            L0 menu item
-          </SideNavMenuItem>
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-            L0 menu item
-          </SideNavMenuItem>
-        </SideNavMenu>
-        <SideNavLink href="https://www.carbondesignsystem.com/">
-          L0 link
-        </SideNavLink>
-        <SideNavLink href="https://www.carbondesignsystem.com/">
-          L0 link
-        </SideNavLink>
-      </SideNavItems>
-    </SideNav>
-    <StoryContent useResponsiveOffset={false} />
-  </>
+export const Default = () => (
+  <div>
+    <Theme theme="g100">
+      <HeaderContainer
+        render={({ isSideNavExpanded, onClickSideNavExpand }) => (
+          <>
+            <Header aria-label="IBM Platform Name">
+              <SkipToContent />
+              <HeaderMenuButton
+                aria-label={isSideNavExpanded ? 'Close menu' : 'Open menu'}
+                onClick={onClickSideNavExpand}
+                isActive={isSideNavExpanded}
+                aria-expanded={isSideNavExpanded}
+                isCollapsible //shows hamburger menu at desktop
+                isFixedNav
+              />
+              <HeaderName href="#" prefix="IBM">
+                [Platform]
+              </HeaderName>
+            </Header>
+            <SideNav
+              aria-label="Side navigation1"
+              expanded={isSideNavExpanded}
+              onSideNavBlur={onClickSideNavExpand}
+              isCollapsible
+              className="nav--global">
+              <SideNavItems>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+                <SideNavDivider />
+                <SideNavLink renderIcon={Fade} href="#">
+                  Link
+                </SideNavLink>
+                <SideNavLink renderIcon={Fade} href="#">
+                  Link
+                </SideNavLink>
+                <SideNavMenu renderIcon={Fade} title="Link">
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                </SideNavMenu>
+              </SideNavItems>
+            </SideNav>
+            <Theme theme="white">
+              <StoryContent />
+            </Theme>
+          </>
+        )}
+      />
+    </Theme>
+  </div>
 );
 
+Default.parameters = {
+  controls: { disable: true },
+  actions: { disable: true },
+};
+
 /**
- * Story for FixedSideNav
+ * Story for SideNav
  * @returns {React.ReactElement} The JSX for the story
  */
-export const FixedSideNav = () => (
+export const SideNavFixed = () => (
   <SideNav
     isFixedNav
     expanded={true}
     isChildOfHeader={false}
     aria-label="Side navigation">
     <SideNavItems>
-      <SideNavMenu title="L0 menu">
-        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-          L0 menu item
-        </SideNavMenuItem>
-        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-          L0 menu item
-        </SideNavMenuItem>
-        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-          L0 menu item
-        </SideNavMenuItem>
+      <SideNavMenu renderIcon={Fade} title="Link">
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
       </SideNavMenu>
-      <SideNavMenu title="L0 menu" isActive={true}>
-        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-          L0 menu item
-        </SideNavMenuItem>
-        <SideNavMenuItem
-          aria-current="page"
-          href="https://www.carbondesignsystem.com/">
-          L0 menu item
-        </SideNavMenuItem>
-        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-          L0 menu item
-        </SideNavMenuItem>
+      <SideNavMenu renderIcon={Fade} title="Link">
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
       </SideNavMenu>
-      <SideNavMenu title="L0 menu">
-        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-          L0 menu item
-        </SideNavMenuItem>
-        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-          L0 menu item
-        </SideNavMenuItem>
-        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
-          L0 menu item
-        </SideNavMenuItem>
+      <SideNavMenu renderIcon={Fade} title="Link">
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
       </SideNavMenu>
-      <SideNavLink href="https://www.carbondesignsystem.com/">
-        L0 link
+      <SideNavMenu renderIcon={Fade} title="Link">
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
+      </SideNavMenu>
+      <SideNavMenu renderIcon={Fade} title="Link">
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
+      </SideNavMenu>
+      <SideNavDivider />
+      <SideNavLink renderIcon={Fade} href="#">
+        Link
       </SideNavLink>
-      <SideNavLink href="https://www.carbondesignsystem.com/">
-        L0 link
+      <SideNavLink renderIcon={Fade} href="#">
+        Link
       </SideNavLink>
+      <SideNavMenu renderIcon={Fade} title="Link">
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
+        <SideNavMenuItem href="#">Link</SideNavMenuItem>
+      </SideNavMenu>
     </SideNavItems>
   </SideNav>
 );

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import mdx from './UIShell.mdx';
 import { SideNav } from '../components/SideNav';
 import {

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -11,7 +11,6 @@ import React, { useState } from 'react';
 import mdx from './UIShell.mdx';
 import { SideNav } from '../components/SideNav';
 import {
-  // SideNav,
   SideNavItems,
   SideNavMenu,
   SideNavMenuItem,
@@ -22,6 +21,7 @@ import {
   Button,
   Modal,
   Content,
+  Theme,
 } from '@carbon/react';
 
 /**
@@ -29,7 +29,7 @@ import {
  * @param {boolean} useResponsiveOffset - `true` if the responsive offset should be used.
  * @returns {React.ReactElement} The JSX for the story
  */
-const StoryContent = ({ useResponsiveOffset = true }) => {
+const StoryContent = ({ useResponsiveOffset = false }) => {
   const [open, setOpen] = useState(false);
   const classNameFirstColumn = {
     'cds--col-lg-13': true,
@@ -39,69 +39,63 @@ const StoryContent = ({ useResponsiveOffset = true }) => {
     .reduce((acc, [key, value]) => (value ? `${acc} ${key}` : acc), '')
     .trim();
   const content = (
-    <div className="cds--grid">
-      <div className="cds--row">
-        <div className={classnameString}>
-          <h2 style={{ margin: '0 0 30px' }}>Purpose and function</h2>
-          <p>
-            The shell is perhaps the most crucial piece of any UI built with
-            <a href="www.carbondesignsystem.com"> Carbon</a>. It contains the
-            shared navigation framework for the entire design system and ties
-            the products in IBM’s portfolio together in a cohesive and elegant
-            way. The shell is the home of the topmost navigation, where users
-            can quickly and dependably gain their bearings and move between
-            pages.
-            <br />
-            <br />
-            The shell was designed with maximum flexibility built in, to serve
-            the needs of a broad range of products and users. Adopting the shell
-            ensures compliance with IBM design standards, simplifies development
-            efforts, and provides great user experiences. All IBM products built
-            with Carbon are required to use the shell’s header.
-            <br />
-            <br />
-            To better understand the purpose and function of the UI shell,
-            consider the “shell” of MacOS, which contains the Apple menu,
-            top-level navigation, and universal, OS-level controls at the top of
-            the screen, as well as a universal dock along the bottom or side of
-            the screen. The Carbon UI shell is roughly analogous in function to
-            these parts of the Mac UI. For example, the app switcher portion of
-            the shell can be compared to the dock in MacOS.
-          </p>
-          <h2 style={{ margin: '30px 0' }}>Header responsive behavior</h2>
-          <p>
-            As a header scales down to fit smaller screen sizes, headers with
-            persistent side nav menus should have the side nav collapse into
-            “hamburger” menu. See the example to better understand responsive
-            behavior of the header.
-          </p>
-          <h2 style={{ margin: '30px 0' }}>Secondary navigation</h2>
-          <p>
-            The side-nav contains secondary navigation and fits below the
-            header. It can be configured to be either fixed-width or flexible,
-            with only one level of nested items allowed. Both links and category
-            lists can be used in the side-nav and may be mixed together. There
-            are several configurations of the side-nav, but only one
-            configuration should be used per product section. If tabs are needed
-            on a page when using a side-nav, then the tabs are secondary in
-            hierarchy to the side-nav.
-          </p>
-          <Button onClick={() => setOpen(true)}>Launch modal</Button>
-          <Modal
-            modalHeading="Add a custom domain"
-            modalLabel="Account resources"
-            primaryButtonText="Add"
-            secondaryButtonText="Cancel"
-            open={open}
-            onRequestClose={() => setOpen(false)}>
-            <p style={{ marginBottom: '1rem' }}>
-              Custom domains direct requests for your apps in this Cloud Foundry
-              organization to a URL that you own. A custom domain can be a
-              shared domain, a shared subdomain, or a shared domain and host.
-            </p>
-          </Modal>
-        </div>
-      </div>
+    <div className={classnameString}>
+      <h2 style={{ margin: '0 0 30px' }}>Purpose and function</h2>
+      <p>
+        The shell is perhaps the most crucial piece of any UI built with
+        <a href="www.carbondesignsystem.com"> Carbon</a>. It contains the shared
+        navigation framework for the entire design system and ties the products
+        in IBM’s portfolio together in a cohesive and elegant way. The shell is
+        the home of the topmost navigation, where users can quickly and
+        dependably gain their bearings and move between pages.
+        <br />
+        <br />
+        The shell was designed with maximum flexibility built in, to serve the
+        needs of a broad range of products and users. Adopting the shell ensures
+        compliance with IBM design standards, simplifies development efforts,
+        and provides great user experiences. All IBM products built with Carbon
+        are required to use the shell’s header.
+        <br />
+        <br />
+        To better understand the purpose and function of the UI shell, consider
+        the “shell” of MacOS, which contains the Apple menu, top-level
+        navigation, and universal, OS-level controls at the top of the screen,
+        as well as a universal dock along the bottom or side of the screen. The
+        Carbon UI shell is roughly analogous in function to these parts of the
+        Mac UI. For example, the app switcher portion of the shell can be
+        compared to the dock in MacOS.
+      </p>
+      <h2 style={{ margin: '30px 0' }}>Header responsive behavior</h2>
+      <p>
+        As a header scales down to fit smaller screen sizes, headers with
+        persistent side nav menus should have the side nav collapse into
+        “hamburger” menu. See the example to better understand responsive
+        behavior of the header.
+      </p>
+      <h2 style={{ margin: '30px 0' }}>Secondary navigation</h2>
+      <p>
+        The side-nav contains secondary navigation and fits below the header. It
+        can be configured to be either fixed-width or flexible, with only one
+        level of nested items allowed. Both links and category lists can be used
+        in the side-nav and may be mixed together. There are several
+        configurations of the side-nav, but only one configuration should be
+        used per product section. If tabs are needed on a page when using a
+        side-nav, then the tabs are secondary in hierarchy to the side-nav.
+      </p>
+      <Button onClick={() => setOpen(true)}>Launch modal</Button>
+      <Modal
+        modalHeading="Add a custom domain"
+        modalLabel="Account resources"
+        primaryButtonText="Add"
+        secondaryButtonText="Cancel"
+        open={open}
+        onRequestClose={() => setOpen(false)}>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+      </Modal>
     </div>
   );
   const style = {
@@ -129,10 +123,10 @@ export default {
 };
 
 /**
- * Story for SideNav
+ * Story for UIShell
  * @returns {React.ReactElement} The JSX for the story
  */
-export const FixedSideNav = () => (
+export const UIShell = () => (
   <>
     <Header aria-label="IBM Platform Name">
       <SkipToContent />
@@ -191,4 +185,60 @@ export const FixedSideNav = () => (
     </SideNav>
     <StoryContent useResponsiveOffset={false} />
   </>
+);
+
+/**
+ * Story for FixedSideNav
+ * @returns {React.ReactElement} The JSX for the story
+ */
+export const FixedSideNav = () => (
+  <SideNav
+    isFixedNav
+    expanded={true}
+    isChildOfHeader={false}
+    aria-label="Side navigation">
+    <SideNavItems>
+      <SideNavMenu title="L0 menu">
+        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          L0 menu item
+        </SideNavMenuItem>
+        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          L0 menu item
+        </SideNavMenuItem>
+        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          L0 menu item
+        </SideNavMenuItem>
+      </SideNavMenu>
+      <SideNavMenu title="L0 menu" isActive={true}>
+        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          L0 menu item
+        </SideNavMenuItem>
+        <SideNavMenuItem
+          aria-current="page"
+          href="https://www.carbondesignsystem.com/">
+          L0 menu item
+        </SideNavMenuItem>
+        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          L0 menu item
+        </SideNavMenuItem>
+      </SideNavMenu>
+      <SideNavMenu title="L0 menu">
+        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          L0 menu item
+        </SideNavMenuItem>
+        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          L0 menu item
+        </SideNavMenuItem>
+        <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          L0 menu item
+        </SideNavMenuItem>
+      </SideNavMenu>
+      <SideNavLink href="https://www.carbondesignsystem.com/">
+        L0 link
+      </SideNavLink>
+      <SideNavLink href="https://www.carbondesignsystem.com/">
+        L0 link
+      </SideNavLink>
+    </SideNavItems>
+  </SideNav>
 );

--- a/packages/react/src/components/UIShell/__tests__/SideNav-test.js
+++ b/packages/react/src/components/UIShell/__tests__/SideNav-test.js
@@ -1,0 +1,364 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { SideNav } from '../components/SideNav';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+jest.mock('./ui-shell.scss', () => ({}));
+
+describe('SideNav', () => {
+  // Carbon React Tests
+  describe('renders as expected - Component API', () => {
+    it('should match snapshot', () => {
+      const { container } = render(<SideNav aria-label="test" />);
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should label the <nav> through `aria-label`', () => {
+      render(<SideNav aria-label="test" />);
+      expect(screen.getByRole('navigation')).toEqual(
+        screen.getByLabelText('test')
+      );
+    });
+  });
+
+  it('should label the <nav> through `aria-label`', () => {
+    render(<SideNav aria-label="test" />);
+    expect(screen.getByRole('navigation')).toEqual(
+      screen.getByLabelText('test')
+    );
+  });
+
+  it('should render an overlay if `isFixedNav` is false', () => {
+    const { container } = render(<SideNav aria-label="test" />);
+    expect(container.childNodes.length).toBe(2);
+  });
+
+  it('should not render an overlay if `isFixedNav` is true', () => {
+    const { container } = render(<SideNav aria-label="test" isFixedNav />);
+    expect(container.childNodes.length).toBe(1);
+  });
+
+  it('should toggle the overlay-active class when `expanded` is true', () => {
+    const { container } = render(<SideNav aria-label="test" expanded />);
+    expect(container.firstChild).toHaveClass('cds--side-nav__overlay-active');
+  });
+
+  it('should toggle the overlay-active class when `defaultExpanded` is true', () => {
+    const { container } = render(<SideNav aria-label="test" defaultExpanded />);
+    expect(container.firstChild).toHaveClass('cds--side-nav__overlay-active');
+  });
+
+  it('should support a custom `className` prop on the element with role="navigation"', () => {
+    render(<SideNav aria-label="test" className="test" />);
+    expect(screen.getByRole('navigation')).toHaveClass('test');
+  });
+
+  it('should spread extra props on the outermost element', () => {
+    render(<SideNav aria-label="test" data-testid="test" />);
+    expect(screen.getByRole('navigation')).toHaveAttribute(
+      'data-testid',
+      'test'
+    );
+  });
+
+  it('should support a `ref` on the element with role="navigation"', () => {
+    const ref = jest.fn();
+    render(<SideNav aria-label="test" ref={ref} />);
+    expect(ref).toHaveBeenCalledWith(screen.getByRole('navigation'));
+  });
+
+  it('should call onOverlayClick when overlay is clicked', () => {
+    const onOverlayClick = jest.fn();
+    const { container } = render(
+      <SideNav aria-label="test" expanded onOverlayClick={onOverlayClick} />
+    );
+    const overlay = container.firstChild;
+    fireEvent.click(overlay);
+    expect(onOverlayClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not add focus or mouse listeners when disabled', () => {
+    const onToggle = jest.fn();
+    render(
+      <SideNav
+        aria-label="test"
+        addFocusListeners={false}
+        addMouseListeners={false}
+        onToggle={onToggle}
+      />
+    );
+    const sideNav = screen.getByRole('navigation');
+    fireEvent.focus(sideNav);
+    fireEvent.mouseEnter(sideNav);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  // it('should handle keyboard events like Escape', () => {
+  //   const onToggle = jest.fn();
+  //   render(
+  //     <SideNav
+  //       aria-label="test"
+  //       expanded
+  //       onToggle={onToggle}
+  //       href="#main-content"
+  //     />
+  //   );
+  //   const sideNav = screen.getByRole('navigation');
+  //   fireEvent.keyDown(sideNav, { key: 'Escape', keyCode: 27 });
+  //   expect(onToggle).toHaveBeenCalledWith(expect.anything(), false);
+  // });
+
+  it('should correctly handle `isRail` when true', () => {
+    render(<SideNav aria-label="test" isRail />);
+    const sideNav = screen.getByRole('navigation');
+    expect(sideNav).toHaveClass('cds--side-nav--rail');
+  });
+
+  it('should correctly handle `isRail` when false', () => {
+    render(<SideNav aria-label="test" isRail={false} />);
+    const sideNav = screen.getByRole('navigation');
+    expect(sideNav).not.toHaveClass('cds--side-nav--rail');
+  });
+
+  it('should toggle the expanded state when uncontrolled', () => {
+    const { container } = render(<SideNav aria-label="test" />);
+    const sideNav = screen.getByRole('navigation');
+    fireEvent.focus(sideNav);
+    expect(container.firstChild).toHaveClass('cds--side-nav__overlay');
+  });
+
+  it('should handle children without throwing error', () => {
+    const { container } = render(
+      <SideNav aria-label="test">
+        <div>No Errors Here!</div>
+      </SideNav>
+    );
+    expect(container).toBeInTheDocument();
+  });
+
+  it('should pass isSideNavExpanded to Carbon SideNav children', () => {
+    const TestChild = React.forwardRef(({ isSideNavExpanded }, ref) => (
+      <div data-testid="child" ref={ref}>
+        {isSideNavExpanded ? 'Expanded' : 'Collapsed'}
+      </div>
+    ));
+    render(
+      <SideNav aria-label="test" expanded>
+        <TestChild />
+      </SideNav>
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('Collapsed');
+  });
+
+  it('should not pass isSideNavExpanded to non-CarbsideNav children', () => {
+    const NonCarbonChild = () => <div data-testid="non-carbon-child" />;
+    render(
+      <SideNav aria-label="test" expanded>
+        <NonCarbonChild />
+      </SideNav>
+    );
+    expect(screen.getByTestId('non-carbon-child')).toBeInTheDocument();
+  });
+
+  it('should pass isSideNavExpanded correctly based on controlled state', () => {
+    const TestChild = React.forwardRef(({ isSideNavExpanded }, ref) => (
+      <div data-testid="child" ref={ref}>
+        {isSideNavExpanded ? 'Expanded' : 'Collapsed'}
+      </div>
+    ));
+    const { rerender } = render(
+      <SideNav aria-label="test" expanded>
+        <TestChild />
+      </SideNav>
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('Collapsed');
+    rerender(
+      <SideNav aria-label="test">
+        <TestChild />
+      </SideNav>
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('Collapsed');
+  });
+
+  it('should call handleToggle and onSideNavBlur when blurred', () => {
+    const onSideNavBlurMock = jest.fn();
+    const TestChild = () => <div data-testid="child">Child</div>;
+    const { getByRole } = render(
+      <SideNav aria-label="test" onSideNavBlur={onSideNavBlurMock}>
+        <TestChild />
+      </SideNav>
+    );
+    const sideNav = getByRole('navigation');
+    fireEvent.focus(sideNav);
+    fireEvent.blur(sideNav);
+    expect(onSideNavBlurMock).not.toHaveBeenCalled();
+  });
+
+  it('should not call onSideNavBlur if not expanded and isFixedNav is true', () => {
+    const onSideNavBlurMock = jest.fn();
+    const TestChild = () => <div data-testid="child">Child</div>;
+    const { getByRole } = render(
+      <SideNav aria-label="test" isFixedNav onSideNavBlur={onSideNavBlurMock}>
+        <TestChild />
+      </SideNav>
+    );
+    const sideNav = getByRole('navigation');
+    fireEvent.focus(sideNav);
+    fireEvent.blur(sideNav);
+    expect(onSideNavBlurMock).not.toHaveBeenCalled();
+  });
+
+  it('should call onSideNavBlur when blurred, is not fixed, and is expanded', () => {
+    const onSideNavBlurMock = jest.fn();
+    const TestChild = () => <div data-testid="child">Child</div>;
+    const { getByRole } = render(
+      <SideNav
+        aria-label="test"
+        onSideNavBlur={onSideNavBlurMock}
+        defaultExpanded>
+        <TestChild />
+      </SideNav>
+    );
+    const sideNav = getByRole('navigation');
+    fireEvent.focus(sideNav);
+    const unrelatedElement = document.createElement('div');
+    document.body.appendChild(unrelatedElement);
+    fireEvent.blur(sideNav, { relatedTarget: unrelatedElement });
+    expect(onSideNavBlurMock).toHaveBeenCalled();
+    document.body.removeChild(unrelatedElement);
+  });
+
+  it('should not call onSideNavBlur when isFixedNav is true', () => {
+    const onSideNavBlurMock = jest.fn();
+    const TestChild = () => <div data-testid="child">Child</div>;
+    const { getByRole } = render(
+      <SideNav
+        aria-label="test"
+        isFixedNav
+        onSideNavBlur={onSideNavBlurMock}
+        defaultExpanded>
+        <TestChild />
+      </SideNav>
+    );
+    const sideNav = getByRole('navigation');
+    fireEvent.focus(sideNav);
+    const unrelatedElement = document.createElement('div');
+    document.body.appendChild(unrelatedElement);
+    fireEvent.blur(sideNav, { relatedTarget: unrelatedElement });
+    expect(onSideNavBlurMock).not.toHaveBeenCalled();
+    document.body.removeChild(unrelatedElement);
+  });
+
+  it('should set expanded state to false on mouse leave', () => {
+    const onToggleMock = jest.fn();
+    const TestChild = () => <div data-testid="child">Child</div>;
+    const { getByRole } = render(
+      <SideNav aria-label="test" defaultExpanded onToggle={onToggleMock}>
+        <TestChild />
+      </SideNav>
+    );
+    const sideNav = getByRole('navigation');
+    expect(sideNav).toHaveClass('cds--side-nav__navigation');
+    fireEvent.mouseLeave(sideNav);
+    expect(sideNav).toHaveClass('cds--side-nav__navigation');
+  });
+
+  it('should handleToggle if isRail is true', () => {
+    const onToggleMock = jest.fn();
+    const TestChild = () => <div data-testid="child">Child</div>;
+    const { getByRole } = render(
+      <SideNav aria-label="test" onToggle={onToggleMock} isRail>
+        <TestChild />
+      </SideNav>
+    );
+    const sideNav = getByRole('navigation');
+    fireEvent.focus(sideNav);
+    expect(onToggleMock).toHaveBeenCalled();
+    fireEvent.mouseLeave(sideNav);
+    expect(onToggleMock).toHaveBeenCalledWith(false, false);
+    fireEvent.mouseEnter(sideNav);
+    expect(onToggleMock).toHaveBeenCalledWith(true, true);
+  });
+
+  it('should not call handleToggle if isRail is false', () => {
+    const onToggleMock = jest.fn();
+    const TestChild = () => <div data-testid="child">Child</div>;
+    const { getByRole } = render(
+      <SideNav
+        aria-label="test"
+        defaultExpanded
+        onToggle={onToggleMock}
+        isRail={false}>
+        <TestChild />
+      </SideNav>
+    );
+    const sideNav = getByRole('navigation');
+    fireEvent.mouseLeave(sideNav);
+    expect(onToggleMock).not.toHaveBeenCalled();
+  });
+
+  it('should expand the SideNav immediately on click', () => {
+    const TestChild = () => <div data-testid="child">Child</div>;
+    const onToggleMock = jest.fn();
+    const { getByRole } = render(
+      <SideNav aria-label="test" onToggle={onToggleMock} isRail>
+        <TestChild />
+      </SideNav>
+    );
+    const sideNav = getByRole('navigation');
+    expect(sideNav).not.toHaveClass('cds--side-nav--expanded');
+    fireEvent.click(sideNav);
+    expect(onToggleMock).toHaveBeenCalledWith(true, true);
+    expect(sideNav).toHaveClass('cds--side-nav--expanded');
+  });
+
+  // it('should focus SideNav after tabbing from headerMenuButton', () => {
+  //   render(
+  //     <>
+  //       <button className="cds--header__menu-toggle"></button>
+  //       <SideNav
+  //         aria-label="test"
+  //         expanded
+  //         isFixedNav={false}
+  //         defaultExpanded
+  //       />
+  //     </>
+  //   );
+  //   const mockHeaderMenuButton = screen.getByRole('button');
+  //   const sideNav = screen.getByRole('navigation');
+
+  //   mockHeaderMenuButton.focus();
+  //   fireEvent.keyDown(window, { key: 'Tab' });
+  //   expect(document.activeElement).toBe(sideNav);
+  // });
+
+  // New Tests
+  it('should correctly handle `isCollapsible` when true', () => {
+    render(<SideNav aria-label="test" isCollapsible />);
+    const sideNav = screen.getByRole('navigation');
+    expect(sideNav).toHaveClass('cds--side-nav--collapsible');
+  });
+});

--- a/packages/react/src/components/UIShell/__tests__/SideNav-test.js
+++ b/packages/react/src/components/UIShell/__tests__/SideNav-test.js
@@ -6,7 +6,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+/* eslint-disable jsdoc/require-jsdoc */
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNav-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNav-test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SideNav renders as expected - Component API should match snapshot 1`] = `
+<div>
+  <div
+    class="cds--side-nav__overlay"
+  />
+  <nav
+    aria-label="test"
+    class="cds--side-nav__navigation cds--side-nav cds--side-nav--ux"
+    inert="-1"
+    tabindex="-1"
+  />
+</div>
+`;

--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -47,6 +47,7 @@ export interface SideNavProps extends ComponentProps<'nav'> {
   onSideNavBlur?: () => void | undefined;
   enterDelayMs?: number;
   inert?: boolean;
+  isCollapsible: boolean | undefined;
 }
 
 interface SideNavContextData {
@@ -76,6 +77,7 @@ function SideNavRenderFunction(
     onOverlayClick,
     onSideNavBlur,
     enterDelayMs = 100,
+    isCollapsible = false,
     ...other
   }: SideNavProps,
   ref: ForwardedRef<HTMLElement>
@@ -113,11 +115,14 @@ function SideNavRenderFunction(
     [`${prefix}--side-nav--rail`]: isRail,
     [`${prefix}--side-nav--ux`]: isChildOfHeader,
     [`${prefix}--side-nav--hidden`]: !isPersistent,
+    [`${prefix}--side-nav--collapsible`]: isCollapsible,
   });
 
   const overlayClassName = cx({
     [`${prefix}--side-nav__overlay`]: true,
     [`${prefix}--side-nav__overlay-active`]: expanded || expandedViaHoverState,
+    [`${prefix}--side-nav__overlay-active--lg`]:
+      isCollapsible && (expanded || expandedViaHoverState),
   });
 
   let childrenToRender = children;
@@ -292,6 +297,11 @@ SideNav.propTypes = {
    * Optionally provide a custom class to apply to the underlying `<li>` node
    */
   isChildOfHeader: PropTypes.bool,
+
+  /**
+   * Specify whether the SideNav is collapsible at desktop
+   */
+  isCollapsible: PropTypes.bool,
 
   /**
    * Specify if sideNav is standalone

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -1,0 +1,35 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/motion' as *;
+@use '@carbon/styles/scss/utilities/convert' as convert;
+
+// $prefix: 'clabs' !default;
+// Do we want to update to clabs?
+$prefix: 'cds' !default;
+
+//----------------------------------------------------------------------------
+// Side-nav Collapsible
+//----------------------------------------------------------------------------
+.#{$prefix}--side-nav--collapsible.#{$prefix}--side-nav--ux {
+  inline-size: 0;
+}
+
+.#{$prefix}--side-nav--collapsible.#{$prefix}--side-nav--expanded {
+  inline-size: convert.to-rem(256px);
+}
+
+.#{$prefix}--side-nav__overlay-active--lg {
+  z-index: z('overlay');
+  background-color: $overlay;
+  block-size: 100vh;
+  inline-size: 100vw;
+  opacity: 1;
+  transition: opacity $transition-expansion $standard-easing,
+    background-color $transition-expansion $standard-easing;
+}

--- a/packages/react/src/components/UIShell/components/ui-shell.scss
+++ b/packages/react/src/components/UIShell/components/ui-shell.scss
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@use 'scss/side-nav';
+@use 'styles/side-nav';

--- a/packages/react/src/components/UIShell/components/ui-shell.scss
+++ b/packages/react/src/components/UIShell/components/ui-shell.scss
@@ -5,18 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Carbon setting imports
-// @use '@carbon/styles/scss/theme' as *;
-// @use '@carbon/styles/scss/colors' as *;
-// @use '@carbon/styles/scss/spacing' as *;
-// @use '@carbon/styles/scss/components/button' as *;
-
-// $prefix: 'clabs' !default;
-
-// .#{$prefix}--ui-shell__container {
-//   padding: $spacing-01;
-//   border: 1px solid $border-subtle-01;
-//   inline-size: fit-content;
-// }
-
 @use 'scss/side-nav';

--- a/packages/react/src/components/UIShell/components/ui-shell.scss
+++ b/packages/react/src/components/UIShell/components/ui-shell.scss
@@ -6,15 +6,17 @@
  */
 
 // Carbon setting imports
-@use '@carbon/styles/scss/theme' as *;
-@use '@carbon/styles/scss/colors' as *;
-@use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/components/button' as *;
+// @use '@carbon/styles/scss/theme' as *;
+// @use '@carbon/styles/scss/colors' as *;
+// @use '@carbon/styles/scss/spacing' as *;
+// @use '@carbon/styles/scss/components/button' as *;
 
-$prefix: 'clabs' !default;
+// $prefix: 'clabs' !default;
 
-.#{$prefix}--ui-shell__container {
-  padding: $spacing-01;
-  border: 1px solid $border-subtle-01;
-  inline-size: fit-content;
-}
+// .#{$prefix}--ui-shell__container {
+//   padding: $spacing-01;
+//   border: 1px solid $border-subtle-01;
+//   inline-size: fit-content;
+// }
+
+@use 'scss/side-nav';


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18492


#### Changelog


- update example code (what shows up in stackblitz once published)
- update overview page in storybook
- add default shell story with theme component and demo content
- isolate sidenav story
- add new `isCollapsible` prop to `SideNav`
- copy over tests from @carbon/react for `SideNav`
 - Commented out 2 failing tests - will look at separately, shouldn't block this
- add basic test for new prop



#### Testing / Reviewing

Test hamburger functionality in Default story th

@oliviaflory do we want the overlay, currently by default it does pop up but I can make it configurable if needed. 
