### PR TITLE
fix: downgrade node to 18 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install
@@ -80,10 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/create-release-tag-and-pr.yml
+++ b/.github/workflows/create-release-tag-and-pr.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           registry-url: https://registry.npmjs.org
           cache: 'yarn'
       - name: Install dependencies

--- a/.github/workflows/publish-canary-cdn.yml
+++ b/.github/workflows/publish-canary-cdn.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: fkirc/skip-duplicate-actions@v5.3.1
         with:
           github_token: ${{ github.token }}
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: '0'
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/storybook-publish.yml
+++ b/.github/workflows/storybook-publish.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
Closes #

Downgrading the Node version in the `build` step of the ci-checks seems to resolve the build errors we're seeing in Web Component component builds. This PR downgrades the Node version to 18 for the rest of the workflows.

#### Changelog

**Changed**

- downgrade to Node v18 for all workflows

#### Testing / Reviewing

Make sure the ci-checks pass
