### PR TITLE
fix: remove button style import

### DIFF
--- a/packages/react/src/components/ExampleButton/components/example-button.scss
+++ b/packages/react/src/components/ExampleButton/components/example-button.scss
@@ -8,7 +8,6 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/components/button' as *;
 
 $prefix: 'clabs' !default;
 


### PR DESCRIPTION

This import of Carbon button styles in the example component isn't needed and is overriding UIShell styles due to the order styles are being imported into storybook. 

#### Changelog



**Removed**

- import for button styles in example component

#### Testing / Reviewing

