### PR TITLE
fix: exports in ui shell

### DIFF
--- a/examples/react/UIShell/src/App.tsx
+++ b/examples/react/UIShell/src/App.tsx
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, useRef } from 'react';
+import { useState, useRef } from 'react';
 import {
   SIDE_NAV_TYPE,
   SideNav,
@@ -23,7 +23,7 @@ import {
   HeaderPopoverButton,
   HeaderPopoverContent,
   TrialCountdown,
-} from '@carbon-labs/react-ui-shell/es/index';
+} from '@carbon-labs/react-ui-shell';
 import {
   SkipToContent,
   Header,

--- a/packages/react/src/components/UIShell/package.json
+++ b/packages/react/src/components/UIShell/package.json
@@ -14,8 +14,14 @@
     "directory": "src/components/UIShell"
   },
   "exports": {
-    "import": "./es/index.js",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/": "./es/",
+    "./lib/": "./lib/",
+    "./scss/": "./scss/"
   },
   "files": [
     "es",


### PR DESCRIPTION
Updates UIShell exports and ensures they work in the following scenarios.

JS from

`from '@carbon-labs/react-ui-shell/es/index.js';`
`from '@carbon-labs/react-ui-shell/es';
`from '@carbon-labs/react-ui-shell';`

SCSS 
`@use '@carbon-labs/react-ui-shell/scss/ui-shell';`

Types
`"type": "./es/index.d.ts"`

It looks to me as though a single types file could be used in root or a dist folder.

#### Changelog

**Changed**
- packages/react/src/components/UIShell/package.json
- examples/react/UIShell/src/App.tsx

#### Testing / Reviewing

Copied UIShell to a separate folder and tried installing and running from local path.

NOTE: Once the correct pattern is verified for "exports" it should be replicated in the other projects.
