### PR TITLE
fix: duplicate style import storybook bug

### DIFF
--- a/packages/react/src/components/Processing/components/processing.scss
+++ b/packages/react/src/components/Processing/components/processing.scss
@@ -9,7 +9,6 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/components/button' as *;
 
 $prefix: 'clabs--processing' !default;
 


### PR DESCRIPTION
#490  was merged in before the issue here could be fixed https://github.com/carbon-design-system/carbon-labs/pull/490#pullrequestreview-2718182247

### Testing
Check that the UI Shell and Processing components both render correctly with this import removed. 