### PR TITLE
fix(storybook): remove background button

### DIFF
--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -226,24 +226,7 @@ export const parameters = {
       cellSize: 8,
       opacity: 0.5,
     },
-    values: [
-      {
-        name: 'white',
-        value: white.background,
-      },
-      {
-        name: 'g10',
-        value: g10.background,
-      },
-      {
-        name: 'g90',
-        value: g90.background,
-      },
-      {
-        name: 'g100',
-        value: g100.background,
-      },
-    ],
+    disable: true,
   },
   controls: {
     // https://storybook.js.org/docs/react/essentials/controls#show-full-documentation-for-each-property


### PR DESCRIPTION
Closes #520 

This PR removes the redundant (and malfunctioning) background theme switcher button from Storybook. The paintbrush button is the one that actually does what it's supposed to do.

<img width="301" alt="Image" src="https://github.com/user-attachments/assets/3000bb68-d537-409d-8be9-33ff899c81c1" />

#### Changelog

**Removed**

- removed Storybook background toolbar addon

#### Testing / Reviewing
Button should be gone
