### PR TITLE
chore(animated-header): Add custom tile content support

### DIFF
--- a/examples/react/AnimatedHeader/src/data/SampleCustomTaskContent.tsx
+++ b/examples/react/AnimatedHeader/src/data/SampleCustomTaskContent.tsx
@@ -1,0 +1,26 @@
+import { ProgressIndicator, ProgressStep, Stack } from '@carbon/react';
+import React from 'react';
+
+const SampleCustomTaskContent = () => {
+  return (
+    <Stack orientation="vertical" gap={8}>
+      <h3>Continue your sample process</h3>
+      <ProgressIndicator vertical>
+        <ProgressStep
+          complete
+          label="First step"
+          description="Sample first step"
+        />
+        <ProgressStep
+          current
+          label="Second step"
+          description="Sample second step"
+        />
+        <ProgressStep label="Third step" description="Sample third step" />
+        <ProgressStep label="Fourth step" description="Sample fourth step" />
+      </ProgressIndicator>
+    </Stack>
+  );
+};
+
+export default SampleCustomTaskContent;

--- a/examples/react/AnimatedHeader/src/data/index.jsx
+++ b/examples/react/AnimatedHeader/src/data/index.jsx
@@ -8,7 +8,9 @@
  */
 
 import { Add } from '@carbon/react/icons';
-import { ButtonKinds } from '@carbon/react';
+import { ButtonKinds, Loading } from '@carbon/react';
+import SampleCustomTaskContent from './SampleCustomTaskContent';
+import React from 'react';
 
 export const workspaceData = [
   {
@@ -316,6 +318,20 @@ export const headerTiles = [
         title: 'Create and run python queries',
         subtitle: 'with Prompt Lab',
         mainIcon: 'DataSet',
+      },
+    ],
+  },
+  {
+    id: 8,
+    label: 'Custom content tasks',
+    tiles: [
+      {
+        id: 'tile-1',
+        customContent: <Loading description="Sample loading state" />
+      },
+      {
+        id: 'tile-2',
+        customContent: <SampleCustomTaskContent />
       },
     ],
   },

--- a/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
@@ -137,9 +137,10 @@ const sharedArgTypes = {
         5: headerTiles[4].label,
         6: headerTiles[5].label,
         7: headerTiles[6].label,
+        8: headerTiles[7].label,
       },
     },
-    options: [0, 1, 2, 3, 4, 5, 6, 7],
+    options: [0, 1, 2, 3, 4, 5, 6, 7, 8],
     mapping: {
       0: null,
       1: headerTiles[0],
@@ -149,6 +150,7 @@ const sharedArgTypes = {
       5: headerTiles[4],
       6: headerTiles[5],
       7: headerTiles[6],
+      8: headerTiles[7],
     },
   },
   selectedWorkspace: {

--- a/packages/react/src/components/AnimatedHeader/__stories__/data/SampleCustomTaskContent.tsx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/data/SampleCustomTaskContent.tsx
@@ -1,0 +1,26 @@
+import { ProgressIndicator, ProgressStep, Stack } from '@carbon/react';
+import React from 'react';
+
+const SampleCustomTaskContent = () => {
+  return (
+    <Stack orientation="vertical" gap={8}>
+      <h3>Continue your sample process</h3>
+      <ProgressIndicator vertical>
+        <ProgressStep
+          complete
+          label="First step"
+          description="Sample first step"
+        />
+        <ProgressStep
+          current
+          label="Second step"
+          description="Sample second step"
+        />
+        <ProgressStep label="Third step" description="Sample third step" />
+        <ProgressStep label="Fourth step" description="Sample fourth step" />
+      </ProgressIndicator>
+    </Stack>
+  );
+};
+
+export default SampleCustomTaskContent;

--- a/packages/react/src/components/AnimatedHeader/__stories__/data/index.jsx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/data/index.jsx
@@ -8,7 +8,9 @@
  */
 
 import { Add } from '@carbon/react/icons';
-import { ButtonKinds } from '@carbon/react';
+import { ButtonKinds, Loading } from '@carbon/react';
+import SampleCustomTaskContent from './SampleCustomTaskContent';
+import React from 'react';
 
 export const workspaceData = [
   {
@@ -316,6 +318,20 @@ export const headerTiles = [
         title: 'Create and run python queries',
         subtitle: 'with Prompt Lab',
         mainIcon: 'DataSet',
+      },
+    ],
+  },
+  {
+    id: 8,
+    label: 'Custom content tasks',
+    tiles: [
+      {
+        id: 'tile-1',
+        customContent: <Loading description="Sample loading state" />
+      },
+      {
+        id: 'tile-2',
+        customContent: <SampleCustomTaskContent />
       },
     ],
   },

--- a/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
@@ -43,12 +43,13 @@ export interface SelectedWorkspace {
 }
 
 export interface Tile {
-  href: string | null;
-  id: string;
-  mainIcon: string | null;
+  href?: string | null;
+  id?: string;
+  mainIcon?: string | null;
   secondaryIcon?: string | null;
   subtitle?: string | null;
-  title: string | null;
+  title?: string | null;
+  customContent?: ReactNode | null;
 }
 
 export interface TileGroup {
@@ -278,6 +279,9 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
                   {...(renderWorkspaceSelectedItem
                     ? { renderSelectedItem: renderWorkspaceSelectedItem }
                     : {})}
+                  {...(selectedWorkspace
+                    ? { selectedItem: selectedWorkspace }
+                    : {})}
                 />
               </div>
             )}
@@ -293,7 +297,8 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
                     secondaryIcon={tile.secondaryIcon}
                     title={tile.title}
                     subtitle={tile.subtitle}
-                    productName={productName}></BaseTile>
+                    productName={productName}
+                    customContent={tile.customContent}></BaseTile>
                 );
               })}
             </div>

--- a/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
@@ -44,7 +44,7 @@ export interface SelectedWorkspace {
 
 export interface Tile {
   href?: string | null;
-  id?: string;
+  id: string;
   mainIcon?: string | null;
   secondaryIcon?: string | null;
   subtitle?: string | null;

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/AIPromptTile/ai-prompt-tile.scss
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/AIPromptTile/ai-prompt-tile.scss
@@ -188,6 +188,10 @@ $prefix: 'clabs--animated-header__ai-prompt-tile' !default;
   fill: $icon-primary;
 }
 
+.#{$prefix}--custom-content {
+  z-index: 4;
+}
+
 @keyframes animate-border {
   0% {
     background-position: 100% 0%;

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/BaseTile/BaseTile.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/BaseTile/BaseTile.tsx
@@ -6,7 +6,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { AIPromptTile } from '../AIPromptTile/AIPromptTile';
 import { GlassTile } from '../GlassTile/GlassTile';
 
@@ -21,6 +21,7 @@ interface BaseTileProps {
   title?: string;
   subtitle?: string;
   productName?: string;
+  customContent?: ReactNode;
 }
 
 export const BaseTile: React.FC<BaseTileProps> = ({
@@ -32,6 +33,7 @@ export const BaseTile: React.FC<BaseTileProps> = ({
   title,
   subtitle,
   productName,
+  customContent,
 }: BaseTileProps) => {
   const props = {
     id,
@@ -42,6 +44,7 @@ export const BaseTile: React.FC<BaseTileProps> = ({
     title,
     subtitle,
     productName,
+    customContent,
   };
   const tile =
     id === 'ai-tile' ? (

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/GlassTile/GlassTile.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/GlassTile/GlassTile.tsx
@@ -6,7 +6,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Link } from '@carbon/react';
 import * as carbonIcons from '@carbon/icons-react';
 import { usePrefix } from '@carbon-labs/utilities/es/index.js';
@@ -21,6 +21,7 @@ interface GlassTileProps {
   secondaryIcon?: string;
   subtitle?: string;
   title?: string;
+  customContent?: ReactNode;
 }
 
 export const GlassTile: React.FC<GlassTileProps> = ({
@@ -31,6 +32,7 @@ export const GlassTile: React.FC<GlassTileProps> = ({
   secondaryIcon,
   subtitle,
   title,
+  customContent,
 }: GlassTileProps) => {
   const prefix = usePrefix();
   const blockClass = `${prefix}--animated-header__glass-tile`;
@@ -46,20 +48,26 @@ export const GlassTile: React.FC<GlassTileProps> = ({
       href={href}>
       <div className={`${blockClass}--body${!open ? ` ${collapsed}` : ''}`}>
         <div className={`${blockClass}--body-background`} />
-        <div className={`${blockClass}--icons`}>
-          {MainIcon && (
-            <MainIcon fill={`var(--cds-icon-secondary)`} size={24} />
-          )}
-        </div>
-        <div className={`${blockClass}--title`}>{title}</div>
-        <div className={`${blockClass}--footer`}>
-          {subtitle && (
-            <div className={`${blockClass}--subtitle`}>{subtitle}</div>
-          )}
-          {SecondaryIcon && (
-            <SecondaryIcon size={16} fill={`var(--cds-icon-secondary)`} />
-          )}
-        </div>
+        {customContent ? (
+          <div className={`${blockClass}--custom-content`}>{customContent}</div>
+        ) : (
+          <>
+            <div className={`${blockClass}--icons`}>
+              {MainIcon && (
+                <MainIcon fill={`var(--cds-icon-secondary)`} size={24} />
+              )}
+            </div>
+            <div className={`${blockClass}--title`}>{title}</div>
+            <div className={`${blockClass}--footer`}>
+              {subtitle && (
+                <div className={`${blockClass}--subtitle`}>{subtitle}</div>
+              )}
+              {SecondaryIcon && (
+                <SecondaryIcon size={16} fill={`var(--cds-icon-secondary)`} />
+              )}
+            </div>
+          </>
+        )}
       </div>
     </Link>
   );

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/GlassTile/glass-tile.scss
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/GlassTile/glass-tile.scss
@@ -129,3 +129,7 @@ $prefix: 'clabs--animated-header__glass-tile' !default;
     white-space: initial;
   }
 }
+
+.#{$prefix}--custom-content {
+  z-index: 2;
+}


### PR DESCRIPTION
Added more flexibility to the tile content. Now the user will be able to specify custom tile content that will be displayed.

#### Changelog

**New**

- Custom tile content handling

**Changed**

- Fixed handling for managed state of workspaces dropdown.