### PR TITLE
feat(UIShell): SideNav panel as grid influencer

### DIFF
--- a/examples/react/UIShell/src/App.tsx
+++ b/examples/react/UIShell/src/App.tsx
@@ -34,61 +34,81 @@ import {
 import { Fade, SquareOutline } from '@carbon/icons-react';
 
 const StoryContent = () => {
-  const content = (
-    <Grid>
-      <Column sm={4} md={8} lg={16}>
-        <h2 style={{ margin: '30px 0' }}>Purpose and function</h2>
-        <p>
-          The shell is perhaps the most crucial piece of any UI built with
-          <a href="www.carbondesignsystem.com"> Carbon</a>. It contains the
-          shared navigation framework for the entire design system and ties the
-          products in IBM’s portfolio together in a cohesive and elegant way.
-          The shell is the home of the topmost navigation, where users can
-          quickly and dependably gain their bearings and move between pages.
-          <br />
-          <br />
-          The shell was designed with maximum flexibility built in, to serve the
-          needs of a broad range of products and users. Adopting the shell
-          ensures compliance with IBM design standards, simplifies development
-          efforts, and provides great user experiences. All IBM products built
-          with Carbon are required to use the shell’s header.
-          <br />
-          <br />
-          To better understand the purpose and function of the UI shell,
-          consider the “shell” of MacOS, which contains the Apple menu,
-          top-level navigation, and universal, OS-level controls at the top of
-          the screen, as well as a universal dock along the bottom or side of
-          the screen. The Carbon UI shell is roughly analogous in function to
-          these parts of the Mac UI. For example, the app switcher portion of
-          the shell can be compared to the dock in MacOS.
-        </p>
-        <h2 style={{ margin: '30px 0' }}>Header responsive behavior</h2>
-        <p>
-          As a header scales down to fit smaller screen sizes, headers with
-          persistent side nav menus should have the side nav collapse into
-          “hamburger” menu. See the example to better understand responsive
-          behavior of the header.
-        </p>
-        <h2 style={{ margin: '30px 0' }}>Secondary navigation</h2>
-        <p>
-          The side-nav contains secondary navigation and fits below the header.
-          It can be configured to be either fixed-width or flexible, with only
-          one level of nested items allowed. Both links and category lists can
-          be used in the side-nav and may be mixed together. There are several
-          configurations of the side-nav, but only one configuration should be
-          used per product section. If tabs are needed on a page when using a
-          side-nav, then the tabs are secondary in hierarchy to the side-nav.
-        </p>
-      </Column>
-    </Grid>
-  );
-  const style = {
-    height: '100%',
-  };
   return (
-    <Content id="main-content" style={style}>
-      {content}
-    </Content>
+    <Theme as={Content} theme="g10">
+      <Grid align="start">
+        <Column sm={4} md={8} lg={12}>
+          <h2 style={{ margin: '0 0 30px 0' }}>Purpose and function</h2>
+          <p>
+            The shell is perhaps the most crucial piece of any UI built with
+            <a href="www.carbondesignsystem.com"> Carbon</a>. It contains the
+            shared navigation framework for the entire design system and ties
+            the products in IBM’s portfolio together in a cohesive and elegant
+            way. The shell is the home of the topmost navigation, where users
+            can quickly and dependably gain their bearings and move between
+            pages.
+            <br />
+            <br />
+            The shell was designed with maximum flexibility built in, to serve
+            the needs of a broad range of products and users. Adopting the shell
+            ensures compliance with IBM design standards, simplifies development
+            efforts, and provides great user experiences. All IBM products built
+            with Carbon are required to use the shell’s header.
+            <br />
+            <br />
+            To better understand the purpose and function of the UI shell,
+            consider the “shell” of MacOS, which contains the Apple menu,
+            top-level navigation, and universal, OS-level controls at the top of
+            the screen, as well as a universal dock along the bottom or side of
+            the screen. The Carbon UI shell is roughly analogous in function to
+            these parts of the Mac UI. For example, the app switcher portion of
+            the shell can be compared to the dock in MacOS.
+          </p>
+          <h2 style={{ margin: '30px 0' }}>Header responsive behavior</h2>
+          <p>
+            As a header scales down to fit smaller screen sizes, headers with
+            persistent side nav menus should have the side nav collapse into
+            “hamburger” menu. See the example to better understand responsive
+            behavior of the header.
+          </p>
+          <h2 style={{ margin: '30px 0' }}>Secondary navigation</h2>
+          <p>
+            The side-nav contains secondary navigation and fits below the
+            header. It can be configured to be either fixed-width or flexible,
+            with only one level of nested items allowed. Both links and category
+            lists can be used in the side-nav and may be mixed together. There
+            are several configurations of the side-nav, but only one
+            configuration should be used per product section. If tabs are needed
+            on a page when using a side-nav, then the tabs are secondary in
+            hierarchy to the side-nav.
+          </p>
+          <h2 style={{ margin: '30px 0' }}>Secondary navigation</h2>
+          <p>
+            The side-nav contains secondary navigation and fits below the
+            header. It can be configured to be either fixed-width or flexible,
+            with only one level of nested items allowed. Both links and category
+            lists can be used in the side-nav and may be mixed together. There
+            are several configurations of the side-nav, but only one
+            configuration should be used per product section. If tabs are needed
+            on a page when using a side-nav, then the tabs are secondary in
+            hierarchy to the side-nav.
+          </p>
+        </Column>
+        <Column sm={4} md={8} lg={4}>
+          <h3 style={{ margin: '0 0 30px 0' }}>Secondary navigation</h3>
+          <p>
+            The side-nav contains secondary navigation and fits below the
+            header. It can be configured to be either fixed-width or flexible,
+            with only one level of nested items allowed. Both links and category
+            lists can be used in the side-nav and may be mixed together. There
+            are several configurations of the side-nav, but only one
+            configuration should be used per product section. If tabs are needed
+            on a page when using a side-nav, then the tabs are secondary in
+            hierarchy to the side-nav.
+          </p>
+        </Column>
+      </Grid>
+    </Theme>
   );
 };
 
@@ -99,106 +119,108 @@ function App() {
       <HeaderContainer
         render={({ isSideNavExpanded, onClickSideNavExpand }) => (
           <>
-            <Header aria-label="IBM Platform Name">
-              <SkipToContent />
-              <HeaderMenuButton
-                aria-label={isSideNavExpanded ? 'Close menu' : 'Open menu'}
-                onClick={onClickSideNavExpand}
-                isActive={isSideNavExpanded}
-                aria-expanded={isSideNavExpanded}
-                isCollapsible //shows hamburger menu at desktop
-                isFixedNav
-              />
-              <HeaderName href="#" prefix="IBM">
-                [Platform]
-              </HeaderName>
-              <HeaderGlobalBar>
-                <HeaderGlobalAction
-                  aria-label={expandedPanel ? 'Close panel' : 'Open panel'}
-                  isActive={expandedPanel}
-                  aria-expanded={expandedPanel}
-                  tooltipAlignment="end"
-                  onClick={() => setExpandedPanel(!expandedPanel)}>
-                  <Fade size={20} />
-                </HeaderGlobalAction>
-              </HeaderGlobalBar>
-              <HeaderPanel expanded={expandedPanel} />
-            </Header>
-            <SideNav
-              navType={SIDE_NAV_TYPE.DEFAULT}
-              aria-label="Side navigation1"
-              expanded={isSideNavExpanded}
-              onSideNavBlur={onClickSideNavExpand}
-              isCollapsible
-              hideOverlay
-              className="nav--global">
-              <SideNavItems>
-                <SideNavMenu
-                  renderIcon={SquareOutline}
-                  title="Sub-menu level 1">
-                  <SideNavMenuItem href="#">Link level 2</SideNavMenuItem>
-                  <SideNavMenuItem href="#">Link level 2</SideNavMenuItem>
-                  <SideNavMenu title="Sub-menu level 2">
-                    <SideNavMenuItem href="#">Link level 3</SideNavMenuItem>
-                    <SideNavMenuItem href="#">Link level 3</SideNavMenuItem>
-                    <SideNavMenuItem href="#">Link level 3</SideNavMenuItem>
+            <Theme theme="g100">
+              <Header aria-label="IBM Platform Name">
+                <SkipToContent />
+                <HeaderMenuButton
+                  aria-label={isSideNavExpanded ? 'Close menu' : 'Open menu'}
+                  onClick={onClickSideNavExpand}
+                  isActive={isSideNavExpanded}
+                  aria-expanded={isSideNavExpanded}
+                  isCollapsible //shows hamburger menu at desktop
+                  isFixedNav
+                />
+                <HeaderName href="#" prefix="IBM">
+                  [Platform]
+                </HeaderName>
+                <HeaderGlobalBar>
+                  <HeaderGlobalAction
+                    aria-label={expandedPanel ? 'Close panel' : 'Open panel'}
+                    isActive={expandedPanel}
+                    aria-expanded={expandedPanel}
+                    tooltipAlignment="end"
+                    onClick={() => setExpandedPanel(!expandedPanel)}>
+                    <Fade size={20} />
+                  </HeaderGlobalAction>
+                </HeaderGlobalBar>
+                <HeaderPanel expanded={expandedPanel} />
+              </Header>
+              <SideNav
+                navType={SIDE_NAV_TYPE.DEFAULT}
+                aria-label="Side navigation1"
+                expanded={isSideNavExpanded}
+                onSideNavBlur={onClickSideNavExpand}
+                isCollapsible
+                hideOverlay
+                className="nav--global">
+                <SideNavItems>
+                  <SideNavMenu
+                    renderIcon={SquareOutline}
+                    title="Sub-menu level 1">
+                    <SideNavMenuItem href="#">Link level 2</SideNavMenuItem>
+                    <SideNavMenuItem href="#">Link level 2</SideNavMenuItem>
+                    <SideNavMenu title="Sub-menu level 2">
+                      <SideNavMenuItem href="#">Link level 3</SideNavMenuItem>
+                      <SideNavMenuItem href="#">Link level 3</SideNavMenuItem>
+                      <SideNavMenuItem href="#">Link level 3</SideNavMenuItem>
+                    </SideNavMenu>
                   </SideNavMenu>
-                </SideNavMenu>
-                <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-                <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-                <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-                <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-                <SideNavDivider />
-                <SideNavLink renderIcon={SquareOutline} href="#">
-                  Link
-                </SideNavLink>
-                <SideNavLink renderIcon={SquareOutline} href="#">
-                  Link
-                </SideNavLink>
-                <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                  <SideNavMenuItem href="#">Link</SideNavMenuItem>
-                </SideNavMenu>
-              </SideNavItems>
-            </SideNav>
-            <SideNav
-              navType={SIDE_NAV_TYPE.PANEL}
-              isChildOfHeader={false}
-              aria-label="Side navigation">
-              <SideNavItems>
-                <SideNavLink renderIcon={Fade} href="#">
-                  Link
-                </SideNavLink>
-                <SideNavLink renderIcon={Fade} href="#">
-                  Link
-                </SideNavLink>
-                <SideNavLink renderIcon={Fade} href="#">
-                  Link
-                </SideNavLink>
-                <SideNavLink renderIcon={Fade} href="#">
-                  Link
-                </SideNavLink>
-                <SideNavDivider />
-                <SideNavLink renderIcon={Fade} href="#">
-                  Link
-                </SideNavLink>
-                <SideNavLink renderIcon={Fade} href="#">
-                  Link
-                </SideNavLink>
-              </SideNavItems>
-            </SideNav>
-            <Theme theme="white">
-              <StoryContent />
+                  <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                  <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                  <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                  <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                  <SideNavDivider />
+                  <SideNavLink renderIcon={SquareOutline} href="#">
+                    Link
+                  </SideNavLink>
+                  <SideNavLink renderIcon={SquareOutline} href="#">
+                    Link
+                  </SideNavLink>
+                  <SideNavMenu renderIcon={SquareOutline} title="Sub-menu">
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                    <SideNavMenuItem href="#">Link</SideNavMenuItem>
+                  </SideNavMenu>
+                </SideNavItems>
+              </SideNav>
             </Theme>
+            <Theme theme="g100">
+              <SideNav
+                navType={SIDE_NAV_TYPE.PANEL}
+                isChildOfHeader={false}
+                aria-label="Side navigation">
+                <SideNavItems>
+                  <SideNavLink renderIcon={Fade} href="#">
+                    Link
+                  </SideNavLink>
+                  <SideNavLink renderIcon={Fade} href="#">
+                    Link
+                  </SideNavLink>
+                  <SideNavLink renderIcon={Fade} href="#">
+                    Link
+                  </SideNavLink>
+                  <SideNavLink renderIcon={Fade} href="#">
+                    Link
+                  </SideNavLink>
+                  <SideNavDivider />
+                  <SideNavLink renderIcon={Fade} href="#">
+                    Link
+                  </SideNavLink>
+                  <SideNavLink renderIcon={Fade} href="#">
+                    Link
+                  </SideNavLink>
+                </SideNavItems>
+              </SideNav>
+            </Theme>
+            <StoryContent />
           </>
         )}
       />

--- a/examples/react/UIShell/src/App.tsx
+++ b/examples/react/UIShell/src/App.tsx
@@ -196,6 +196,7 @@ function App() {
               <SideNav
                 navType={SIDE_NAV_TYPE.PANEL}
                 isChildOfHeader={false}
+                hideOverlay
                 aria-label="Side navigation">
                 <SideNavItems>
                   <SideNavLink renderIcon={Fade} href="#">

--- a/packages/react/.storybook/styles.scss
+++ b/packages/react/.storybook/styles.scss
@@ -1,3 +1,28 @@
 @use '@carbon/styles' as styles with (
   $font-path: '~@ibm/plex'
 );
+
+:root {
+  @include styles.theme(styles.$white);
+}
+
+[data-carbon-theme='g10'] {
+  @include styles.theme(styles.$g10);
+}
+
+[data-carbon-theme='g90'] {
+  @include styles.theme(styles.$g90);
+}
+
+[data-carbon-theme='g100'] {
+  @include styles.theme(styles.$g100);
+}
+
+body {
+  background: styles.$background;
+  color: styles.$text-primary;
+}
+
+.sb-show-main.sb-main-padded {
+  padding: 0;
+}

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -170,6 +170,7 @@ function App() {
             <SideNav
               navType={SIDE_NAV_TYPE.PANEL}
               isChildOfHeader={false}
+              hideOverlay
               aria-label="Side navigation">
               <SideNavItems>
                 <SideNavLink renderIcon={Fade} href="#">

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -47,61 +47,81 @@ export default {
  * @returns {React.ReactElement} The JSX for the story
  */
 const StoryContent = () => {
-  const content = (
-    <Grid>
-      <Column sm={4} md={8} lg={16}>
-        <h2 style={{ margin: '30px 0' }}>Purpose and function</h2>
-        <p>
-          The shell is perhaps the most crucial piece of any UI built with
-          <a href="www.carbondesignsystem.com"> Carbon</a>. It contains the
-          shared navigation framework for the entire design system and ties the
-          products in IBM’s portfolio together in a cohesive and elegant way.
-          The shell is the home of the topmost navigation, where users can
-          quickly and dependably gain their bearings and move between pages.
-          <br />
-          <br />
-          The shell was designed with maximum flexibility built in, to serve the
-          needs of a broad range of products and users. Adopting the shell
-          ensures compliance with IBM design standards, simplifies development
-          efforts, and provides great user experiences. All IBM products built
-          with Carbon are required to use the shell’s header.
-          <br />
-          <br />
-          To better understand the purpose and function of the UI shell,
-          consider the “shell” of MacOS, which contains the Apple menu,
-          top-level navigation, and universal, OS-level controls at the top of
-          the screen, as well as a universal dock along the bottom or side of
-          the screen. The Carbon UI shell is roughly analogous in function to
-          these parts of the Mac UI. For example, the app switcher portion of
-          the shell can be compared to the dock in MacOS.
-        </p>
-        <h2 style={{ margin: '30px 0' }}>Header responsive behavior</h2>
-        <p>
-          As a header scales down to fit smaller screen sizes, headers with
-          persistent side nav menus should have the side nav collapse into
-          “hamburger” menu. See the example to better understand responsive
-          behavior of the header.
-        </p>
-        <h2 style={{ margin: '30px 0' }}>Secondary navigation</h2>
-        <p>
-          The side-nav contains secondary navigation and fits below the header.
-          It can be configured to be either fixed-width or flexible, with only
-          one level of nested items allowed. Both links and category lists can
-          be used in the side-nav and may be mixed together. There are several
-          configurations of the side-nav, but only one configuration should be
-          used per product section. If tabs are needed on a page when using a
-          side-nav, then the tabs are secondary in hierarchy to the side-nav.
-        </p>
-      </Column>
-    </Grid>
-  );
-  const style = {
-    height: '100%',
-  };
   return (
-    <Content id="main-content" style={style}>
-      {content}
-    </Content>
+    <Theme as={Content} theme="g10">
+      <Grid align="start">
+        <Column sm={4} md={8} lg={12}>
+          <h2 style={{ margin: '0 0 30px 0' }}>Purpose and function</h2>
+          <p>
+            The shell is perhaps the most crucial piece of any UI built with
+            <a href="www.carbondesignsystem.com"> Carbon</a>. It contains the
+            shared navigation framework for the entire design system and ties
+            the products in IBM’s portfolio together in a cohesive and elegant
+            way. The shell is the home of the topmost navigation, where users
+            can quickly and dependably gain their bearings and move between
+            pages.
+            <br />
+            <br />
+            The shell was designed with maximum flexibility built in, to serve
+            the needs of a broad range of products and users. Adopting the shell
+            ensures compliance with IBM design standards, simplifies development
+            efforts, and provides great user experiences. All IBM products built
+            with Carbon are required to use the shell’s header.
+            <br />
+            <br />
+            To better understand the purpose and function of the UI shell,
+            consider the “shell” of MacOS, which contains the Apple menu,
+            top-level navigation, and universal, OS-level controls at the top of
+            the screen, as well as a universal dock along the bottom or side of
+            the screen. The Carbon UI shell is roughly analogous in function to
+            these parts of the Mac UI. For example, the app switcher portion of
+            the shell can be compared to the dock in MacOS.
+          </p>
+          <h2 style={{ margin: '30px 0' }}>Header responsive behavior</h2>
+          <p>
+            As a header scales down to fit smaller screen sizes, headers with
+            persistent side nav menus should have the side nav collapse into
+            “hamburger” menu. See the example to better understand responsive
+            behavior of the header.
+          </p>
+          <h2 style={{ margin: '30px 0' }}>Secondary navigation</h2>
+          <p>
+            The side-nav contains secondary navigation and fits below the
+            header. It can be configured to be either fixed-width or flexible,
+            with only one level of nested items allowed. Both links and category
+            lists can be used in the side-nav and may be mixed together. There
+            are several configurations of the side-nav, but only one
+            configuration should be used per product section. If tabs are needed
+            on a page when using a side-nav, then the tabs are secondary in
+            hierarchy to the side-nav.
+          </p>
+          <h2 style={{ margin: '30px 0' }}>Secondary navigation</h2>
+          <p>
+            The side-nav contains secondary navigation and fits below the
+            header. It can be configured to be either fixed-width or flexible,
+            with only one level of nested items allowed. Both links and category
+            lists can be used in the side-nav and may be mixed together. There
+            are several configurations of the side-nav, but only one
+            configuration should be used per product section. If tabs are needed
+            on a page when using a side-nav, then the tabs are secondary in
+            hierarchy to the side-nav.
+          </p>
+        </Column>
+        <Column sm={4} md={8} lg={4}>
+          <h3 style={{ margin: '0 0 30px 0' }}>Secondary navigation</h3>
+          <p>
+            The side-nav contains secondary navigation and fits below the
+            header. It can be configured to be either fixed-width or flexible,
+            with only one level of nested items allowed. Both links and category
+            lists can be used in the side-nav and may be mixed together. There
+            are several configurations of the side-nav, but only one
+            configuration should be used per product section. If tabs are needed
+            on a page when using a side-nav, then the tabs are secondary in
+            hierarchy to the side-nav.
+          </p>
+        </Column>
+      </Grid>
+    </Theme>
   );
 };
 
@@ -113,10 +133,10 @@ export const Default = () => {
   const [expandedPanel, setExpandedPanel] = useState(false);
   return (
     <div>
-      <Theme theme="g100">
-        <HeaderContainer
-          render={({ isSideNavExpanded, onClickSideNavExpand }) => (
-            <>
+      <HeaderContainer
+        render={({ isSideNavExpanded, onClickSideNavExpand }) => (
+          <>
+            <Theme theme="g100">
               <Header aria-label="IBM Platform Name">
                 <SkipToContent />
                 <HeaderMenuButton
@@ -143,7 +163,7 @@ export const Default = () => {
                 <HeaderPanel expanded={expandedPanel} />
               </Header>
               <SideNav
-                aria-label="Side navigation1"
+                aria-label="Main navigation"
                 expanded={isSideNavExpanded}
                 onSideNavBlur={onClickSideNavExpand}
                 isCollapsible
@@ -187,10 +207,12 @@ export const Default = () => {
                   </SideNavMenu>
                 </SideNavItems>
               </SideNav>
+            </Theme>
+            <Theme theme="g100">
               <SideNav
                 navType={SIDE_NAV_TYPE.PANEL}
                 isChildOfHeader={false}
-                aria-label="Side navigation">
+                aria-label="Product navigation">
                 <SideNavItems>
                   <SideNavLink renderIcon={Fade} href="#">
                     Link
@@ -213,13 +235,11 @@ export const Default = () => {
                   </SideNavLink>
                 </SideNavItems>
               </SideNav>
-              <Theme theme="white">
-                <StoryContent />
-              </Theme>
-            </>
-          )}
-        />
-      </Theme>
+            </Theme>
+            <StoryContent />
+          </>
+        )}
+      />
     </div>
   );
 };
@@ -307,6 +327,76 @@ export const SideNavNested = () => (
 SideNavNested.storyName = 'SideNav w/ 3rd level';
 
 /**
+ * Story for SideNav panel
+ * @returns {React.ReactElement} The JSX for the story
+ */
+export const SideNavPanel = () => {
+  return (
+    <>
+      <SideNav
+        navType={SIDE_NAV_TYPE.PANEL}
+        isChildOfHeader={false}
+        aria-label="Product navigation">
+        <SideNavItems>
+          <SideNavLink renderIcon={Fade} href="#">
+            Link
+          </SideNavLink>
+          <SideNavLink renderIcon={Fade} href="#">
+            Link
+          </SideNavLink>
+          <SideNavLink renderIcon={Fade} href="#">
+            Link
+          </SideNavLink>
+          <SideNavLink renderIcon={Fade} href="#">
+            Link
+          </SideNavLink>
+          <SideNavDivider />
+          <SideNavLink renderIcon={Fade} href="#">
+            Link
+          </SideNavLink>
+          <SideNavLink renderIcon={Fade} href="#">
+            Link
+          </SideNavLink>
+        </SideNavItems>
+      </SideNav>
+      <Content>
+        <Grid align="start">
+          <Column sm={4} md={8} lg={12}>
+            <h2 style={{ margin: '0 0 30px 0' }}>Purpose and function</h2>
+            <p>
+              The shell is perhaps the most crucial piece of any UI built with
+              <a href="www.carbondesignsystem.com"> Carbon</a>. It contains the
+              shared navigation framework for the entire design system and ties
+              the products in IBM’s portfolio together in a cohesive and elegant
+              way. The shell is the home of the topmost navigation, where users
+              can quickly and dependably gain their bearings and move between
+              pages.
+              <br />
+              <br />
+              The shell was designed with maximum flexibility built in, to serve
+              the needs of a broad range of products and users. Adopting the
+              shell ensures compliance with IBM design standards, simplifies
+              development efforts, and provides great user experiences. All IBM
+              products built with Carbon are required to use the shell’s header.
+              <br />
+              <br />
+              To better understand the purpose and function of the UI shell,
+              consider the “shell” of MacOS, which contains the Apple menu,
+              top-level navigation, and universal, OS-level controls at the top
+              of the screen, as well as a universal dock along the bottom or
+              side of the screen. The Carbon UI shell is roughly analogous in
+              function to these parts of the Mac UI. For example, the app
+              switcher portion of the shell can be compared to the dock in
+              MacOS.
+            </p>
+          </Column>
+        </Grid>
+      </Content>
+    </>
+  );
+};
+
+/**
  * Story for HeaderPanel
  * @param {object} args Storybook args that control component props
  * @returns {React.ReactElement} The JSX for the story
@@ -321,36 +411,3 @@ HeaderPanelStory.args = {
 HeaderPanelStory.argTypes = {
   expanded: { control: 'boolean' },
 };
-
-/**
- * Story for SideNav
- * @returns {React.ReactElement} The JSX for the story
- */
-export const SideNavPanel = () => (
-  <SideNav
-    navType={SIDE_NAV_TYPE.PANEL}
-    isChildOfHeader={false}
-    aria-label="Side navigation">
-    <SideNavItems>
-      <SideNavLink renderIcon={Fade} href="#">
-        Link
-      </SideNavLink>
-      <SideNavLink renderIcon={Fade} href="#">
-        Link
-      </SideNavLink>
-      <SideNavLink renderIcon={Fade} href="#">
-        Link
-      </SideNavLink>
-      <SideNavLink renderIcon={Fade} href="#">
-        Link
-      </SideNavLink>
-      <SideNavDivider />
-      <SideNavLink renderIcon={Fade} href="#">
-        Link
-      </SideNavLink>
-      <SideNavLink renderIcon={Fade} href="#">
-        Link
-      </SideNavLink>
-    </SideNavItems>
-  </SideNav>
-);

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -212,6 +212,7 @@ export const Default = () => {
               <SideNav
                 navType={SIDE_NAV_TYPE.PANEL}
                 isChildOfHeader={false}
+                hideOverlay
                 aria-label="Product navigation">
                 <SideNavItems>
                   <SideNavLink renderIcon={Fade} href="#">

--- a/packages/react/src/components/UIShell/components/styles/_content.scss
+++ b/packages/react/src/components/UIShell/components/styles/_content.scss
@@ -12,6 +12,7 @@ $prefix: 'cds' !default;
 .#{$prefix}--side-nav--panel ~ .#{$prefix}--content,
 div:has(.#{$prefix}--side-nav--panel) ~ .#{$prefix}--content {
   margin-inline-start: convert.to-rem(48px);
+  /* Matches the side nav transition timing and easing from Carbon styles */
   transition: margin-inline-start 0.11s cubic-bezier(0.2, 0, 1, 0.9),
     transform 0.11s cubic-bezier(0.2, 0, 1, 0.9);
 }

--- a/packages/react/src/components/UIShell/components/styles/_content.scss
+++ b/packages/react/src/components/UIShell/components/styles/_content.scss
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/styles/scss/utilities/convert' as convert;
+
+$prefix: 'cds' !default;
+
+.#{$prefix}--side-nav--panel ~ .#{$prefix}--content,
+div:has(.#{$prefix}--side-nav--panel) ~ .#{$prefix}--content {
+  margin-inline-start: convert.to-rem(48px);
+  transition: margin-inline-start 0.11s cubic-bezier(0.2, 0, 1, 0.9),
+    transform 0.11s cubic-bezier(0.2, 0, 1, 0.9);
+}
+
+.#{$prefix}--side-nav--panel.#{$prefix}--side-nav--expanded
+  ~ .#{$prefix}--content,
+div:has(.#{$prefix}--side-nav--panel.#{$prefix}--side-nav--expanded)
+  ~ .#{$prefix}--content {
+  margin-inline-start: convert.to-rem(256px);
+}

--- a/packages/react/src/components/UIShell/components/styles/_content.scss
+++ b/packages/react/src/components/UIShell/components/styles/_content.scss
@@ -6,15 +6,14 @@
  */
 
 @use '@carbon/styles/scss/utilities/convert' as convert;
+@use '@carbon/styles/scss/motion' as *;
 
 $prefix: 'cds' !default;
 
 .#{$prefix}--side-nav--panel ~ .#{$prefix}--content,
 div:has(.#{$prefix}--side-nav--panel) ~ .#{$prefix}--content {
   margin-inline-start: convert.to-rem(48px);
-  /* Matches the side nav transition timing and easing from Carbon styles */
-  transition: margin-inline-start 0.11s cubic-bezier(0.2, 0, 1, 0.9),
-    transform 0.11s cubic-bezier(0.2, 0, 1, 0.9);
+  transition: margin-inline-start $duration-fast-02, transform $duration-fast-02;
 }
 
 .#{$prefix}--side-nav--panel.#{$prefix}--side-nav--expanded

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -65,7 +65,7 @@ div:has(.#{$prefix}--header)
 
   .#{$prefix}--side-nav__item.#{$prefix}--side-nav__item--icon
     a.#{$prefix}--side-nav__link {
-    padding-inline-start: mini-units(8);
+    padding-inline-start: $spacing-10;
   }
 
   .#{$prefix}--side-nav__toggle {

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -17,6 +17,13 @@
 
 $prefix: 'cds' !default;
 
+div:has(.#{$prefix}--header)
+  ~ div:has(.#{$prefix}--side-nav)
+  .#{$prefix}--side-nav {
+  block-size: calc(100% - $spacing-09);
+  inset-block-start: $spacing-09;
+}
+
 //----------------------------------------------------------------------------
 // Side-nav Collapsible
 //----------------------------------------------------------------------------

--- a/packages/react/src/components/UIShell/components/ui-shell.scss
+++ b/packages/react/src/components/UIShell/components/ui-shell.scss
@@ -6,3 +6,4 @@
  */
 
 @use 'styles/side-nav';
+@use 'styles/content';


### PR DESCRIPTION
Closes #416



#### Changelog

**New**

- add missing styles to storybook to enable theme switcher
- add content styles when combined with sidenav panel

**Changed**

- update default story
- update example 



#### Testing / Reviewing

Check that SideNav panel now acts as a grid influencer in default story and panel story.
