### PR TITLE
fix(SideNavToggle): show on screen height resize

### DIFF
--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -508,6 +508,15 @@ function SideNavRenderFunction(
     }
   };
 
+  const SideNavToggleButton = (
+    <SideNavToggle
+      className={!expandedState ? `${prefix}--side-nav__toggle--collapsed` : ''}
+      renderIcon={expandedState ? SidePanelClose : SidePanelOpen}
+      onClick={() => setExpandedState(!expandedState)}>
+      {sideNavToggleText}
+    </SideNavToggle>
+  );
+
   return (
     <SideNavContext.Provider
       value={{
@@ -535,13 +544,14 @@ function SideNavRenderFunction(
         {...eventHandlers}
         {...other}>
         {childrenToRender}
-        {navType === SIDE_NAV_TYPE.PANEL && (
-          <SideNavToggle
-            renderIcon={expandedState ? SidePanelClose : SidePanelOpen}
-            onClick={() => setExpandedState(!expandedState)}>
-            {sideNavToggleText}
-          </SideNavToggle>
-        )}
+        {navType === SIDE_NAV_TYPE.PANEL &&
+          (expandedState ? (
+            SideNavToggleButton
+          ) : (
+            <div className={`${prefix}--side-nav__toggle-container`}>
+              {SideNavToggleButton}
+            </div>
+          ))}
       </nav>
     </SideNavContext.Provider>
   );

--- a/packages/react/src/components/UIShell/components/SideNavToggle.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavToggle.tsx
@@ -5,12 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { ForwardedRef, ReactNode, Ref } from 'react';
 import { SideNavIcon } from '@carbon/react';
 import { usePrefix } from '../internal/usePrefix';
 
 interface SideNavToggleProps {
+  /**
+   * Specify an optional className to be applied to the button node
+   */
+  className?: string;
+
   /**
    * Specify the text content for the link
    */
@@ -35,14 +41,22 @@ interface SideNavToggleProps {
 
 export const SideNavToggle = React.forwardRef<HTMLElement, SideNavToggleProps>(
   function SideNavToggle(
-    { renderIcon: IconElement, tabIndex, children, ...rest },
+    {
+      className: customClassName,
+      renderIcon: IconElement,
+      tabIndex,
+      children,
+      ...rest
+    },
     ref: ForwardedRef<HTMLElement>
   ) {
     const prefix = usePrefix();
 
     return (
       <button
-        className={`${prefix}--side-nav__toggle`}
+        className={cx(customClassName, {
+          [`${prefix}--side-nav__toggle`]: true,
+        })}
         ref={ref as Ref<HTMLButtonElement>}
         type="button"
         tabIndex={tabIndex ?? 0}
@@ -64,6 +78,11 @@ SideNavToggle.propTypes = {
    * Specify the text content for the toggle
    */
   children: PropTypes.node as unknown as React.Validator<React.ReactNode>,
+
+  /**
+   * Specify an optional className to be applied to the button node
+   */
+  className: PropTypes.string,
 
   /**
    * Provide an optional function to be called when clicked

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -338,11 +338,11 @@ div:has(.#{$prefix}--header)
 
 .#{$prefix}--side-nav__toggle-container {
   position: absolute;
-  bottom: 0;
-  width: 100%;
   background: $background;
+  inline-size: 100%;
+  inset-block-end: 0;
 
   .#{$prefix}--side-nav__toggle.#{$prefix}--side-nav__toggle--collapsed:hover {
     background: $background-hover;
-  }  
+  }
 }

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -335,3 +335,14 @@ div:has(.#{$prefix}--header)
     overflow: visible;
   }
 }
+
+.#{$prefix}--side-nav__toggle-container {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background: $background;
+
+  .#{$prefix}--side-nav__toggle.#{$prefix}--side-nav__toggle--collapsed:hover {
+    background: $background-hover;
+  }  
+}


### PR DESCRIPTION
Closes #496 

This PR ensures that the toggle button when the side nav panel is collapsed doesn't disappear when the screen height gets smaller.

This is mostly for a visual fix for mouse interaction -- using the keyboard to tab still has a weird behavior. The whole reason this is happening is because of the `overflow` css property that is being applied to the side nav contents. If we remove the values that are currently being applied when the menu is collapsed, **the tooltip/flyout menu will not appear**, as they are considered "overflow" and thus hidden away. To fix this behavior, we would need to refactor most of the menu and also the aforementioned components. For now, this visual fix is a basic compromise to be done.

#### Changelog

**New**

- wrapper div for the toggle button only to ensure black background upon hover

#### Testing / Reviewing
Go to the side nav panel story, and resize the screen height. The toggle button should still appear at the bottom left of the screen no matter what.
