### PR TITLE
chore(generate script): update React and WC generate 

### DIFF
--- a/packages/react/tasks/generate/templates/README.md
+++ b/packages/react/tasks/generate/templates/README.md
@@ -16,7 +16,8 @@ Install `@carbon-labs/DISPLAY_NAME` to use this package.
 
 ### Storybook
 
-You can view the current state of the [component](https://labs.carbondesignsystem.com/react/).
+You can view the current state of the
+[component](https://labs.carbondesignsystem.com/react/).
 
 ## 📝 License
 

--- a/packages/react/tasks/generate/templates/README.md
+++ b/packages/react/tasks/generate/templates/README.md
@@ -1,0 +1,31 @@
+<p align="center">
+  <a href="https://www.carbondesignsystem.com">
+    <img alt="Carbon Design System" src="https://user-images.githubusercontent.com/3901764/57545698-ce5f2380-7320-11e9-8682-903df232d7b0.png" width="100%" />
+  </a>
+</p>
+<h1 align="center">
+  Carbon Labs
+</h1>
+
+> A community-driven incubation space enabling rapid prototyping, development,
+> and deployment of Carbon-based components.
+
+## Getting started
+
+### Storybook
+
+You can view the current state of all components in [React](https://labs.carbondesignsystem.com/react/).
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/react/tasks/generate/templates/README.md
+++ b/packages/react/tasks/generate/templates/README.md
@@ -16,7 +16,7 @@ Install `@carbon-labs/DISPLAY_NAME` to use this package.
 
 ### Storybook
 
-You can view the current state of all components in [React](https://labs.carbondesignsystem.com/react/).
+You can view the current state of the [component](https://labs.carbondesignsystem.com/react/).
 
 ## 📝 License
 

--- a/packages/react/tasks/generate/templates/README.md
+++ b/packages/react/tasks/generate/templates/README.md
@@ -12,6 +12,8 @@
 
 ## Getting started
 
+Install `@carbon-labs/DISPLAY_NAME` to use this package.
+
 ### Storybook
 
 You can view the current state of all components in [React](https://labs.carbondesignsystem.com/react/).

--- a/packages/react/tasks/generate/templates/package-edit.json
+++ b/packages/react/tasks/generate/templates/package-edit.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon-labs/react-STYLE_NAME",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "author": "Your Name <your@email.com>",
   "publishConfig": {
     "access": "public",

--- a/packages/react/tasks/generate/templates/package-edit.json
+++ b/packages/react/tasks/generate/templates/package-edit.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon-labs/react-STYLE_NAME",
   "version": "0.0.0",
-  "author": "Carbon Labs",
+  "author": "Your Name <your@email.com>",
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/react/tasks/generate/templates/package-edit.json
+++ b/packages/react/tasks/generate/templates/package-edit.json
@@ -1,6 +1,7 @@
 {
   "name": "@carbon-labs/react-STYLE_NAME",
   "version": "0.0.0",
+  "author": "Carbon Labs",
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/web-components/tasks/generate/templates/README.md
+++ b/packages/web-components/tasks/generate/templates/README.md
@@ -16,7 +16,8 @@ Install `@carbon-labs/wc-DISPLAY_NAME` to use this package.
 
 ### Storybook
 
-You can view the current state of the [component](https://labs.carbondesignsystem.com/web-components/).
+You can view the current state of the
+[component](https://labs.carbondesignsystem.com/web-components/).
 
 ## 📝 License
 

--- a/packages/web-components/tasks/generate/templates/README.md
+++ b/packages/web-components/tasks/generate/templates/README.md
@@ -16,7 +16,7 @@ Install `@carbon-labs/wc-DISPLAY_NAME` to use this package.
 
 ### Storybook
 
-You can view the current state of all components in [Web Components](https://labs.carbondesignsystem.com/web-components/).
+You can view the current state of the [component](https://labs.carbondesignsystem.com/web-components/).
 
 ## 📝 License
 

--- a/packages/web-components/tasks/generate/templates/README.md
+++ b/packages/web-components/tasks/generate/templates/README.md
@@ -1,0 +1,31 @@
+<p align="center">
+  <a href="https://www.carbondesignsystem.com">
+    <img alt="Carbon Design System" src="https://user-images.githubusercontent.com/3901764/57545698-ce5f2380-7320-11e9-8682-903df232d7b0.png" width="100%" />
+  </a>
+</p>
+<h1 align="center">
+  Carbon Labs
+</h1>
+
+> A community-driven incubation space enabling rapid prototyping, development,
+> and deployment of Carbon-based components.
+
+## Getting started
+
+### Storybook
+
+You can view the current state of all components in [React](https://labs.carbondesignsystem.com/react/).
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/web-components/tasks/generate/templates/README.md
+++ b/packages/web-components/tasks/generate/templates/README.md
@@ -12,9 +12,11 @@
 
 ## Getting started
 
+Install `@carbon-labs/wc-DISPLAY_NAME` to use this package.
+
 ### Storybook
 
-You can view the current state of all components in [React](https://labs.carbondesignsystem.com/react/).
+You can view the current state of all components in [Web Components](https://labs.carbondesignsystem.com/web-components/).
 
 ## 📝 License
 

--- a/packages/web-components/tasks/generate/templates/package-edit.json
+++ b/packages/web-components/tasks/generate/templates/package-edit.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon-labs/wc-DISPLAY_NAME",
-  "version": "0.4.0",
+  "version": "0.0.0",
   "author": "Your Name <your@email.com>",
   "publishConfig": {
     "access": "public",

--- a/packages/web-components/tasks/generate/templates/package-edit.json
+++ b/packages/web-components/tasks/generate/templates/package-edit.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon-labs/wc-DISPLAY_NAME",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "author": "Your Name <your@email.com>",
   "publishConfig": {
     "access": "public",

--- a/packages/web-components/tasks/generate/templates/package-edit.json
+++ b/packages/web-components/tasks/generate/templates/package-edit.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon-labs/wc-DISPLAY_NAME",
   "version": "0.4.0",
-  "author": "Carbon Labs",
+  "author": "Your Name <your@email.com>",
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/web-components/tasks/generate/templates/package-edit.json
+++ b/packages/web-components/tasks/generate/templates/package-edit.json
@@ -1,6 +1,7 @@
 {
   "name": "@carbon-labs/wc-DISPLAY_NAME",
   "version": "0.4.0",
+  "author": "Carbon Labs",
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
Closes #489

Update default templates from generate script within `@carbon/labs`

#### Changelog

**New**

- Updated `package-edit.json` in both `React` and `Web components` to include `author` option.
- Added `README.md` with basic content in `React` and `Web components` templates.

#### Testing / Reviewing

Run `yarn generate` from `packages/react` or `packages/web-components`
