### PR TITLE
fix(ci): downgrade node to 18 for ci build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
Closes #

Running into build errors from the Web Component side - downgrading to Node v18 seems to resolve the issue. Temporary fix until we switch over to use Rollup for builds

#### Changelog

**Changed**

- downgrade to Node v18 for the build step in the `ci` checks


#### Testing / Reviewing

Check that the build step for the ci-check passes in this PR
