### PR TITLE
fix(UIShell): resolve storybook z-index issue

### DIFF
--- a/packages/react/src/components/WhatsNew/components/whats-new.scss
+++ b/packages/react/src/components/WhatsNew/components/whats-new.scss
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@use '@carbon/react';
 @use '@carbon/react/scss/zone';
 @use '@carbon/styles/scss/themes';
 @use '@carbon/react/scss/theme' as *;


### PR DESCRIPTION
Closes #510 

This PR fixes the issue where the styles were duplicated throughout all components, meaning that new 'state' styles were overridden by their default styles. This duplication was caused in the latest `WhatsNew` component, where it includes `use @carbon/react;` in the component styles. This makes Storybook grab all the styles from the package and reimport them, essentially.

#### Changelog

**Removed**

- nonessential `@carbon/react` style import

#### Testing / Reviewing
Since this would only change prod Storybook due to the way styles are bundled with Webpack, we can't test if this fixes the issue. 

However, since this change concerns the new What's New component, testing this PR would just be to ensure there are no unexpected changes after doing this change. 
