### PR TITLE
chore: add split panel codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 # Other packages
 /packages/react/src/components/AnimatedHeader/   @carbon-design-system/animated-header-devs
 /packages/react/src/components/Processing/       @carbon-design-system/processing-devs
+/packages/react/src/components/SplitPanel/       @carbon-design-system/split-panel-devs
 /packages/react/src/components/TextHighlighter/  @carbon-design-system/text-highlighter-devs
 /packages/react/src/components/ThemeSettings/    @carbon-design-system/theme-settings-devs
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ bottlenecks in publishing and deployments. Here are some available components:
 | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
 | [`@carbon-labs/react-animated-header`](https://github.com/carbon-design-system/carbon-labs/tree/main/packages/react/src/components/AnimatedHeader)   | Animated header component  |
 | [`@carbon-labs/react-processing`](https://github.com/carbon-design-system/carbon-labs/tree/main/packages/react/src/components/Processing)            | Processing                 |
+| [`@carbon-labs/split-panel`](https://github.com/carbon-design-system/carbon-labs/tree/main/packages/react/src/components/SplitPanel)                 | Split panel component      |
 | [`@carbon-labs/react-text-highlighter`](https://github.com/carbon-design-system/carbon-labs/tree/main/packages/react/src/components/TextHighlighter) | Text highlighter component |
 | [`@carbon-labs/react-theme-switcher`](https://github.com/carbon-design-system/carbon-labs/tree/main/packages/react/src/components/ThemeSettings)     | Theme settings             |
 | [`@carbon-labs/react-ui-shell`](https://github.com/carbon-design-system/carbon-labs/tree/main/packages/react/src/components/UIShell)                 | UI shell components        |

--- a/packages/react/src/components/SplitPanel/__stories__/SplitPanel.mdx
+++ b/packages/react/src/components/SplitPanel/__stories__/SplitPanel.mdx
@@ -5,7 +5,7 @@ import * as SplitPanelStories from './SplitPanel.stories';
 
 # SplitPanel
 
-- **Initiative owner(s):** FILL THIS LINE
+- **Initiative owner(s):** Lee Chase
 - **Status:** Draft
 - **Target library:** TBD
 - **Target library maintainer(s) / PR Reviewer(s):** N/A


### PR DESCRIPTION
Add missing details from split panel docs

#### Changelog

**New**

- Add split panel to CODEOWNERS
- Add split panel in README