### PR TITLE
fix(processing): remove button import + fix storybook style

### DIFF
--- a/packages/react/src/components/Processing/__tests__/__snapshots__/Processing.test.js.snap
+++ b/packages/react/src/components/Processing/__tests__/__snapshots__/Processing.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Processing renders as expected - Component API should match snapshot 1`] = `
 <div>
   <div
-    class="clabs--processing__linear"
+    class="clabs--processing clabs--processing__linear"
   >
     <svg
       class="clabs--processing__dots"

--- a/packages/react/src/components/Processing/components/Processing.tsx
+++ b/packages/react/src/components/Processing/components/Processing.tsx
@@ -32,7 +32,7 @@ const Processing: React.FC<ProcessingProps> = ({
   };
 
   return (
-    <div className={`${blockClass}__${getAnimationEffect()}`}>
+    <div className={`${blockClass} ${blockClass}__${getAnimationEffect()}`}>
       <svg className={`${blockClass}__dots`} viewBox="0 0 32 32">
         <circle
           className={`${blockClass}__dot ${blockClass}__dot--left`}

--- a/packages/react/src/components/Processing/components/processing.scss
+++ b/packages/react/src/components/Processing/components/processing.scss
@@ -9,11 +9,10 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/components/button' as *;
 
 $prefix: 'clabs--processing' !default;
 
-#storybook-root {
+#storybook-root:has(.#{$prefix}) {
   display: grid;
   block-size: calc(100vh - 32px);
   place-items: center;


### PR DESCRIPTION
#490 was merged in before the issue here could be fixed 


#### Changelog

**New**

- N/A

**Changed**

- Removed unused button import from `processing.scss`
- Fixed center display of processing element in storybook for only processing component

**Removed**

- N/A

#### Testing / Reviewing

- Local host / preview
