### PR TITLE
chore: instrument packages with telemetry

### DIFF
--- a/packages/react/src/components/AnimatedHeader/README.md
+++ b/packages/react/src/components/AnimatedHeader/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/react-animated-header
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/react/src/components/AnimatedHeader/package.json
+++ b/packages/react/src/components/AnimatedHeader/package.json
@@ -19,13 +19,17 @@
     "es",
     "lib",
     "scss",
-    "assets"
+    "assets",
+    "telemetry.yml"
   ],
   "scripts": {
     "build": "node ../../../tasks/build.js",
-    "clean": "rm -rf {es,lib,scss}"
+    "clean": "rm -rf {es,lib,scss}",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 40597fb8-d0ed-45fb-a95a-5b1751e22c36 --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "dependencies": {
+    "@ibm/telemetry-js": "^1.9.1",
     "jest-canvas-mock": "^2.5.2",
     "lottie-web": "^5.12.2"
   },

--- a/packages/react/src/components/AnimatedHeader/telemetry.yml
+++ b/packages/react/src/components/AnimatedHeader/telemetry.yml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: 40597fb8-d0ed-45fb-a95a-5b1751e22c36
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # General
+        - href
+        - id
+        - mainIcon
+        - open
+        - productName
+        - secondaryIcon
+        - subtitle
+        - title
+        # Animated Header
+        - allTiles
+        - allWorkspaces
+        - className
+        - description
+        - handleHeaderItemsToString
+        - handleWorkspaceItemsToString
+        - headerAnimation
+        - headerStatic
+        - selectedTileGroup
+        - selectedWorkspace
+        - setSelectedTileGroup
+        - setSelectedWorkspace
+        - tasksConfig
+        - userName
+        - welcomeText
+        - workspaceLabel
+        # React
+        - key
+        - ref
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/react/src/components/MDXComponents/README.md
+++ b/packages/react/src/components/MDXComponents/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/mdx-components
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/react/src/components/Processing/README.md
+++ b/packages/react/src/components/Processing/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/react-processing
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/react/src/components/Processing/package.json
+++ b/packages/react/src/components/Processing/package.json
@@ -18,13 +18,19 @@
   "files": [
     "es",
     "lib",
-    "scss"
+    "scss",
+    "telemetry.yml"
   ],
   "scripts": {
     "build": "node ../../../tasks/build.js",
-    "clean": "rm -rf {es,lib,scss}"
+    "clean": "rm -rf {es,lib,scss}",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 399aab88-efa6-421f-91f7-0be428e0b6c2 --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "devDependencies": {
     "@carbon-labs/utilities": "canary"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.9.1"
   }
 }

--- a/packages/react/src/components/Processing/telemetry.yml
+++ b/packages/react/src/components/Processing/telemetry.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: 399aab88-efa6-421f-91f7-0be428e0b6c2
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # Processing
+        - loop
+        # React
+        - key
+        - ref
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/react/src/components/TextHighlighter/README.md
+++ b/packages/react/src/components/TextHighlighter/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/react-text-highlighter
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/react/src/components/TextHighlighter/package.json
+++ b/packages/react/src/components/TextHighlighter/package.json
@@ -18,13 +18,19 @@
   "files": [
     "es",
     "lib",
-    "scss"
+    "scss",
+    "telemetry.yml"
   ],
   "scripts": {
     "build": "node ../../../tasks/build.js",
-    "clean": "rm -rf {es,lib,scss}"
+    "clean": "rm -rf {es,lib,scss}",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 18a7a4e1-d21d-4d71-9dce-20587f4abd2e --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "devDependencies": {
     "@carbon-labs/utilities": "canary"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.9.1"
   }
 }

--- a/packages/react/src/components/TextHighlighter/telemetry.yml
+++ b/packages/react/src/components/TextHighlighter/telemetry.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: 18a7a4e1-d21d-4d71-9dce-20587f4abd2e
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # TextHighlighter
+        - children
+        - kind
+        - reference
+        - type
+        # React
+        - key
+        - ref
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/react/src/components/ThemeSettings/README.md
+++ b/packages/react/src/components/ThemeSettings/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/react-theme-settings
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/react/src/components/ThemeSettings/package.json
+++ b/packages/react/src/components/ThemeSettings/package.json
@@ -18,13 +18,19 @@
   "files": [
     "es",
     "lib",
-    "scss"
+    "scss",
+    "telemetry.yml"
   ],
   "scripts": {
     "build": "node ../../../tasks/build.js",
-    "clean": "rm -rf {es,lib,scss}"
+    "clean": "rm -rf {es,lib,scss}",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 34d6803f-45c0-46e0-be02-b4499b40336e --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "devDependencies": {
     "@carbon-labs/utilities": "canary"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.9.1"
   }
 }

--- a/packages/react/src/components/ThemeSettings/telemetry.yml
+++ b/packages/react/src/components/ThemeSettings/telemetry.yml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: 34d6803f-45c0-46e0-be02-b4499b40336e
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # General
+        - className
+        - id
+        - legendText
+        - onChange
+        - value
+        # ThemeMenuComplement
+        - checked
+        - labelText
+        # ThemeSetDropdown
+        - label
+        - titleText
+        # ThemeSettings
+        - children
+        # ThemeSwitcher
+        - labelDark
+        - labelLight
+        - labelSystem
+        # React
+        - key
+        - ref
+      allowedAttributeStringValues:
+        # General - value
+        - dark
+        - g10/g100
+        - g10/g90
+        - light
+        - system
+        - white/g100
+        - white/g90
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/react/src/components/UIShell/telemetry.yml
+++ b/packages/react/src/components/UIShell/telemetry.yml
@@ -7,29 +7,104 @@ collect:
   jsx:
     elements:
       allowedAttributeNames:
-        # SideNav
+        # General
         - addFocusListeners
-        - addMouseListeners
+        - align
+        - as
+        - autoAlign
+        - children
         - className
         - defaultExpanded
+        - defaultOpen
+        - element
         - enterDelayMs
         - expanded
         - href
+        - isActive
+        - isSideNavExpanded
+        - label
+        - large
+        - leaveDelayMs
+        - renderIcon
+        - selected
+        - tabIndex
+        - title
+        # HeaderContainer
+        - isSwitcherExpanded
+        - render
+        # HeaderPanel
+        - onHeaderPanelFocus
+        # HeaderPopover
+        - alignmentAxisOffset
+        # SharkFinIcon
+        - small
+        # SideNav
+        - addMouseListeners
+        - hideOverlay
         - inert
         - isChildOfHeader
         - isCollapsible
         - isFixedNav
         - isPersistent
         - isRail
+        - isTreeview
+        - navType
         - onOverlayClick
         - onSideNavBlur
         - onToggle
+        - translateWithId
+        # SideNavFlyoutMenu
+        - description
+        - dropShadow
+        - highContrast
+        - menuContent
+        # SideNavItems
+        - accessibilityLabel
+        # SideNavLink
+        - aria-label
+        - aria-labelledby
+        # SideNavLinkPopover
+        - closeOnActivation
+        - disabled
+        - isSelected
+        - size
+        - wrapperClasses
+        # SideNavMenu
+        - depth
+        - onMenuToggle
+        # SideNavMenuItem
+        - isFlyoutMenuItem
+        # SideNavToggle
+        - onClick
         # React
         - key
         - ref
       allowedAttributeStringValues:
-        - 'true'
-        - 'false'
+        # General - align
+        - bottom
+        - bottom-end
+        - bottom-left
+        - bottom-right
+        - bottom-start
+        - left
+        - left-bottom
+        - left-end
+        - left-start
+        - left-top
+        - right
+        - right-bottom
+        - right-end
+        - right-start
+        - right-top
+        - top
+        - top-end
+        - top-left
+        - top-right
+        - top-start
+        # SideNavLinkPopover - size
+        - lg
+        - md
+        - sm
   npm:
     dependencies: null
   js:

--- a/packages/react/src/components/WhatsNew/README.md
+++ b/packages/react/src/components/WhatsNew/README.md
@@ -139,9 +139,6 @@ See the latest updates and version history in the
 Licensed under the
 [Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
 
-<!-- Uncomment when telemetry added -->
-
-<!--
 ## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
 
 This package uses IBM Telemetry to collect de-identified and anonymized metrics
@@ -149,4 +146,4 @@ data. By installing this package as a dependency you are agreeing to telemetry
 collection. To opt out, see
 [Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
 For more information on the data being collected, please see the
-[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics). -->
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/react/src/components/WhatsNew/package.json
+++ b/packages/react/src/components/WhatsNew/package.json
@@ -18,11 +18,14 @@
   "files": [
     "es",
     "lib",
-    "scss"
+    "scss",
+    "telemetry.yml"
   ],
   "scripts": {
     "build": "node ../../../tasks/build.js",
-    "clean": "rm -rf {es,lib,scss}"
+    "clean": "rm -rf {es,lib,scss}",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 1e5a49a0-1bc8-4547-8a7c-4b96e1842ead --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "devDependencies": {
     "@carbon-labs/utilities": "canary",
@@ -30,5 +33,8 @@
   },
   "peerDependencies": {
     "@carbon/ibm-products": "^2.49.0"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.9.1"
   }
 }

--- a/packages/react/src/components/WhatsNew/telemetry.yml
+++ b/packages/react/src/components/WhatsNew/telemetry.yml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: 1e5a49a0-1bc8-4547-8a7c-4b96e1842ead
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # General
+        - children
+        - className
+        - index
+        #
+        - rootMargin
+        - threshold
+        # Bubble
+        - align
+        - dropShadow
+        - highContrast
+        - open
+        - target
+        # TocItem
+        - isActive
+        # TocSection
+        - as
+        # View
+        - title
+        # ViewStack
+        - ariaLabel
+        - onViewChangeEnd
+        - onViewChangeStart
+        - role
+        - viewAssistiveTranslator
+        # React
+        - key
+        - ref
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/web-components/src/components/chat/README.md
+++ b/packages/web-components/src/components/chat/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/ai-chat
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/web-components/src/components/chat/package.json
+++ b/packages/web-components/src/components/chat/package.json
@@ -39,7 +39,7 @@
     "@babel/runtime": "^7.23.2",
     "@carbon-labs/utilities": "0.15.0",
     "@carbon/web-components": "2.21.0",
-    "@ibm/telemetry-js": "^1.6.0",
+    "@ibm/telemetry-js": "^1.9.1",
     "highlightjs": "^9.16.2",
     "mathjax": "^3.2.2",
     "mermaid": "^11.2.1",

--- a/packages/web-components/src/components/feedback/README.md
+++ b/packages/web-components/src/components/feedback/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/ai-feedback
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/web-components/src/components/feedback/package.json
+++ b/packages/web-components/src/components/feedback/package.json
@@ -24,14 +24,16 @@
   },
   "files": [
     "es/**/*",
-    "custom-elements.json"
+    "custom-elements.json",
+    "telemetry.yml"
   ],
   "types": "./src/index.d.ts",
   "customElements": "custom-elements.json",
   "scripts": {
     "build": "gulp build --option feedback",
     "build:dist": "rm -rf dist && rollup --config ../../../tasks/build-dist.js",
-    "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary"
+    "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
     "@babel/core": "^7.26.0",
@@ -39,6 +41,7 @@
     "@carbon-labs/utilities": "0.15.0",
     "@carbon/grid": "^11.21.0",
     "@carbon/web-components": "2.21.0",
+    "@ibm/telemetry-js": "^1.9.1",
     "uuid": "^9.0.1"
   }
 }

--- a/packages/web-components/src/components/feedback/telemetry.yml
+++ b/packages/web-components/src/components/feedback/telemetry.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
 version: 1
-projectId: 7fbf7425-cf43-4071-a260-d681aade7109
+projectId: ef54ec81-9b57-4759-b8aa-773e3be8b6bd
 endpoint: 'https://www-api.ibm.com/ibm-telemetry/v1/metrics'
 collect:
   npm:

--- a/packages/web-components/src/components/network-graph/README.md
+++ b/packages/web-components/src/components/network-graph/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/network-graph
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/web-components/src/components/network-graph/package.json
+++ b/packages/web-components/src/components/network-graph/package.json
@@ -23,14 +23,16 @@
   },
   "files": [
     "es/**/*",
-    "custom-elements.json"
+    "custom-elements.json",
+    "telemetry.yml"
   ],
   "types": "./src/index.d.ts",
   "customElements": "custom-elements.json",
   "scripts": {
     "build": "gulp build --option network-graph",
     "build:dist": "rm -rf dist && rollup --config ../../../tasks/build-dist.js",
-    "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary"
+    "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
     "@babel/core": "^7.26.0",
@@ -38,6 +40,7 @@
     "@carbon-labs/utilities": "0.15.0",
     "@carbon/grid": "^11.21.0",
     "@carbon/web-components": "2.21.0",
+    "@ibm/telemetry-js": "^1.9.1",
     "force-graph": "^1.43.5"
   }
 }

--- a/packages/web-components/src/components/network-graph/telemetry.yml
+++ b/packages/web-components/src/components/network-graph/telemetry.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
 version: 1
-projectId: 7fbf7425-cf43-4071-a260-d681aade7109
+projectId: 30eb61b1-2474-4246-a5f4-cdee46ddafb0
 endpoint: 'https://www-api.ibm.com/ibm-telemetry/v1/metrics'
 collect:
   npm:

--- a/packages/web-components/src/components/tag/README.md
+++ b/packages/web-components/src/components/tag/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/ai-tag
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/web-components/src/components/tag/package.json
+++ b/packages/web-components/src/components/tag/package.json
@@ -23,20 +23,23 @@
   },
   "files": [
     "es/**/*",
-    "custom-elements.json"
+    "custom-elements.json",
+    "telemetry.yml"
   ],
   "types": "./src/index.d.ts",
   "customElements": "custom-elements.json",
   "scripts": {
     "build": "gulp build --option tag",
     "build:dist": "rm -rf dist && rollup --config ../../../tasks/build-dist.js",
-    "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary"
+    "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
     "@babel/core": "^7.26.0",
     "@babel/runtime": "^7.23.2",
     "@carbon-labs/utilities": "0.8.0",
     "@carbon/grid": "^11.21.0",
-    "@carbon/web-components": "2.21.0"
+    "@carbon/web-components": "2.21.0",
+    "@ibm/telemetry-js": "^1.9.1"
   }
 }

--- a/packages/web-components/src/components/tag/telemetry.yml
+++ b/packages/web-components/src/components/tag/telemetry.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
 version: 1
-projectId: 7fbf7425-cf43-4071-a260-d681aade7109
+projectId: 99a48c00-fd34-4267-80a4-935d08af5880
 endpoint: 'https://www-api.ibm.com/ibm-telemetry/v1/metrics'
 collect:
   npm:

--- a/packages/web-components/src/components/ux-control/README.md
+++ b/packages/web-components/src/components/ux-control/README.md
@@ -1,0 +1,15 @@
+# @carbon-labs/ai-ux-control
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/web-components/src/components/ux-control/package.json
+++ b/packages/web-components/src/components/ux-control/package.json
@@ -24,20 +24,23 @@
   },
   "files": [
     "es/**/*",
-    "custom-elements.json"
+    "custom-elements.json",
+    "telemetry.yml"
   ],
   "types": "./src/index.d.ts",
   "customElements": "custom-elements.json",
   "scripts": {
     "build": "gulp build --option ux-control",
     "build:dist": "rm -rf dist && rollup --config ../../../tasks/build-dist.js",
-    "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary"
+    "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
     "@babel/core": "^7.26.0",
     "@babel/runtime": "^7.23.2",
     "@carbon-labs/utilities": "0.8.0",
     "@carbon/grid": "^11.21.0",
-    "@carbon/web-components": "2.21.0"
+    "@carbon/web-components": "2.21.0",
+    "@ibm/telemetry-js": "^1.9.1"
   }
 }

--- a/packages/web-components/src/components/ux-control/telemetry.yml
+++ b/packages/web-components/src/components/ux-control/telemetry.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
 version: 1
-projectId: 7fbf7425-cf43-4071-a260-d681aade7109
+projectId: c32b4a2b-352b-4dfa-9250-d91aed78e7f3
 endpoint: 'https://www-api.ibm.com/ibm-telemetry/v1/metrics'
 collect:
   npm:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,7 +2520,7 @@ __metadata:
     "@babel/runtime": "npm:^7.23.2"
     "@carbon-labs/utilities": "npm:0.15.0"
     "@carbon/web-components": "npm:2.21.0"
-    "@ibm/telemetry-js": "npm:^1.6.0"
+    "@ibm/telemetry-js": "npm:^1.9.1"
     "@types/highlightjs": "npm:^9"
     highlightjs: "npm:^9.16.2"
     mathjax: "npm:^3.2.2"
@@ -2541,6 +2541,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.15.0"
     "@carbon/grid": "npm:^11.21.0"
     "@carbon/web-components": "npm:2.21.0"
+    "@ibm/telemetry-js": "npm:^1.9.1"
     uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
@@ -2554,6 +2555,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.8.0"
     "@carbon/grid": "npm:^11.21.0"
     "@carbon/web-components": "npm:2.21.0"
+    "@ibm/telemetry-js": "npm:^1.9.1"
   languageName: unknown
   linkType: soft
 
@@ -2566,6 +2568,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.8.0"
     "@carbon/grid": "npm:^11.21.0"
     "@carbon/web-components": "npm:2.21.0"
+    "@ibm/telemetry-js": "npm:^1.9.1"
   languageName: unknown
   linkType: soft
 
@@ -2589,6 +2592,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.15.0"
     "@carbon/grid": "npm:^11.21.0"
     "@carbon/web-components": "npm:2.21.0"
+    "@ibm/telemetry-js": "npm:^1.9.1"
     force-graph: "npm:^1.43.5"
   languageName: unknown
   linkType: soft
@@ -2598,6 +2602,7 @@ __metadata:
   resolution: "@carbon-labs/react-animated-header@workspace:packages/react/src/components/AnimatedHeader"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
+    "@ibm/telemetry-js": "npm:^1.9.1"
     jest-canvas-mock: "npm:^2.5.2"
     lottie-web: "npm:^5.12.2"
   languageName: unknown
@@ -2616,6 +2621,7 @@ __metadata:
   resolution: "@carbon-labs/react-processing@workspace:packages/react/src/components/Processing"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
+    "@ibm/telemetry-js": "npm:^1.9.1"
   languageName: unknown
   linkType: soft
 
@@ -2624,6 +2630,7 @@ __metadata:
   resolution: "@carbon-labs/react-text-highlighter@workspace:packages/react/src/components/TextHighlighter"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
+    "@ibm/telemetry-js": "npm:^1.9.1"
   languageName: unknown
   linkType: soft
 
@@ -2632,6 +2639,7 @@ __metadata:
   resolution: "@carbon-labs/react-theme-settings@workspace:packages/react/src/components/ThemeSettings"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
+    "@ibm/telemetry-js": "npm:^1.9.1"
   languageName: unknown
   linkType: soft
 
@@ -2650,6 +2658,7 @@ __metadata:
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
     "@carbon/ibm-products": "npm:^2.49.0"
+    "@ibm/telemetry-js": "npm:^1.9.1"
   peerDependencies:
     "@carbon/ibm-products": ^2.49.0
   languageName: unknown
@@ -4374,7 +4383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/telemetry-js@npm:^1.5.0, @ibm/telemetry-js@npm:^1.6.0":
+"@ibm/telemetry-js@npm:^1.5.0":
   version: 1.6.0
   resolution: "@ibm/telemetry-js@npm:1.6.0"
   bin:


### PR DESCRIPTION
This PR instruments all remaining packages with IBM Telemetry. For each package:

#### Changelog

**New**

- Installs the `@ibm/telemetry-js` dependency
- Adds `README.md` to include the telemetry notice
- `telemetry.yml` configuration files with project ID
- If a React package, a `telemetry:config` script that generates the `telemetry.yml` file with the prop and prop value allowlists
- `package.json` exports the `telemetry.yml` file

**Changed**

- If already instrumented, updated to the latest `@ibm/telemetry-js` version
- Regenerated the UIShell `telemetry.yml` through the `telemetry:config` script as new components have been added with net-new prop and prop values since the last time the config was generated

**Removed**

- N/A

#### Testing / Reviewing

N/A
