### PR TITLE
feat(animated-header): add custom itemToString func for Dropdowns

### DIFF
--- a/examples/react/AnimatedHeader/src/App.tsx
+++ b/examples/react/AnimatedHeader/src/App.tsx
@@ -29,11 +29,21 @@ function App() {
     setSelectedTile(e.selectedItem.id);
   };
 
+  const handleHeaderItems = (item: any) => {
+    return item ? item.label : '';
+  };
+
+  const handleWorkspaceItems = (item: any) => {
+    return item ? item.label : '';
+  };
+
   return (
     <AnimatedHeader
       allTiles={tiles}
       allWorkspaces={workspaces}
       description="Connect, monitor, and manage data."
+      handleHeaderItemsToString={handleHeaderItems}
+      handleWorkspaceItemsToString={handleWorkspaceItems}
       headerAnimation={watsonXAnimatedLight}
       headerStatic={watsonXStaticLight}
       productName="[Product name]"

--- a/examples/react/AnimatedHeader/src/data/index.jsx
+++ b/examples/react/AnimatedHeader/src/data/index.jsx
@@ -13,22 +13,22 @@ import { ButtonKinds } from '@carbon/react';
 export const workspaceData = [
   {
     id: 'workspace-1',
-    text: 'Workspace 1',
+    label: 'Workspace 1',
   },
   {
     id: 'workspace-2',
-    text: 'Workspace 2',
+    label: 'Workspace 2',
   },
   {
     id: 'workspace-3',
-    text: 'Workspace 3',
+    label: 'Workspace 3',
   },
 ];
 
 export const headerTiles = [
   {
     id: 1,
-    name: 'AI Chat Tile w/ two glass tiles',
+    label: 'AI Chat Tile w/ two glass tiles',
     tiles: [
       {
         id: 'ai-tile',
@@ -54,7 +54,7 @@ export const headerTiles = [
   },
   {
     id: 2,
-    name: 'Three glass tiles',
+    label: 'Three glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -81,7 +81,7 @@ export const headerTiles = [
   },
   {
     id: 3,
-    name: 'Four glass tiles',
+    label: 'Four glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -115,7 +115,7 @@ export const headerTiles = [
   },
   {
     id: 4,
-    name: 'Five glass tiles',
+    label: 'Five glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -156,7 +156,7 @@ export const headerTiles = [
   },
   {
     id: 5,
-    name: 'Six glass tiles',
+    label: 'Six glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -204,7 +204,7 @@ export const headerTiles = [
   },
   {
     id: 6,
-    name: 'Seven glass tiles',
+    label: 'Seven glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -259,7 +259,7 @@ export const headerTiles = [
   },
   {
     id: 7,
-    name: 'Eight glass tiles',
+    label: 'Eight glass tiles',
     tiles: [
       {
         id: 'tile-1',

--- a/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.mdx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.mdx
@@ -138,6 +138,8 @@ Example of Animated Header with all prop types enabled.
   allTiles={tiles}
   allWorkspaces={workspaces}
   description="Connect, monitor, and manage data."
+  handleHeaderItemsToString={handleHeaderItems}
+  handleWorkspaceItemsToString={handleWorkspaceItems}
   headerAnimation={watsonXAnimatedLight}
   headerStatic={watsonXStaticLight}
   productName="[Product name]"

--- a/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
@@ -61,6 +61,14 @@ const sharedArgTypes = {
     description:
       'Provide short sentence in max. 3 lines related to product context',
   },
+  handleHeaderItemsToString: {
+    description:
+      'Helper function passed to downshift that allows the library to render a given item to a string label. By default, it extracts the `label` field from a given item to serve as the item label in the list. (Dropdown under description in header).',
+  },
+  handleWorkspaceItemsToString: {
+    description:
+      'Helper function passed to downshift that allows the library to render a given item to a string label. By default, it extracts the `label` field from a given item to serve as the item label in the list. (Dropdown related to workspace selection).',
+  },
   headerAnimation: {
     description:
       'In-product imagery / lottie animation (.json) dim. 1312 x 738 **To update headerAnimation content storybook requires remount in toolbar**',
@@ -201,11 +209,21 @@ export const ThemeG10 = (args) => {
     updateArgs({ ...args, selectedTileGroup: e.selectedItem.id });
   };
 
+  const handleHeaderItems = (item) => {
+    return item ? item.label : '';
+  };
+
+  const handleWorkspaceItems = (item) => {
+    return item ? item.label : '';
+  };
+
   return (
     <AnimatedHeader
       {...args}
-      setSelectedWorkspace={(e) => handleWorkspaceSelect(e)}
-      setSelectedTileGroup={(e) => handleTileGroup(e)}></AnimatedHeader>
+      setSelectedWorkspace={handleWorkspaceSelect}
+      setSelectedTileGroup={handleTileGroup}
+      handleHeaderItemsToString={handleHeaderItems}
+      handleWorkspaceItemsToString={handleWorkspaceItems}></AnimatedHeader>
   );
 };
 
@@ -229,11 +247,21 @@ export const ThemeG100 = (args) => {
     updateArgs({ ...args, selectedTileGroup: e.selectedItem.id });
   };
 
+  const handleHeaderItems = (item) => {
+    return item ? item.label : '';
+  };
+
+  const handleWorkspaceItems = (item) => {
+    return item ? item.label : '';
+  };
+
   return (
     <AnimatedHeader
       {...args}
-      setSelectedWorkspace={(e) => handleWorkspaceSelect(e)}
-      setSelectedTileGroup={(e) => handleTileGroup(e)}></AnimatedHeader>
+      setSelectedWorkspace={handleWorkspaceSelect}
+      setSelectedTileGroup={handleTileGroup}
+      handleHeaderItemsToString={handleHeaderItems}
+      handleWorkspaceItemsToString={handleWorkspaceItems}></AnimatedHeader>
   );
 };
 

--- a/packages/react/src/components/AnimatedHeader/__stories__/data/index.jsx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/data/index.jsx
@@ -13,22 +13,22 @@ import { ButtonKinds } from '@carbon/react';
 export const workspaceData = [
   {
     id: 'workspace-1',
-    text: 'Workspace 1',
+    label: 'Workspace 1',
   },
   {
     id: 'workspace-2',
-    text: 'Workspace 2',
+    label: 'Workspace 2',
   },
   {
     id: 'workspace-3',
-    text: 'Workspace 3',
+    label: 'Workspace 3',
   },
 ];
 
 export const headerTiles = [
   {
     id: 1,
-    name: 'AI Chat Tile w/ two glass tiles',
+    label: 'AI Chat Tile w/ two glass tiles',
     tiles: [
       {
         id: 'ai-tile',
@@ -54,7 +54,7 @@ export const headerTiles = [
   },
   {
     id: 2,
-    name: 'Three glass tiles',
+    label: 'Three glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -81,7 +81,7 @@ export const headerTiles = [
   },
   {
     id: 3,
-    name: 'Four glass tiles',
+    label: 'Four glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -115,7 +115,7 @@ export const headerTiles = [
   },
   {
     id: 4,
-    name: 'Five glass tiles',
+    label: 'Five glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -156,7 +156,7 @@ export const headerTiles = [
   },
   {
     id: 5,
-    name: 'Six glass tiles',
+    label: 'Six glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -204,7 +204,7 @@ export const headerTiles = [
   },
   {
     id: 6,
-    name: 'Seven glass tiles',
+    label: 'Seven glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -259,7 +259,7 @@ export const headerTiles = [
   },
   {
     id: 7,
-    name: 'Eight glass tiles',
+    label: 'Eight glass tiles',
     tiles: [
       {
         id: 'tile-1',

--- a/packages/react/src/components/AnimatedHeader/__tests__/AnimatedHeader-test.tsx
+++ b/packages/react/src/components/AnimatedHeader/__tests__/AnimatedHeader-test.tsx
@@ -33,6 +33,8 @@ describe('AnimatedHeader', () => {
           allTiles={headerTiles}
           allWorkspaces={workspaceData}
           description="Connect, monitor, and manage data."
+          handleHeaderItemsToString={() => ''}
+          handleWorkspaceItemsToString={() => ''}
           productName="[Product name]"
           selectedTileGroup={headerTiles[0]}
           selectedWorkspace={workspaceData[0]}

--- a/packages/react/src/components/AnimatedHeader/__tests__/__snapshots__/AnimatedHeader-test.tsx.snap
+++ b/packages/react/src/components/AnimatedHeader/__tests__/__snapshots__/AnimatedHeader-test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AnimatedHeader renders as expected - Component API should match snapshot 1`] = `
 <div>
   <section
-    class="clabs--animated-header false"
+    class="clabs--animated-header"
   >
     <div
       class="cds--css-grid"
@@ -357,7 +357,7 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
                     class="cds--tooltip-trigger__wrapper"
                   >
                     <button
-                      aria-labelledby="tooltip-:rd:"
+                      aria-labelledby="tooltip-:re:"
                       class="cds--btn--icon-only clabs--animated-header__ai-prompt-tile--icon-button  cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--disabled"
                       disabled=""
                       type="button"
@@ -381,7 +381,7 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
                   <span
                     aria-hidden="true"
                     class="cds--popover"
-                    id="tooltip-:rd:"
+                    id="tooltip-:re:"
                     role="tooltip"
                   >
                     <span

--- a/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
@@ -67,8 +67,8 @@ export interface AnimatedHeaderProps {
   allTiles: TileGroup[];
   allWorkspaces?: SelectedWorkspace[];
   description?: string;
-  handleHeaderItemsToString: (item) => string;
-  handleWorkspaceItemsToString: (item) => string;
+  handleHeaderItemsToString: (item: TileGroup | null) => string;
+  handleWorkspaceItemsToString: (item: SelectedWorkspace | null) => string;
   headerAnimation?: object;
   headerStatic?: React.JSX.Element;
   productName?: string;

--- a/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
@@ -45,7 +45,7 @@ export interface TasksConfig {
 
 export interface SelectedWorkspace {
   id: string;
-  text: string;
+  label: string;
 }
 
 export interface Tile {
@@ -59,7 +59,7 @@ export interface Tile {
 
 export interface TileGroup {
   id: number;
-  name: string;
+  label: string;
   tiles: Tile[];
 }
 
@@ -67,6 +67,8 @@ export interface AnimatedHeaderProps {
   allTiles: TileGroup[];
   allWorkspaces?: SelectedWorkspace[];
   description?: string;
+  handleHeaderItemsToString: (item) => string;
+  handleWorkspaceItemsToString: (item) => string;
   headerAnimation?: object;
   headerStatic?: React.JSX.Element;
   productName?: string;
@@ -84,6 +86,8 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
   allTiles,
   allWorkspaces,
   description,
+  handleHeaderItemsToString,
+  handleWorkspaceItemsToString,
   headerAnimation,
   headerStatic,
   productName = '[Product name]',
@@ -180,10 +184,11 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
       animation?.removeEventListener('DOMLoaded', load);
       animation?.removeEventListener('complete', loop);
     };
-  }, [animationContainer, headerAnimation, isReduced]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [headerAnimation, isReduced]);
 
   return (
-    <section className={`${blockClass} ${!open && collapsed}`}>
+    <section className={`${blockClass}${!open ? ` ${collapsed}` : ''}`}>
       <Grid>
         <div className={`${blockClass}__gradient--overlay`} />
 
@@ -257,11 +262,11 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
                     className={`${blockClass}__header-dropdown`}
                     size="md"
                     titleText="Label"
-                    label={tasksConfig.dropdown?.label || allTiles[0].name}
+                    label={tasksConfig.dropdown?.label || allTiles[0].label}
                     hideLabel
                     type="inline"
                     items={allTiles}
-                    itemToString={(item) => (item ? item.name : '')}
+                    itemToString={(item) => handleHeaderItemsToString(item)}
                     onChange={(e) => setSelectedTileGroup(e)}
                   />
                 </div>
@@ -285,7 +290,7 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
                   hideLabel
                   type="inline"
                   items={allWorkspaces}
-                  itemToString={(item) => (item ? item['text'] : '')}
+                  itemToString={(item) => handleWorkspaceItemsToString(item)}
                   onChange={(e) => setSelectedWorkspace(e)}
                 />
               </div>
@@ -360,6 +365,22 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
    * Provide short sentence in max. 3 lines related to product context
    */
   description: PropTypes.string,
+
+  /**
+   * Helper function passed to downshift that allows the library to render a
+   * given item to a string label. By default, it extracts the `label` field
+   * from a given item to serve as the item label in the list. (Dropdown
+   * under description in header).
+   */
+  handleHeaderItemsToString: PropTypes.func,
+
+  /**
+   * Helper function passed to downshift that allows the library to render a
+   * given item to a string label. By default, it extracts the `label` field
+   * from a given item to serve as the item label in the list. (Dropdown
+   * related to workspace selection).
+   */
+  handleWorkspaceItemsToString: PropTypes.func,
 
   /**
    * In-product imagery / lottie animation (.json) dim. 1312 x 738

--- a/packages/react/src/components/AnimatedHeader/data/index.jsx
+++ b/packages/react/src/components/AnimatedHeader/data/index.jsx
@@ -13,22 +13,22 @@ import { ButtonKinds } from '@carbon/react';
 export const workspaceData = [
   {
     id: 'workspace-1',
-    text: 'Workspace 1',
+    label: 'Workspace 1',
   },
   {
     id: 'workspace-2',
-    text: 'Workspace 2',
+    label: 'Workspace 2',
   },
   {
     id: 'workspace-3',
-    text: 'Workspace 3',
+    label: 'Workspace 3',
   },
 ];
 
 export const headerTiles = [
   {
     id: 1,
-    name: 'AI Chat Tile w/ two glass tiles',
+    label: 'AI Chat Tile w/ two glass tiles',
     tiles: [
       {
         id: 'ai-tile',
@@ -54,7 +54,7 @@ export const headerTiles = [
   },
   {
     id: 2,
-    name: 'Three glass tiles',
+    label: 'Three glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -81,7 +81,7 @@ export const headerTiles = [
   },
   {
     id: 3,
-    name: 'Four glass tiles',
+    label: 'Four glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -115,7 +115,7 @@ export const headerTiles = [
   },
   {
     id: 4,
-    name: 'Five glass tiles',
+    label: 'Five glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -156,7 +156,7 @@ export const headerTiles = [
   },
   {
     id: 5,
-    name: 'Six glass tiles',
+    label: 'Six glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -204,7 +204,7 @@ export const headerTiles = [
   },
   {
     id: 6,
-    name: 'Seven glass tiles',
+    label: 'Seven glass tiles',
     tiles: [
       {
         id: 'tile-1',
@@ -259,7 +259,7 @@ export const headerTiles = [
   },
   {
     id: 7,
-    name: 'Eight glass tiles',
+    label: 'Eight glass tiles',
     tiles: [
       {
         id: 'tile-1',


### PR DESCRIPTION
Allows the end user to control custom `itemToString` function

#### Changelog

**New**

- N/A

**Changed**

- Two new props:
- handleHeaderItemsToString: (item) => string;
- handleWorkspaceItemsToString: (item) => string;

**Removed**

- Remove `animationContainer` from useEffect dependency array

#### Testing / Reviewing

localhost / Preview
