### PR TITLE
fix: update exports to match UI shell

### DIFF
--- a/examples/react/AnimatedHeader/src/App.tsx
+++ b/examples/react/AnimatedHeader/src/App.tsx
@@ -8,16 +8,21 @@
  */
 
 import React, { useState } from 'react';
-import { AnimatedHeader } from '@carbon-labs/react-animated-header';
 import {
+  AnimatedHeader,
   watsonXAnimatedLight,
   watsonXStaticLight,
-} from '@carbon-labs/react-animated-header/assets';
-import { headerTiles, workspaceData, tasksConfigDropdown } from './data';
+} from '@carbon-labs/react-animated-header';
+
+import {
+  headerTiles,
+  workspaceData,
+  tasksConfigDropdown,
+} from './data/index.tsx';
 import {
   SelectedWorkspace,
   TileGroup,
-} from '@carbon-labs/react-animated-header/es/components/AnimatedHeader/AnimatedHeader';
+} from '@carbon-labs/react-animated-header/es/components/AnimatedHeader/AnimatedHeader.js';
 
 function App() {
   const [tiles] = useState(headerTiles);
@@ -48,12 +53,12 @@ function App() {
     <AnimatedHeader
       allTiles={tiles}
       allWorkspaces={workspaces}
-      description="Connect, monitor, and manage data."
+      description='Connect, monitor, and manage data.'
       handleHeaderItemsToString={handleHeaderItems}
       handleWorkspaceItemsToString={handleWorkspaceItems}
       headerAnimation={watsonXAnimatedLight}
       headerStatic={watsonXStaticLight}
-      productName="[Product name]"
+      productName='[Product name]'
       renderHeaderSelectedItem={selectedTileGroupRenderer}
       renderWorkspaceSelectedItem={selectedWorkspaceItemRenderer}
       selectedTileGroup={selectedTile}
@@ -61,8 +66,8 @@ function App() {
       setSelectedTileGroup={handleTileGroup}
       setSelectedWorkspace={handleWorkspaceSelect}
       tasksConfig={tasksConfigDropdown}
-      userName="Drew"
-      welcomeText="Welcome"
+      userName='Drew'
+      welcomeText='Welcome'
       workspaceLabel="Open in: Drew's workspace"
     />
   );

--- a/examples/react/AnimatedHeader/src/App.tsx
+++ b/examples/react/AnimatedHeader/src/App.tsx
@@ -53,12 +53,12 @@ function App() {
     <AnimatedHeader
       allTiles={tiles}
       allWorkspaces={workspaces}
-      description='Connect, monitor, and manage data.'
+      description="Connect, monitor, and manage data."
       handleHeaderItemsToString={handleHeaderItems}
       handleWorkspaceItemsToString={handleWorkspaceItems}
       headerAnimation={watsonXAnimatedLight}
       headerStatic={watsonXStaticLight}
-      productName='[Product name]'
+      productName="[Product name]"
       renderHeaderSelectedItem={selectedTileGroupRenderer}
       renderWorkspaceSelectedItem={selectedWorkspaceItemRenderer}
       selectedTileGroup={selectedTile}
@@ -66,8 +66,8 @@ function App() {
       setSelectedTileGroup={handleTileGroup}
       setSelectedWorkspace={handleWorkspaceSelect}
       tasksConfig={tasksConfigDropdown}
-      userName='Drew'
-      welcomeText='Welcome'
+      userName="Drew"
+      welcomeText="Welcome"
       workspaceLabel="Open in: Drew's workspace"
     />
   );

--- a/examples/react/AnimatedHeader/src/App.tsx
+++ b/examples/react/AnimatedHeader/src/App.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useState } from 'react';
-import { AnimatedHeader } from '@carbon-labs/react-animated-header/es/index';
+import { AnimatedHeader } from '@carbon-labs/react-animated-header';
 import {
   watsonXAnimatedLight,
   watsonXStaticLight,

--- a/examples/react/AnimatedHeader/src/data/index.tsx
+++ b/examples/react/AnimatedHeader/src/data/index.tsx
@@ -326,7 +326,7 @@ export const headerTiles = [
     tiles: [
       {
         id: 'tile-1',
-        customContent: <Loading description='Sample loading state' />,
+        customContent: <Loading description="Sample loading state" />,
       },
       {
         id: 'tile-2',

--- a/examples/react/AnimatedHeader/src/data/index.tsx
+++ b/examples/react/AnimatedHeader/src/data/index.tsx
@@ -10,7 +10,6 @@
 import { Add } from '@carbon/react/icons';
 import { ButtonKinds, Loading } from '@carbon/react';
 import SampleCustomTaskContent from './SampleCustomTaskContent';
-import React from 'react';
 
 export const workspaceData = [
   {
@@ -327,11 +326,11 @@ export const headerTiles = [
     tiles: [
       {
         id: 'tile-1',
-        customContent: <Loading description="Sample loading state" />
+        customContent: <Loading description='Sample loading state' />,
       },
       {
         id: 'tile-2',
-        customContent: <SampleCustomTaskContent />
+        customContent: <SampleCustomTaskContent />,
       },
     ],
   },

--- a/examples/react/ExampleButton/src/App.tsx
+++ b/examples/react/ExampleButton/src/App.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { ExampleButton } from '@carbon-labs/react-example-button/es/index';
+import { ExampleButton } from '@carbon-labs/react-example-button';
 
 function App() {
   return <ExampleButton />;

--- a/examples/react/Processing/src/App.tsx
+++ b/examples/react/Processing/src/App.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { Processing } from '@carbon-labs/react-processing/es/index';
+import { Processing } from '@carbon-labs/react-processing';
 
 function App() {
   return <Processing loop />;

--- a/examples/react/TextHighlighter/src/App.tsx
+++ b/examples/react/TextHighlighter/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
   return (
     <p>
       This text is not highlighted
-      <TextHighlighter kind='mark' type='default'>
+      <TextHighlighter kind="mark" type="default">
         {' '}
         This is some highlighted text{' '}
       </TextHighlighter>

--- a/examples/react/TextHighlighter/src/App.tsx
+++ b/examples/react/TextHighlighter/src/App.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { TextHighlighter } from '@carbon-labs/react-text-highlighter/es/index';
+import { TextHighlighter } from '@carbon-labs/react-text-highlighter';
 
 function App() {
   return <TextHighlighter />;

--- a/examples/react/TextHighlighter/src/App.tsx
+++ b/examples/react/TextHighlighter/src/App.tsx
@@ -11,7 +11,16 @@ import React from 'react';
 import { TextHighlighter } from '@carbon-labs/react-text-highlighter';
 
 function App() {
-  return <TextHighlighter />;
+  return (
+    <p>
+      This text is not highlighted
+      <TextHighlighter kind='mark' type='default'>
+        {' '}
+        This is some highlighted text{' '}
+      </TextHighlighter>
+      This is also not highlighted
+    </p>
+  );
 }
 
 export default App;

--- a/examples/react/WhatsNew/src/App.tsx
+++ b/examples/react/WhatsNew/src/App.tsx
@@ -30,7 +30,7 @@ import {
   TocSection,
   ViewStack,
   View,
-} from '@carbon-labs/react-whats-new/es/index';
+} from '@carbon-labs/react-whats-new';
 
 pkg.component.ScrollGradient = true;
 

--- a/packages/react/src/components/AnimatedHeader/package.json
+++ b/packages/react/src/components/AnimatedHeader/package.json
@@ -19,9 +19,10 @@
       "require": "./lib/index.js",
       "type": "./es/index.d.ts"
     },
-    "./es/": "./es/",
-    "./lib/": "./lib/",
-    "./scss/": "./scss/"
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*",
+    "./assets/*": "./assets/*"
   },
   "files": [
     "es",

--- a/packages/react/src/components/AnimatedHeader/package.json
+++ b/packages/react/src/components/AnimatedHeader/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/AnimatedHeader"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",

--- a/packages/react/src/components/AnimatedHeader/package.json
+++ b/packages/react/src/components/AnimatedHeader/package.json
@@ -14,8 +14,14 @@
     "directory": "src/components/AnimatedHeader"
   },
   "exports": {
-    "import": "./es/index.js",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/": "./es/",
+    "./lib/": "./lib/",
+    "./scss/": "./scss/"
   },
   "files": [
     "es",

--- a/packages/react/src/components/ExampleButton/package.json
+++ b/packages/react/src/components/ExampleButton/package.json
@@ -14,8 +14,14 @@
     "directory": "src/components/ExampleButton"
   },
   "exports": {
-    "import": "./es/index.js",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/": "./es/",
+    "./lib/": "./lib/",
+    "./scss/": "./scss/"
   },
   "files": [
     "es",

--- a/packages/react/src/components/ExampleButton/package.json
+++ b/packages/react/src/components/ExampleButton/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/ExampleButton"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",

--- a/packages/react/src/components/ExampleButton/package.json
+++ b/packages/react/src/components/ExampleButton/package.json
@@ -19,9 +19,9 @@
       "require": "./lib/index.js",
       "type": "./es/index.d.ts"
     },
-    "./es/": "./es/",
-    "./lib/": "./lib/",
-    "./scss/": "./scss/"
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*"
   },
   "files": [
     "es",

--- a/packages/react/src/components/MDXComponents/package.json
+++ b/packages/react/src/components/MDXComponents/package.json
@@ -13,8 +13,16 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/MDXComponents"
   },
-  "main": "./src/index.js",
-  "module": "./src/index.js",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/": "./es/",
+    "./lib/": "./lib/",
+    "./scss/": "./scss/"
+  },
   "files": [
     "es",
     "lib",

--- a/packages/react/src/components/MDXComponents/package.json
+++ b/packages/react/src/components/MDXComponents/package.json
@@ -19,9 +19,9 @@
       "require": "./lib/index.js",
       "type": "./es/index.d.ts"
     },
-    "./es/": "./es/",
-    "./lib/": "./lib/",
-    "./scss/": "./scss/"
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*"
   },
   "files": [
     "es",

--- a/packages/react/src/components/MDXComponents/package.json
+++ b/packages/react/src/components/MDXComponents/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/MDXComponents"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",

--- a/packages/react/src/components/Processing/package.json
+++ b/packages/react/src/components/Processing/package.json
@@ -13,8 +13,16 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/Processing"
   },
-  "main": "./src/index.js",
-  "module": "./src/index.js",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*"
+  },
   "files": [
     "es",
     "lib",

--- a/packages/react/src/components/Processing/package.json
+++ b/packages/react/src/components/Processing/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/Processing"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",

--- a/packages/react/src/components/SplitPanel/package.json
+++ b/packages/react/src/components/SplitPanel/package.json
@@ -13,8 +13,16 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/SplitPanel"
   },
-  "main": "./src/index.js",
-  "module": "./src/index.js",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*"
+  },
   "files": [
     "es",
     "lib",

--- a/packages/react/src/components/SplitPanel/package.json
+++ b/packages/react/src/components/SplitPanel/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/SplitPanel"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",

--- a/packages/react/src/components/TextHighlighter/package.json
+++ b/packages/react/src/components/TextHighlighter/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/TextHighlighter"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",

--- a/packages/react/src/components/TextHighlighter/package.json
+++ b/packages/react/src/components/TextHighlighter/package.json
@@ -19,9 +19,9 @@
       "require": "./lib/index.js",
       "type": "./es/index.d.ts"
     },
-    "./es/": "./es/",
-    "./lib/": "./lib/",
-    "./scss/": "./scss/"
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*"
   },
   "files": [
     "es",

--- a/packages/react/src/components/TextHighlighter/package.json
+++ b/packages/react/src/components/TextHighlighter/package.json
@@ -14,8 +14,14 @@
     "directory": "src/components/TextHighlighter"
   },
   "exports": {
-    "import": "./es/index.js",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/": "./es/",
+    "./lib/": "./lib/",
+    "./scss/": "./scss/"
   },
   "files": [
     "es",

--- a/packages/react/src/components/ThemeSettings/package.json
+++ b/packages/react/src/components/ThemeSettings/package.json
@@ -14,8 +14,14 @@
     "directory": "src/components/ThemeSettings"
   },
   "exports": {
-    "import": "./es/index.js",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/": "./es/",
+    "./lib/": "./lib/",
+    "./scss/": "./scss/"
   },
   "files": [
     "es",

--- a/packages/react/src/components/ThemeSettings/package.json
+++ b/packages/react/src/components/ThemeSettings/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/ThemeSettings"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",

--- a/packages/react/src/components/ThemeSettings/package.json
+++ b/packages/react/src/components/ThemeSettings/package.json
@@ -19,9 +19,9 @@
       "require": "./lib/index.js",
       "type": "./es/index.d.ts"
     },
-    "./es/": "./es/",
-    "./lib/": "./lib/",
-    "./scss/": "./scss/"
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*"
   },
   "files": [
     "es",

--- a/packages/react/src/components/UIShell/package.json
+++ b/packages/react/src/components/UIShell/package.json
@@ -19,9 +19,9 @@
       "require": "./lib/index.js",
       "type": "./es/index.d.ts"
     },
-    "./es/": "./es/",
-    "./lib/": "./lib/",
-    "./scss/": "./scss/"
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*"
   },
   "files": [
     "es",

--- a/packages/react/src/components/UIShell/package.json
+++ b/packages/react/src/components/UIShell/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/UIShell"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",

--- a/packages/react/src/components/WhatsNew/package.json
+++ b/packages/react/src/components/WhatsNew/package.json
@@ -14,8 +14,14 @@
     "directory": "src/components/WhatsNew"
   },
   "exports": {
-    "import": "./es/index.js",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/": "./es/",
+    "./lib/": "./lib/",
+    "./scss/": "./scss/"
   },
   "files": [
     "es",

--- a/packages/react/src/components/WhatsNew/package.json
+++ b/packages/react/src/components/WhatsNew/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/WhatsNew"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",

--- a/packages/react/src/components/WhatsNew/package.json
+++ b/packages/react/src/components/WhatsNew/package.json
@@ -19,9 +19,9 @@
       "require": "./lib/index.js",
       "type": "./es/index.d.ts"
     },
-    "./es/": "./es/",
-    "./lib/": "./lib/",
-    "./scss/": "./scss/"
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*"
   },
   "files": [
     "es",

--- a/packages/react/tasks/generate/templates/example/src/App.tsx
+++ b/packages/react/tasks/generate/templates/example/src/App.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { DISPLAY_NAME } from '@carbon-labs/react-STYLE_NAME/es/index';
+import { DISPLAY_NAME } from '@carbon-labs/react-STYLE_NAME';
 
 function App() {
   return <DISPLAY_NAME />;

--- a/packages/react/tasks/generate/templates/package-edit.json
+++ b/packages/react/tasks/generate/templates/package-edit.json
@@ -15,8 +15,14 @@
     "directory": "src/components/DISPLAY_NAME"
   },
   "exports": {
-    "import": "./es/index.js",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "type": "./es/index.d.ts"
+    },
+    "./es/": "./es/",
+    "./lib/": "./lib/",
+    "./scss/": "./scss/"
   },
   "files": ["es", "lib", "scss"],
   "scripts": {

--- a/packages/react/tasks/generate/templates/package-edit.json
+++ b/packages/react/tasks/generate/templates/package-edit.json
@@ -14,11 +14,11 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/DISPLAY_NAME"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js",
-      "type": "./es/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./es/": "./es/",
     "./lib/": "./lib/",


### PR DESCRIPTION
Related to #603 

Given the verified example of fixing the UI Shell exports and example application, this PR update the remaining react package exports and example imports.

Slight change to sub folder exports to match https://nodejs.org/api/packages.html#subpath-exports

#### Changelog

**Changed**

- React package.json files to match UiShell
- Example imports to remove es/index.js
- Updated generate script file.

#### Testing / Reviewing

Was verified locally by checking/updating examples.
To be verified by opening stackblitz examples after publish.