### PR TITLE
fix(SideNav): handle unexpanded tabindex

### DIFF
--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -234,16 +234,20 @@ function SideNavRenderFunction(
           }
         );
       resetNodeTabIndices();
+    }
+  }, [prefix, internalIsTreeview]);
 
+  useEffect(() => {
+    if (sideNavRef.current) {
       const firstElement = sideNavRef?.current?.querySelector(
         'a, button'
       ) as HTMLElement;
 
-      if (firstElement) {
+      if (firstElement && (navType == SIDE_NAV_TYPE.PANEL || expanded)) {
         firstElement.tabIndex = 0;
       }
     }
-  }, [prefix, internalIsTreeview]);
+  }, [expanded]);
 
   /**
    * Returns the parent SideNavMenu, if node is actually inside one.


### PR DESCRIPTION
Closes #483

#### Changelog

**Changed**

- makes it so the first `SideNavMenuItem` gains `tabIndex=0` only when the panel is expanded, or it's a panel `navType`

#### Testing / Reviewing
Tabbed into it