### PR TITLE
docs: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 /packages/web-components/src/components/chat      @carbon-design-system/carbon-ai-chat-admins @carbon-design-system/developers-system-reviewers
 
 # Carbon UI Shell
-/packages/react/src/components/uishell      @carbon-design-system/carbon-ui-shell-labs-devs
+/packages/react/src/components/UIShell      @carbon-design-system/carbon-ui-shell-labs-devs
 
 # Admins should be notified of changes to CI/CD workflows
 # codeowners, and any other config present in .github.


### PR DESCRIPTION
Codeowners hasn't been correctly assigning reviewers for the UIShell updates, I believe the issue is that github is case sensitive. 