### PR TITLE
chore(animated-header): Expose expand/collapse button label

### DIFF
--- a/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.mdx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.mdx
@@ -153,5 +153,7 @@ Example of Animated Header with all prop types enabled.
   userName="Drew"
   welcomeText="Welcome"
   workspaceLabel="Open in: Drew's workspace"
+  expandButtonLabel="Expand"
+  collapseButtonLabel="Collapse"
 />
 ```

--- a/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
@@ -185,6 +185,14 @@ const sharedArgTypes = {
   workspaceLabel: {
     description: 'Specify the default workspace label above the tiles',
   },
+  expandButtonLabel: {
+    description: 'Specify custom expand button label',
+    type: 'string',
+  },
+  collapseButtonLabel: {
+    description: 'Specify custom collapse button label',
+    type: 'string',
+  },
 };
 
 const sharedArgs = {
@@ -198,6 +206,8 @@ const sharedArgs = {
   tasksConfig: 2,
   userName: 'Drew',
   welcomeText: 'Welcome',
+  expandButtonLabel: 'Expand',
+  collapseButtonLabel: 'Collapse'
 };
 
 export const ThemeG10 = (args) => {

--- a/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
@@ -207,7 +207,7 @@ const sharedArgs = {
   userName: 'Drew',
   welcomeText: 'Welcome',
   expandButtonLabel: 'Expand',
-  collapseButtonLabel: 'Collapse'
+  collapseButtonLabel: 'Collapse',
 };
 
 export const ThemeG10 = (args) => {

--- a/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
@@ -77,6 +77,8 @@ export interface AnimatedHeaderProps {
   userName?: string;
   welcomeText?: string;
   workspaceLabel?: string;
+  expandButtonLabel?: string;
+  collapseButtonLabel?: string;
 }
 
 const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
@@ -98,6 +100,8 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
   userName,
   welcomeText,
   workspaceLabel = `Open in: ${userName}'s workspace` || `Select a workspace`,
+  expandButtonLabel = 'Expand',
+  collapseButtonLabel = 'Collapse',
 }: AnimatedHeaderProps) => {
   const prefix = usePrefix();
   const blockClass = `${prefix}--animated-header`;
@@ -313,7 +317,7 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
             kind="ghost"
             renderIcon={open ? ChevronUp : ChevronDown}
             onClick={handleButtonCollapseClick}>
-            {open ? `Collapse` : `Expand`}
+            {open ? collapseButtonLabel : expandButtonLabel}
           </Button>
         </div>
       </Grid>
@@ -339,9 +343,19 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
   className: PropTypes.string,
 
   /**
+   * Custom collapse button label
+   */
+  collapseButtonLabel: PropTypes.string,
+
+  /**
    * Provide short sentence in max. 3 lines related to product context
    */
   description: PropTypes.string,
+
+  /**
+   * Custom expand button label
+   */
+  expandButtonLabel: PropTypes.string,
 
   /**
    * Helper function passed to downshift that allows the library to render a


### PR DESCRIPTION
Allow for specifying custom labels for expand/collapse button. Needed since we don't support internationalisation.

#### Changelog

**New**

- expandButtonLabel, collapseButtonLabel props