### PR TITLE
fix: allow excess args for commander

### DIFF
--- a/tools/check-license.cjs
+++ b/tools/check-license.cjs
@@ -28,6 +28,7 @@ const {
 } = reLicense;
 
 program
+  .allowExcessArguments(true)
   .option(
     '-c, --test-current-year',
     'Ensures the license header represents the current year'


### PR DESCRIPTION
Closes #

Allows excess args for commander so precommits will run as expected.

#### Changelog

**Changed**

- `tools/check-license.cjs`
