### PR TITLE
chore: bump empty state version

### DIFF
--- a/packages/web-components/src/components/empty-state/package.json
+++ b/packages/web-components/src/components/empty-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon-labs/wc-empty-state",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
Fix mismatched version numbers preventing release.
In the follow up PR to empty state WC, the version number in the empty state `package.json` was downgraded to `0.0.1` — likely missed during a conflict since these get bumped in each release.

#### Changelog

**Changed**

- bump empty state package.json back to 0.1.0
