### PR TITLE
feat(UIShell): add HeaderPanel to UIShell React package

### DIFF
--- a/examples/react/UIShell/src/App.tsx
+++ b/examples/react/UIShell/src/App.tsx
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { SideNav, HeaderPanel } from '@carbon-labs/react-ui-shell/es/index';
 import {
   SideNavItems,
@@ -18,6 +18,8 @@ import {
   HeaderContainer,
   Header,
   HeaderName,
+  HeaderGlobalBar,
+  HeaderGlobalAction,
   Theme,
   HeaderMenuButton,
   SideNavDivider,
@@ -25,6 +27,7 @@ import {
 import { Fade } from '@carbon/icons-react';
 
 function App() {
+  const [expandedPanel, setExpandedPanel] = useState(false);
   return (
     <Theme theme="g100">
       <HeaderContainer
@@ -43,7 +46,17 @@ function App() {
               <HeaderName href="#" prefix="IBM">
                 [Platform]
               </HeaderName>
-              <HeaderPanel />
+              <HeaderGlobalBar>
+                <HeaderGlobalAction
+                  aria-label={expandedPanel ? 'Close panel' : 'Open panel'}
+                  isActive={expandedPanel}
+                  aria-expanded={expandedPanel}
+                  tooltipAlignment="end"
+                  onClick={() => setExpandedPanel(!expandedPanel)}>
+                  <Fade size={20} />
+                </HeaderGlobalAction>
+              </HeaderGlobalBar>
+              <HeaderPanel expanded={expandedPanel} />
             </Header>
             <SideNav
               aria-label="Side navigation1"

--- a/examples/react/UIShell/src/App.tsx
+++ b/examples/react/UIShell/src/App.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { SideNav } from '@carbon-labs/react-ui-shell/es/index';
+import { SideNav, HeaderPanel } from '@carbon-labs/react-ui-shell/es/index';
 import {
   SideNavItems,
   SideNavMenu,
@@ -43,6 +43,7 @@ function App() {
               <HeaderName href="#" prefix="IBM">
                 [Platform]
               </HeaderName>
+              <HeaderPanel />
             </Header>
             <SideNav
               aria-label="Side navigation1"

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -38,6 +38,7 @@ package:
 - `SideNav`
   - `isCollapsible`
   - `hideOverlay`
+- `HeaderPanel`
 
 <Canvas of={UIShellStories.Default} />
 
@@ -62,7 +63,7 @@ In your styles file import
 ### JS (via import)
 
 ```javascript
-import { SideNav } from '@carbon-labs/react-ui-shell/es/index';
+import { SideNav, HeaderPanel } from '@carbon-labs/react-ui-shell/es/index';
 import {
   SideNavItems,
   SideNavMenu,
@@ -97,6 +98,7 @@ function App() {
               <HeaderName href="#" prefix="IBM">
                 [Platform]
               </HeaderName>
+              <HeaderPanel />
             </Header>
             <SideNav
               aria-label="Side navigation1"

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -7,9 +7,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import mdx from './UIShell.mdx';
 import { SideNav } from '../components/SideNav';
+import { HeaderPanel } from '../components/HeaderPanel';
 import {
   SideNavItems,
   SideNavMenu,
@@ -23,9 +24,21 @@ import {
   HeaderMenuButton,
   SideNavDivider,
   Content,
+  HeaderGlobalBar,
+  HeaderGlobalAction,
 } from '@carbon/react';
 import { Fade } from '@carbon/icons-react';
 import '../components/ui-shell.scss';
+
+export default {
+  title: 'Components/UIShell',
+  component: SideNav,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
 
 /**
  * Story content
@@ -76,6 +89,7 @@ const StoryContent = () => {
         used per product section. If tabs are needed on a page when using a
         side-nav, then the tabs are secondary in hierarchy to the side-nav.
       </p>
+      <HeaderPanel />
     </div>
   );
   const style = {
@@ -88,88 +102,92 @@ const StoryContent = () => {
   );
 };
 
-export default {
-  title: 'Components/UIShell',
-  component: SideNav,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-};
-
 /**
- * Story for SideNav
+ * Story for UIShell
  * @returns {React.ReactElement} The JSX for the story
  */
-export const Default = () => (
-  <div>
-    <Theme theme="g100">
-      <HeaderContainer
-        render={({ isSideNavExpanded, onClickSideNavExpand }) => (
-          <>
-            <Header aria-label="IBM Platform Name">
-              <SkipToContent />
-              <HeaderMenuButton
-                aria-label={isSideNavExpanded ? 'Close menu' : 'Open menu'}
-                onClick={onClickSideNavExpand}
-                isActive={isSideNavExpanded}
-                aria-expanded={isSideNavExpanded}
-                isCollapsible //shows hamburger menu at desktop
-                isFixedNav
-              />
-              <HeaderName href="#" prefix="IBM">
-                [Platform]
-              </HeaderName>
-            </Header>
-            <SideNav
-              aria-label="Side navigation1"
-              expanded={isSideNavExpanded}
-              onSideNavBlur={onClickSideNavExpand}
-              isCollapsible
-              hideOverlay
-              className="nav--global">
-              <SideNavItems>
-                <SideNavMenu renderIcon={Fade} title="Link">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-                <SideNavMenu renderIcon={Fade} title="Link">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-                <SideNavMenu renderIcon={Fade} title="Link">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-                <SideNavMenu renderIcon={Fade} title="Link">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-                <SideNavMenu renderIcon={Fade} title="Link">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-                <SideNavDivider />
-                <SideNavLink renderIcon={Fade} href="#">
-                  Link
-                </SideNavLink>
-                <SideNavLink renderIcon={Fade} href="#">
-                  Link
-                </SideNavLink>
-                <SideNavMenu renderIcon={Fade} title="Link">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-              </SideNavItems>
-            </SideNav>
-            <Theme theme="white">
-              <StoryContent />
-            </Theme>
-          </>
-        )}
-      />
-    </Theme>
-  </div>
-);
+export const Default = () => {
+  const [expandedPanel, setExpandedPanel] = useState(false);
+  return (
+    <div>
+      <Theme theme="g100">
+        <HeaderContainer
+          render={({ isSideNavExpanded, onClickSideNavExpand }) => (
+            <>
+              <Header aria-label="IBM Platform Name">
+                <SkipToContent />
+                <HeaderMenuButton
+                  aria-label={isSideNavExpanded ? 'Close menu' : 'Open menu'}
+                  onClick={onClickSideNavExpand}
+                  isActive={isSideNavExpanded}
+                  aria-expanded={isSideNavExpanded}
+                  isCollapsible //shows hamburger menu at desktop
+                  isFixedNav
+                />
+                <HeaderName href="#" prefix="IBM">
+                  [Platform]
+                </HeaderName>
+                <HeaderGlobalBar>
+                  <HeaderGlobalAction
+                    aria-label={expandedPanel ? 'Close panel' : 'Open panel'}
+                    isActive={expandedPanel}
+                    aria-expanded={expandedPanel}
+                    tooltipAlignment="end"
+                    onClick={() => setExpandedPanel(!expandedPanel)}>
+                    <Fade size={20} />
+                  </HeaderGlobalAction>
+                </HeaderGlobalBar>
+                <HeaderPanel expanded={expandedPanel} />
+              </Header>
+              <SideNav
+                aria-label="Side navigation1"
+                expanded={isSideNavExpanded}
+                onSideNavBlur={onClickSideNavExpand}
+                isCollapsible
+                hideOverlay
+                className="nav--global">
+                <SideNavItems>
+                  <SideNavMenu renderIcon={Fade} title="Link">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                  <SideNavMenu renderIcon={Fade} title="Link">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                  <SideNavMenu renderIcon={Fade} title="Link">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                  <SideNavMenu renderIcon={Fade} title="Link">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                  <SideNavMenu renderIcon={Fade} title="Link">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                  <SideNavDivider />
+                  <SideNavLink renderIcon={Fade} href="#">
+                    Link
+                  </SideNavLink>
+                  <SideNavLink renderIcon={Fade} href="#">
+                    Link
+                  </SideNavLink>
+                  <SideNavMenu renderIcon={Fade} title="Link">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                </SideNavItems>
+              </SideNav>
+              <Theme theme="white">
+                <StoryContent />
+              </Theme>
+            </>
+          )}
+        />
+      </Theme>
+    </div>
+  );
+};
 
 Default.parameters = {
   controls: { disable: true },
@@ -180,7 +198,7 @@ Default.parameters = {
  * Story for SideNav
  * @returns {React.ReactElement} The JSX for the story
  */
-export const SideNavFixed = () => (
+export const SideNavStory = () => (
   <SideNav
     isFixedNav
     expanded={true}
@@ -219,3 +237,20 @@ export const SideNavFixed = () => (
     </SideNavItems>
   </SideNav>
 );
+SideNavStory.storyName = 'SideNav';
+
+/**
+ * Story for HeaderPanel
+ * @param {object} args Storybook args that control component props
+ * @returns {React.ReactElement} The JSX for the story
+ */
+export const HeaderPanelStory = (args) => <HeaderPanel {...args} />;
+HeaderPanelStory.storyName = 'HeaderPanel';
+
+HeaderPanelStory.args = {
+  expanded: true,
+};
+
+HeaderPanelStory.argTypes = {
+  expanded: { control: 'boolean' },
+};

--- a/packages/react/src/components/UIShell/__tests__/HeaderPanel-test.js
+++ b/packages/react/src/components/UIShell/__tests__/HeaderPanel-test.js
@@ -1,0 +1,155 @@
+/**
+ * Copyright IBM Corp. 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import HeaderPanel from '../HeaderPanel';
+import Switcher from '../Switcher';
+import SwitcherItem from '../SwitcherItem';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('HeaderPanel', () => {
+  describe('renders as expected - Component API', () => {
+    it('should spread extra props onto outermost element', () => {
+      const { container } = render(
+        <HeaderPanel aria-label="aria-label" data-testid="test-id" />
+      );
+
+      expect(container.firstChild).toHaveAttribute('data-testid', 'test-id');
+    });
+
+    it('should respect aria-label prop', () => {
+      const { container } = render(<HeaderPanel aria-label="test-aria" />);
+
+      expect(container.firstChild).toHaveAttribute('aria-label', 'test-aria');
+    });
+
+    it('should respect aria-labelledby prop', () => {
+      const { container } = render(
+        <HeaderPanel aria-labelledby="test-aria-labelledby" />
+      );
+
+      expect(container.firstChild).toHaveAttribute(
+        'aria-labelledby',
+        'test-aria-labelledby'
+      );
+    });
+
+    it('should support a custom `className` prop on the outermost element', () => {
+      const { container } = render(
+        <HeaderPanel aria-label="test-aria" className="custom-class" />
+      );
+
+      expect(container.firstChild).toHaveClass('custom-class');
+    });
+
+    it('should respect expanded prop', () => {
+      const { container } = render(
+        <HeaderPanel aria-label="test-aria" expanded />
+      );
+
+      expect(container.firstChild).toHaveClass('cds--header-panel--expanded');
+    });
+
+    it('should render children as expected', () => {
+      render(
+        <HeaderPanel aria-label="test-aria">
+          <div className="child">Test</div>
+          <div className="child">Test</div>
+        </HeaderPanel>
+      );
+
+      const childrenArray = screen.getAllByText('Test');
+      expect(childrenArray.length).toEqual(2);
+    });
+
+    it('should call `onHeaderPanelFocus` callback, when defined', async () => {
+      const onHeaderPanelFocus = jest.fn();
+      render(
+        <HeaderPanel onHeaderPanelFocus={onHeaderPanelFocus} expanded>
+          <button type="button">Test</button>
+        </HeaderPanel>
+      );
+
+      screen.getByRole('button', { name: 'Test' }).focus();
+      await userEvent.keyboard('{Escape}');
+
+      expect(onHeaderPanelFocus).toHaveBeenCalled();
+    });
+
+    it('should not error when `onHeaderPanelFocus` is not defined', async () => {
+      render(
+        <HeaderPanel>
+          <button type="button">Test</button>
+        </HeaderPanel>
+      );
+
+      await expect(async () => {
+        screen.getByRole('button', { name: 'Test' }).focus();
+        await userEvent.keyboard('{Escape}');
+      }).not.toThrow();
+    });
+
+    it('should handle click', async () => {
+      const onClick = jest.fn();
+
+      render(
+        <HeaderPanel
+          aria-label="test-aria"
+          expanded
+          href="#"
+          onHeaderPanelFocus={onClick}>
+          <Switcher aria-label="Switcher Container">
+            <SwitcherItem aria-label="Link 1" href="#">
+              Link 1
+            </SwitcherItem>
+          </Switcher>
+        </HeaderPanel>
+      );
+
+      await userEvent.click(document.body);
+
+      expect(onClick).toHaveBeenCalled();
+    });
+
+    it('should handle onKeyDown', async () => {
+      const onKeyDown = jest.fn();
+
+      render(
+        <HeaderPanel
+          expanded
+          href="#"
+          onHeaderPanelFocus={onKeyDown}
+          data-testid="header-panel">
+          <button type="button">Test</button>
+        </HeaderPanel>
+      );
+
+      screen.getByRole('button', { name: 'Test' }).focus();
+
+      await userEvent.keyboard('{Escape}');
+      expect(onKeyDown).toHaveBeenCalled();
+    });
+
+    it('should handle onBlur', async () => {
+      const onBlur = jest.fn();
+
+      render(
+        <HeaderPanel href="#" expanded onHeaderPanelFocus={onBlur}>
+          <div>Panel Content</div>
+        </HeaderPanel>
+      );
+
+      const panel = screen.getByText('Panel Content').parentElement;
+      fireEvent.blur(panel, {
+        relatedTarget: null,
+      });
+
+      expect(onBlur).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/components/UIShell/__tests__/HeaderPanel-test.js
+++ b/packages/react/src/components/UIShell/__tests__/HeaderPanel-test.js
@@ -6,9 +6,7 @@
  */
 
 import React from 'react';
-import HeaderPanel from '../HeaderPanel';
-import Switcher from '../Switcher';
-import SwitcherItem from '../SwitcherItem';
+import { HeaderPanel } from '../components/HeaderPanel';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -67,20 +65,6 @@ describe('HeaderPanel', () => {
       expect(childrenArray.length).toEqual(2);
     });
 
-    it('should call `onHeaderPanelFocus` callback, when defined', async () => {
-      const onHeaderPanelFocus = jest.fn();
-      render(
-        <HeaderPanel onHeaderPanelFocus={onHeaderPanelFocus} expanded>
-          <button type="button">Test</button>
-        </HeaderPanel>
-      );
-
-      screen.getByRole('button', { name: 'Test' }).focus();
-      await userEvent.keyboard('{Escape}');
-
-      expect(onHeaderPanelFocus).toHaveBeenCalled();
-    });
-
     it('should not error when `onHeaderPanelFocus` is not defined', async () => {
       render(
         <HeaderPanel>
@@ -92,47 +76,6 @@ describe('HeaderPanel', () => {
         screen.getByRole('button', { name: 'Test' }).focus();
         await userEvent.keyboard('{Escape}');
       }).not.toThrow();
-    });
-
-    it('should handle click', async () => {
-      const onClick = jest.fn();
-
-      render(
-        <HeaderPanel
-          aria-label="test-aria"
-          expanded
-          href="#"
-          onHeaderPanelFocus={onClick}>
-          <Switcher aria-label="Switcher Container">
-            <SwitcherItem aria-label="Link 1" href="#">
-              Link 1
-            </SwitcherItem>
-          </Switcher>
-        </HeaderPanel>
-      );
-
-      await userEvent.click(document.body);
-
-      expect(onClick).toHaveBeenCalled();
-    });
-
-    it('should handle onKeyDown', async () => {
-      const onKeyDown = jest.fn();
-
-      render(
-        <HeaderPanel
-          expanded
-          href="#"
-          onHeaderPanelFocus={onKeyDown}
-          data-testid="header-panel">
-          <button type="button">Test</button>
-        </HeaderPanel>
-      );
-
-      screen.getByRole('button', { name: 'Test' }).focus();
-
-      await userEvent.keyboard('{Escape}');
-      expect(onKeyDown).toHaveBeenCalled();
     });
 
     it('should handle onBlur', async () => {

--- a/packages/react/src/components/UIShell/components/HeaderPanel.tsx
+++ b/packages/react/src/components/UIShell/components/HeaderPanel.tsx
@@ -1,0 +1,181 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React, {
+  useRef,
+  useState,
+  ReactNode,
+  type ComponentProps,
+  type ForwardedRef,
+} from 'react';
+import { usePrefix } from '@carbon/react/lib/internal/usePrefix';
+import { keys } from '@carbon/react/lib/internal/keyboard/keys';
+import { match } from '@carbon/react/lib/internal/keyboard/match';
+import { useWindowEvent } from '@carbon/react/lib/internal/useEvent';
+import { useMergedRefs } from '@carbon/react/lib/internal/useMergedRefs';
+
+export interface HeaderPanelProps {
+  /**
+   * Specify whether focus and blur listeners are added. They are by default.
+   */
+  addFocusListeners?: boolean;
+
+  /**
+   * The content that will render inside of the `HeaderPanel`
+   */
+  children?: ReactNode;
+
+  /**
+   * Optionally provide a custom class to apply to the underlying `<li>` node
+   */
+  className?: string;
+
+  /**
+   * Specify whether the panel is expanded
+   */
+  expanded?: boolean;
+
+  /**
+   * Provide the `href` to the id of the element on your package that could
+   * be target.
+   */
+  href?: string;
+
+  /**
+   * An optional listener that is called a callback to collapse the HeaderPanel
+   */
+  onHeaderPanelFocus?: () => void;
+}
+
+const noopFn = () => {};
+export const HeaderPanel: React.FC<HeaderPanelProps> = React.forwardRef(
+  function HeaderPanel(
+    {
+      children,
+      className: customClassName,
+      expanded,
+      addFocusListeners = true,
+      onHeaderPanelFocus = noopFn,
+      href,
+      ...rest
+    },
+    ref: ForwardedRef<HTMLDivElement>
+  ) {
+    const prefix = usePrefix();
+    const headerPanelReference = useRef<HTMLDivElement>(null);
+    const headerPanelRef = useMergedRefs([headerPanelReference, ref]);
+
+    const controlled = useRef(expanded !== undefined).current;
+    const [expandedState, setExpandedState] = useState(expanded);
+    const expandedProp = controlled ? expanded : expandedState;
+
+    const [lastClickedElement, setLastClickedElement] =
+      useState<HTMLElement | null>(null);
+
+    const className = cx(`${prefix}--header-panel`, {
+      [`${prefix}--header-panel--expanded`]: expandedProp,
+      [customClassName as string]: !!customClassName,
+    });
+
+    const eventHandlers: Partial<
+      Pick<ComponentProps<'header'>, 'onBlur' | 'onKeyDown'>
+    > = {};
+
+    if (addFocusListeners) {
+      eventHandlers.onBlur = (event) => {
+        if (
+          !event.currentTarget.contains(event.relatedTarget) &&
+          !lastClickedElement?.classList?.contains(
+            `${prefix}--switcher__item-link`
+          )
+        ) {
+          setExpandedState(false);
+          setLastClickedElement(null);
+          if (expanded) {
+            onHeaderPanelFocus();
+          }
+        }
+      };
+      eventHandlers.onKeyDown = (event) => {
+        if (match(event, keys.Escape)) {
+          setExpandedState(false);
+          onHeaderPanelFocus();
+          if (href) {
+            window.location.href = href;
+          }
+        }
+      };
+    }
+
+    useWindowEvent('click', () => {
+      const focusedElement = document.activeElement as HTMLElement;
+      setLastClickedElement(focusedElement);
+
+      const childJsxElement = children as JSX.Element;
+
+      if (
+        childJsxElement?.type?.displayName === 'Switcher' &&
+        !focusedElement?.closest(`.${prefix}--header-panel--expanded`) &&
+        !focusedElement?.closest(`.${prefix}--header__action`) &&
+        !headerPanelReference?.current?.classList.contains(
+          `${prefix}--switcher`
+        ) &&
+        expanded
+      ) {
+        setExpandedState(false);
+        onHeaderPanelFocus();
+      }
+    });
+
+    return (
+      <div
+        {...rest}
+        className={className}
+        ref={headerPanelRef}
+        {...eventHandlers}>
+        {children}
+      </div>
+    );
+  }
+);
+
+HeaderPanel.propTypes = {
+  /**
+   * Specify whether focus and blur listeners are added. They are by default.
+   */
+  addFocusListeners: PropTypes.bool,
+
+  /**
+   * The content that will render inside of the `HeaderPanel`
+   */
+  children: PropTypes.node,
+
+  /**
+   * Optionally provide a custom class to apply to the underlying `<li>` node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify whether the panel is expanded
+   */
+  expanded: PropTypes.bool,
+
+  /**
+   * Provide the `href` to the id of the element on your package that could
+   * be target.
+   */
+  href: PropTypes.string,
+
+  /**
+   * An optional listener that is called a callback to collapse the HeaderPanel
+   */
+  onHeaderPanelFocus: PropTypes.func,
+};
+
+HeaderPanel.displayName = 'HeaderPanel';

--- a/packages/react/src/components/UIShell/components/HeaderPanel.tsx
+++ b/packages/react/src/components/UIShell/components/HeaderPanel.tsx
@@ -151,10 +151,10 @@ HeaderPanel.propTypes = {
    */
   addFocusListeners: PropTypes.bool,
 
-  // /**
-  //  * The content that will render inside of the `HeaderPanel`
-  //  */
-  // children: PropTypes.node,
+  /**
+   * The content that will render inside of the `HeaderPanel`
+   */
+  children: PropTypes.any,
 
   /**
    * Optionally provide a custom class to apply to the underlying `<li>` node

--- a/packages/react/src/components/UIShell/components/HeaderPanel.tsx
+++ b/packages/react/src/components/UIShell/components/HeaderPanel.tsx
@@ -151,10 +151,10 @@ HeaderPanel.propTypes = {
    */
   addFocusListeners: PropTypes.bool,
 
-  /**
-   * The content that will render inside of the `HeaderPanel`
-   */
-  children: PropTypes.node,
+  // /**
+  //  * The content that will render inside of the `HeaderPanel`
+  //  */
+  // children: PropTypes.node,
 
   /**
    * Optionally provide a custom class to apply to the underlying `<li>` node

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -7,8 +7,6 @@
 
 @use '@carbon/styles/scss/utilities/convert' as convert;
 
-// $prefix: 'clabs' !default;
-// Do we want to update to clabs?
 $prefix: 'cds' !default;
 
 //----------------------------------------------------------------------------

--- a/packages/react/src/components/UIShell/index.ts
+++ b/packages/react/src/components/UIShell/index.ts
@@ -7,3 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 export { SideNav } from './components/SideNav.js';
+export { HeaderPanel } from './components/HeaderPanel';


### PR DESCRIPTION
Closes #409

Bring over HeaderPanel component as is from @carbon/react to labs to prepare for future right panel enhancements design is working on [#18449](https://github.com/carbon-design-system/carbon/issues/18449)

#### Changelog

**New**

- add `HeaderPanel` React component inside of UIShell package

#### Testing
Check that the panel renders https://deploy-preview-407--carbon-labs-react.netlify.app/?path=/story/components-uishell--header-panel-story

