### PR TITLE
fix(animated-header): add backup for autoprefixer

### DIFF
--- a/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/animated-header.scss
+++ b/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/animated-header.scss
@@ -66,7 +66,12 @@ body {
   justify-content: flex-end;
 
   block-size: fill-available;
+  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+  block-size: -webkit-fill-available;
+
   inline-size: fill-available;
+  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+  inline-size: -webkit-fill-available;
 
   max-inline-size: 96rem;
   writing-mode: horizontal-tb;
@@ -96,7 +101,12 @@ body {
   z-index: 1;
 
   block-size: fill-available;
+  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+  block-size: -webkit-fill-available;
+
   inline-size: fill-available;
+  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+  inline-size: -webkit-fill-available;
 
   margin-inline: auto;
   max-inline-size: 99rem;
@@ -291,7 +301,12 @@ body {
   justify-content: flex-end;
 
   block-size: fill-available;
+  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+  block-size: -webkit-fill-available;
+
   inline-size: fill-available;
+  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+  inline-size: -webkit-fill-available;
 
   max-inline-size: 96rem;
 }


### PR DESCRIPTION
Add backup support for when autoprefixer is not in use

#### Changelog

**New**

- N/A

**Changed**

- Add `block-size: -webkit-fill-available;  inline-size: -webkit-fill-available;` as backup

**Removed**

- N/A

#### Testing / Reviewing

Local host