### PR TITLE
fix(SideNav): prevent SideNavToggle tabindex reset

### DIFF
--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -447,6 +447,9 @@ function SideNavRenderFunction(
   function resetNodeTabIndices() {
     const items = sideNavRef?.current?.querySelectorAll('[tabIndex="0"]') ?? [];
     items.forEach((item) => {
+      if (item.classList.contains(`${prefix}--side-nav__toggle`)) {
+        return;
+      }
       item.tabIndex = -1;
     });
   }

--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -465,7 +465,11 @@ function SideNavRenderFunction(
         tabIndex={-1}
         ref={navRef}
         className={`${prefix}--side-nav__navigation ${className}`}
-        inert={!isRail ? (expanded || isLg ? undefined : -1) : undefined}
+        inert={
+          !isRail && navType !== SIDE_NAV_TYPE.PANEL && !(expanded || isLg)
+            ? -1
+            : undefined
+        }
         {...accessibilityLabel}
         {...eventHandlers}
         {...other}>

--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -445,12 +445,10 @@ function SideNavRenderFunction(
   hideOverlay;
 
   function resetNodeTabIndices() {
-    Array.prototype.forEach.call(
-      sideNavRef?.current?.querySelectorAll('[tabIndex="0"]') ?? [],
-      (item) => {
-        item.tabIndex = -1;
-      }
-    );
+    const items = sideNavRef?.current?.querySelectorAll('[tabIndex="0"]') ?? [];
+    items.forEach((item) => {
+      item.tabIndex = -1;
+    });
   }
 
   return (

--- a/packages/react/src/components/UIShell/components/SideNavToggle.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavToggle.tsx
@@ -63,7 +63,7 @@ SideNavToggle.propTypes = {
   /**
    * Specify the text content for the toggle
    */
-  children: PropTypes.element,
+  children: PropTypes.node as unknown as React.Validator<React.ReactNode>,
 
   /**
    * Provide an optional function to be called when clicked


### PR DESCRIPTION
Closes #425

This PR fixes a regression that caused the SideNavToggle tab index value to reset

#### Changelog

**Changed**

- side nav menu tab index reset logic

#### Testing / Reviewing

Confirm that the SideNavToggle is accessible by keyboard once again