### PR TITLE
chore(UIShell): add telemetry to UI shell package

### DIFF
--- a/packages/react/src/components/UIShell/README.md
+++ b/packages/react/src/components/UIShell/README.md
@@ -1,0 +1,10 @@
+# @carbon-labs/react-ui-shell
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/react/src/components/UIShell/package.json
+++ b/packages/react/src/components/UIShell/package.json
@@ -18,13 +18,19 @@
   "files": [
     "es",
     "lib",
-    "scss"
+    "scss",
+    "telemetry.yml"
   ],
   "scripts": {
     "build": "node ../../../tasks/build.js",
-    "clean": "rm -rf {es,lib,scss}"
+    "clean": "rm -rf {es,lib,scss}",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 5b9dce15-eeda-4b53-8683-3e3aeb599fd1 --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "devDependencies": {
     "@carbon-labs/utilities": "canary"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.9.1"
   }
 }

--- a/packages/react/src/components/UIShell/telemetry.yml
+++ b/packages/react/src/components/UIShell/telemetry.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: 5b9dce15-eeda-4b53-8683-3e3aeb599fd1
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # SideNav
+        - addFocusListeners
+        - addMouseListeners
+        - className
+        - defaultExpanded
+        - enterDelayMs
+        - expanded
+        - href
+        - inert
+        - isChildOfHeader
+        - isCollapsible
+        - isFixedNav
+        - isPersistent
+        - isRail
+        - onOverlayClick
+        - onSideNavBlur
+        - onToggle
+        # React
+        - key
+        - ref
+      allowedAttributeStringValues:
+        - 'true'
+        - 'false'
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -2603,6 +2603,7 @@ __metadata:
   resolution: "@carbon-labs/react-ui-shell@workspace:packages/react/src/components/UIShell"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
+    "@ibm/telemetry-js": "npm:^1.9.1"
   languageName: unknown
   linkType: soft
 
@@ -4040,6 +4041,15 @@ __metadata:
   bin:
     ibmtelemetry: dist/collect.js
   checksum: 10c0/29b2d321b97218b4c3b19dc4a6dbccb88655dd5a9941c71a2974bd5f387532098dd4a791690e378b9e42b4f09e7b1ef349d370e9ef9ff834485d112405cea328
+  languageName: node
+  linkType: hard
+
+"@ibm/telemetry-js@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@ibm/telemetry-js@npm:1.9.1"
+  bin:
+    ibmtelemetry: dist/collect.js
+  checksum: 10c0/fc7684c0051f76884ecc24409558b6162a11a1c80536afbe1f201b5f26f234f5ae7236ab13b260ce4faaaec0deacc0f2b702b2ae6b02765fef81c5bc4f3215e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #397 

Adds telemetry to the UI shell package so we can track and monitor adoption of the package.

#### Changelog

**New**

- `telemetry.yml` file, which is generated by the
- `telemetry:config` script, to run whenever we add React components that have net-new prop or prop values for the package
- `README.md` to put the telemetry notice
- `@ibm/telemetry-js` dependency

**Changed**

- N/A

**Removed**

- N/A

#### Testing / Reviewing

I generated and saved the telemetry project ID. Not really sure how to test this PR; we've never really tested the instrumented PRs. One thing to note, the `telemetry:config` script generated an empty array for `allowedAttributeStringValues` which caused YAML validation errors. Because of this, I manually added `true` and `false` as allowed prop values for now.