### PR TITLE
fix(UIShell): remove box-shadow on header action focus

### DIFF
--- a/packages/react/src/components/UIShell/components/styles/_header.scss
+++ b/packages/react/src/components/UIShell/components/styles/_header.scss
@@ -22,6 +22,7 @@ $prefix: 'cds' !default;
 
 .#{$prefix}--header__action:focus {
   border-width: 2px;
+  box-shadow: none;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #551

This PR removes the box shadow on header global actions so that the focus state is no longer doubled

#### Changelog

**Removed**

- header global action box shadow

#### Testing / Reviewing

confirm the component focus state looks correct
