### PR TITLE
Revert "fix(deps): update dependency vega to v5.32.0 [security]"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -29049,25 +29049,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega-crossfilter@npm:~4.1.3":
-  version: 4.1.3
-  resolution: "vega-crossfilter@npm:4.1.3"
+"vega-crossfilter@npm:~4.1.2":
+  version: 4.1.2
+  resolution: "vega-crossfilter@npm:4.1.2"
   dependencies:
     d3-array: "npm:^3.2.2"
-    vega-dataflow: "npm:^5.7.7"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/bb7b353c1106d47b03dc4589b08c796de187ae567c99cc44b7c3ad5aa096f2e8457373a99a81a449c9307b50b980589ba71e0589c74ae8b614a8807069050ac6
+    vega-dataflow: "npm:^5.7.6"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/8ec7fec62add90fc2effaa15ab5569f232ffdc10e6b080113cb919ee350138215caee4182e5e488087325988d1af78a21a6d668aef8e97e6c3778661e0b13f82
   languageName: node
   linkType: hard
 
-"vega-dataflow@npm:^5.7.7, vega-dataflow@npm:~5.7.7":
-  version: 5.7.7
-  resolution: "vega-dataflow@npm:5.7.7"
+"vega-dataflow@npm:^5.7.6, vega-dataflow@npm:~5.7.6":
+  version: 5.7.6
+  resolution: "vega-dataflow@npm:5.7.6"
   dependencies:
-    vega-format: "npm:^1.1.3"
-    vega-loader: "npm:^4.5.3"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/a2d5a094a0f369624e838c6845aaab0e36eac7bc50c643de4e8427c4a41d6bd08b8ac9b8f8169b70c6cc353c416f8a729b19550bc1e9432650eaef8a58b268ab
+    vega-format: "npm:^1.1.2"
+    vega-loader: "npm:^4.5.2"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/6a8b5d6a5c9cd081b3c7ae206158f531ccf3601a0e2a49eb4d8eaa2ce85d44763030015b1dc782db5630d99f14933a5fce6a057150b9d0db4826aac60f8526f1
   languageName: node
   linkType: hard
 
@@ -29090,16 +29090,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega-encode@npm:~4.10.2":
-  version: 4.10.2
-  resolution: "vega-encode@npm:4.10.2"
+"vega-encode@npm:~4.10.1":
+  version: 4.10.1
+  resolution: "vega-encode@npm:4.10.1"
   dependencies:
     d3-array: "npm:^3.2.2"
     d3-interpolate: "npm:^3.0.1"
-    vega-dataflow: "npm:^5.7.7"
-    vega-scale: "npm:^7.4.2"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/339c596966b453655f6539e0859236780825c5c46166959ccccffb4671ba8459ad7b121df16ccb51842aeca18a225f4e15f261b198bb2dd6fc62913230a4b51f
+    vega-dataflow: "npm:^5.7.6"
+    vega-scale: "npm:^7.4.1"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/a0fbdac9636bebd032d1420297992670cf20e11812e8623cf260aab5f006352ab6801bd556d7211139d8e9a24299680a67576787f3bb553cb05917d0fa58b5d8
   languageName: node
   linkType: hard
 
@@ -29110,17 +29110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega-expression@npm:^5.2.0, vega-expression@npm:~5.2.0":
-  version: 5.2.0
-  resolution: "vega-expression@npm:5.2.0"
-  dependencies:
-    "@types/estree": "npm:^1.0.0"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/76a2d00f2825991dc005c69f8d3a648c8db78df1b5cd68e32cc05e6feac652f05e5f4dac78449171794d07ac35600ba9d7517e705aaf88a11ebb9dd14cf12578
-  languageName: node
-  linkType: hard
-
-"vega-expression@npm:~5.1.1":
+"vega-expression@npm:^5.0.1, vega-expression@npm:^5.1.1, vega-expression@npm:~5.1.1":
   version: 5.1.1
   resolution: "vega-expression@npm:5.1.1"
   dependencies:
@@ -29130,73 +29120,73 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega-force@npm:~4.2.2":
-  version: 4.2.2
-  resolution: "vega-force@npm:4.2.2"
+"vega-force@npm:~4.2.1":
+  version: 4.2.1
+  resolution: "vega-force@npm:4.2.1"
   dependencies:
     d3-force: "npm:^3.0.0"
-    vega-dataflow: "npm:^5.7.7"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/e3711d8c2991baeb580f179dbe6fb4d36454c64f3fc759a3a0adeb1f38f060cbf194285bcf4c8022a61cfa7422efa7235cc2254286eaf76035020acdb4a098bb
+    vega-dataflow: "npm:^5.7.6"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/f32b5805bd6d8532526e3440aade699139a0217e9440b6cdf1c0d043884c847e945789811555c40c77c9153082a59e9b0553d5e46913161e6aef335f07f98762
   languageName: node
   linkType: hard
 
-"vega-format@npm:^1.1.3, vega-format@npm:~1.1.3":
-  version: 1.1.3
-  resolution: "vega-format@npm:1.1.3"
+"vega-format@npm:^1.1.2, vega-format@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "vega-format@npm:1.1.2"
   dependencies:
     d3-array: "npm:^3.2.2"
     d3-format: "npm:^3.1.0"
     d3-time-format: "npm:^4.1.0"
-    vega-time: "npm:^2.1.3"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/07215557933fbc0cecea2311dc23bdea3248dc2859b424884bcfcd6f6bcdf64edf3217f5314b0b56fd97f4b6111329355f7150653d4bc3c5af63a312a558b33f
+    vega-time: "npm:^2.1.2"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/216a0373cb676350a1a09c33015ff29b5825a50cf2e29b284927a20a75dc99557d703bb7f03b1c39ee8c27a145d0c5b2f630a0ebc73437b6ce05d6e7bfb7b595
   languageName: node
   linkType: hard
 
-"vega-functions@npm:^5.18.0, vega-functions@npm:~5.18.0":
-  version: 5.18.0
-  resolution: "vega-functions@npm:5.18.0"
+"vega-functions@npm:^5.15.0, vega-functions@npm:~5.15.0":
+  version: 5.15.0
+  resolution: "vega-functions@npm:5.15.0"
   dependencies:
     d3-array: "npm:^3.2.2"
     d3-color: "npm:^3.1.0"
     d3-geo: "npm:^3.1.0"
-    vega-dataflow: "npm:^5.7.7"
-    vega-expression: "npm:^5.2.0"
-    vega-scale: "npm:^7.4.2"
-    vega-scenegraph: "npm:^4.13.1"
-    vega-selections: "npm:^5.6.0"
+    vega-dataflow: "npm:^5.7.6"
+    vega-expression: "npm:^5.1.1"
+    vega-scale: "npm:^7.4.1"
+    vega-scenegraph: "npm:^4.13.0"
+    vega-selections: "npm:^5.4.2"
     vega-statistics: "npm:^1.9.0"
-    vega-time: "npm:^2.1.3"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/231a4efabf819a3cfa8ef22d791acb329dc6d0afb04a0d10c7b5463315e987a5b0d991430ef0c6f7cf4c85518f0eb8664d85543bb80716aacc7ccaa2ea829c60
+    vega-time: "npm:^2.1.2"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/6d54d1d17731c00db7654f91bca5314cbc38464426eb2a28ef1d1e64d39a02a88b77e42736b68c70b106f9b73595fec6405f986601318b7750943ea8e1711a05
   languageName: node
   linkType: hard
 
-"vega-geo@npm:~4.4.3":
-  version: 4.4.3
-  resolution: "vega-geo@npm:4.4.3"
+"vega-geo@npm:~4.4.2":
+  version: 4.4.2
+  resolution: "vega-geo@npm:4.4.2"
   dependencies:
     d3-array: "npm:^3.2.2"
     d3-color: "npm:^3.1.0"
     d3-geo: "npm:^3.1.0"
     vega-canvas: "npm:^1.2.7"
-    vega-dataflow: "npm:^5.7.7"
-    vega-projection: "npm:^1.6.2"
+    vega-dataflow: "npm:^5.7.6"
+    vega-projection: "npm:^1.6.1"
     vega-statistics: "npm:^1.9.0"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/fed05ee92d2884dcf3cd7f529dbf0309d82576fe041d175121524b8c4155f2f9283a71d0a0f98be3b1e6bacd55f50f9c28b528ae22e8cf286977bd1fb29b8b15
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/fe65a0d4c3105712401a3499411ca464353529432302a5883569a8bb932d15994b3dec2fcb07e39e3462d4b853b870d115f3337997f8ce00d83654f98792bd6b
   languageName: node
   linkType: hard
 
-"vega-hierarchy@npm:~4.1.3":
-  version: 4.1.3
-  resolution: "vega-hierarchy@npm:4.1.3"
+"vega-hierarchy@npm:~4.1.2":
+  version: 4.1.2
+  resolution: "vega-hierarchy@npm:4.1.2"
   dependencies:
     d3-hierarchy: "npm:^3.1.2"
-    vega-dataflow: "npm:^5.7.7"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/7be74243d41313b95f3e2f7d645d4ca87378088f97572b9101a9113c432c5691682b0e249e1bdb85c162b322df11871a517a3a1e58a6a749a2d983a70836a3bf
+    vega-dataflow: "npm:^5.7.6"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/1def25686f49b46c1ed541fe4b05c7ccd3838754ba39ed1bc469ab9e422079a53a220a67384d5f1b0404ebf06c55de82179d7d8c5f1621cee9db1a8eae0ed7b0
   languageName: node
   linkType: hard
 
@@ -29207,15 +29197,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega-label@npm:~1.3.1":
-  version: 1.3.1
-  resolution: "vega-label@npm:1.3.1"
+"vega-label@npm:~1.3.0":
+  version: 1.3.0
+  resolution: "vega-label@npm:1.3.0"
   dependencies:
     vega-canvas: "npm:^1.2.7"
-    vega-dataflow: "npm:^5.7.7"
-    vega-scenegraph: "npm:^4.13.1"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/651212f9528501698c43d149c2397cd835dc3a4492f75f544a445065ba3c1e8b8ed62796249eabf3b5813e1105c9f7bf84f06e188c7b1291b9422afdc0f53ad5
+    vega-dataflow: "npm:^5.7.6"
+    vega-scenegraph: "npm:^4.13.0"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/5f3d102a65ac6fabad74534563b38878a103790dda9feca7bbac3d2164dcc4e34167ef8f739bac44a4b77a9587d1aa0658fd517983d156d4303567d95e10f310
   languageName: node
   linkType: hard
 
@@ -29240,90 +29230,90 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega-loader@npm:^4.5.3, vega-loader@npm:~4.5.3":
-  version: 4.5.3
-  resolution: "vega-loader@npm:4.5.3"
+"vega-loader@npm:^4.5.2, vega-loader@npm:~4.5.2":
+  version: 4.5.2
+  resolution: "vega-loader@npm:4.5.2"
   dependencies:
     d3-dsv: "npm:^3.0.1"
     node-fetch: "npm:^2.6.7"
     topojson-client: "npm:^3.1.0"
-    vega-format: "npm:^1.1.3"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/0b28f9c78468956d6358333342e93491af69399aa8e640f19c444c1d71a47f22a485ea0de86dfd5f3e5fe4fd6b75a8794275b719953e3b6dc28acf0562ebf605
+    vega-format: "npm:^1.1.2"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/edde4a6bcc1d0708e0799943311ff2bce64c61cbcbb2c5432f9e1d65faeb9d392724c382e16a364e800554eef1c0fb8b80fab736d8219a246487d728270415da
   languageName: node
   linkType: hard
 
-"vega-parser@npm:~6.6.0":
-  version: 6.6.0
-  resolution: "vega-parser@npm:6.6.0"
+"vega-parser@npm:~6.4.0":
+  version: 6.4.0
+  resolution: "vega-parser@npm:6.4.0"
   dependencies:
-    vega-dataflow: "npm:^5.7.7"
+    vega-dataflow: "npm:^5.7.6"
     vega-event-selector: "npm:^3.0.1"
-    vega-functions: "npm:^5.18.0"
-    vega-scale: "npm:^7.4.2"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/3ae5317912deed75f0d6e0f1ca74bb7d45f273b0881206ab1466c5c4e42789362606e99a0f72471d1ae03164c880ad5e5123cdf7061c6468f4bf82404c9201dc
+    vega-functions: "npm:^5.15.0"
+    vega-scale: "npm:^7.4.1"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/e450be067df44ed79ae6072fc8771e1119430d77d1e50c4b56eacb27ffd800f4b8b98ebed670dd00176e70e7a215762212615c0fc84246fb9222358f1c282d62
   languageName: node
   linkType: hard
 
-"vega-projection@npm:^1.6.2, vega-projection@npm:~1.6.2":
-  version: 1.6.2
-  resolution: "vega-projection@npm:1.6.2"
+"vega-projection@npm:^1.6.1, vega-projection@npm:~1.6.1":
+  version: 1.6.1
+  resolution: "vega-projection@npm:1.6.1"
   dependencies:
     d3-geo: "npm:^3.1.0"
     d3-geo-projection: "npm:^4.0.0"
-    vega-scale: "npm:^7.4.2"
-  checksum: 10c0/cc737de9fc62e32c16a894196811066657b0610d522e79051cab8759d2f7e7250bf4686bed016fc4d62eb76ad0eb0adfde4e50dddda3d2a77a0644922fb42c25
+    vega-scale: "npm:^7.4.1"
+  checksum: 10c0/e5a078c9ec4eeb0a88db95dab66bd82bfa5ac174a357aac6c099e8a7618d8546e7f87222f1395fe4bd0326ebe5cffbe1ca586058bf66f4d2fdd1aea5cdd4dbb7
   languageName: node
   linkType: hard
 
-"vega-regression@npm:~1.3.1":
-  version: 1.3.1
-  resolution: "vega-regression@npm:1.3.1"
+"vega-regression@npm:~1.3.0":
+  version: 1.3.0
+  resolution: "vega-regression@npm:1.3.0"
   dependencies:
     d3-array: "npm:^3.2.2"
-    vega-dataflow: "npm:^5.7.7"
+    vega-dataflow: "npm:^5.7.6"
     vega-statistics: "npm:^1.9.0"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/7beb72975be62139ac38da649bba4e4a03a918b192c03b4ea3133ce26458d7ed07f6d4d149fba9a56a15fb1a3bb3638f032bfadc4afc2c426f5e69aac6c06955
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/e45284604f6177bdcfb357d7a4a6e1d0714a2a2aaada1c1408203f59333e6fa45ddcf931a2354addfb67738304f39578ba6b9b605276b9c10ae25722b5644dfb
   languageName: node
   linkType: hard
 
-"vega-runtime@npm:^6.2.1, vega-runtime@npm:~6.2.1":
-  version: 6.2.1
-  resolution: "vega-runtime@npm:6.2.1"
+"vega-runtime@npm:^6.2.0, vega-runtime@npm:~6.2.0":
+  version: 6.2.0
+  resolution: "vega-runtime@npm:6.2.0"
   dependencies:
-    vega-dataflow: "npm:^5.7.7"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/5f197fa3aac635381139168434590b211eb39d2bdb1897434959abc823c85f66dfeec102500ff3e76284ac9fdad5bc08e65655e2bbaa53b004d773705d83670a
+    vega-dataflow: "npm:^5.7.6"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/8ad4b406120acd481e5bc53f0cff72501cf9c3db2acb467735ee66e99550e535497a10abb1c82186d2e9a13bf5602efee68632d6a78f7b504110f70d261d4993
   languageName: node
   linkType: hard
 
-"vega-scale@npm:^7.4.2, vega-scale@npm:~7.4.2":
-  version: 7.4.2
-  resolution: "vega-scale@npm:7.4.2"
+"vega-scale@npm:^7.4.1, vega-scale@npm:~7.4.1":
+  version: 7.4.1
+  resolution: "vega-scale@npm:7.4.1"
   dependencies:
     d3-array: "npm:^3.2.2"
     d3-interpolate: "npm:^3.0.1"
     d3-scale: "npm:^4.0.2"
     d3-scale-chromatic: "npm:^3.1.0"
-    vega-time: "npm:^2.1.3"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/ea684565bebfef3ecbeb321b9cce6257eecd09f054f2af7215122aaeea1f9483ca8549814ecc4afd471d7140ea66931af9da14fc17a6d5a988d7b2f86019c229
+    vega-time: "npm:^2.1.2"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/5911c62c601ad9e3ac890141941fd6166dea247acf03fa685053e7de3fe4b754a4c15fd86b99ee8fed85eae6d87208e97d8d658b94d6b79f30f57e174671655b
   languageName: node
   linkType: hard
 
-"vega-scenegraph@npm:^4.13.1, vega-scenegraph@npm:~4.13.1":
-  version: 4.13.1
-  resolution: "vega-scenegraph@npm:4.13.1"
+"vega-scenegraph@npm:^4.13.0, vega-scenegraph@npm:~4.13.0":
+  version: 4.13.0
+  resolution: "vega-scenegraph@npm:4.13.0"
   dependencies:
     d3-path: "npm:^3.1.0"
     d3-shape: "npm:^3.2.0"
     vega-canvas: "npm:^1.2.7"
-    vega-loader: "npm:^4.5.3"
-    vega-scale: "npm:^7.4.2"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/d84c3b719cd17d11e334d1c28580be3f184842f8ff9cd5fb0442c76fa7adc6d6ffd3edafd2f218f29990b69be79dbcf9e9c2d6b2d98afbe11f5d89fa2e285bb2
+    vega-loader: "npm:^4.5.2"
+    vega-scale: "npm:^7.4.1"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/fc51cfca7b0fbad61fbdc3de4be6e39755322c889f4a1b0c4684b154639bd7fe0174b88d62ac1fade3b22014452c7595fac6a335182c88c62f73dfc15e324b37
   languageName: node
   linkType: hard
 
@@ -29334,14 +29324,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega-selections@npm:^5.6.0":
-  version: 5.6.0
-  resolution: "vega-selections@npm:5.6.0"
+"vega-selections@npm:^5.4.2":
+  version: 5.4.2
+  resolution: "vega-selections@npm:5.4.2"
   dependencies:
     d3-array: "npm:3.2.4"
-    vega-expression: "npm:^5.2.0"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/285b108f67185480f6de4c39e2eeca51f28995ed83bf02da617bff83682ac007bf3bea933fa5df411bbc4254e5dd5466f177817066b925f56e89ddbbd6ad97e6
+    vega-expression: "npm:^5.0.1"
+    vega-util: "npm:^1.17.1"
+  checksum: 10c0/32085d122e0f828d2e566ecf2aab307e1430bbe69654f93d5d20c7b83c9be128254e43f3aba577c2d191a4793947ed6400214b74215e640f10f8e16d56fe10c3
   languageName: node
   linkType: hard
 
@@ -29364,14 +29354,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega-time@npm:^2.1.3, vega-time@npm:~2.1.3":
-  version: 2.1.3
-  resolution: "vega-time@npm:2.1.3"
+"vega-time@npm:^2.1.2, vega-time@npm:~2.1.2":
+  version: 2.1.2
+  resolution: "vega-time@npm:2.1.2"
   dependencies:
     d3-array: "npm:^3.2.2"
     d3-time: "npm:^3.1.0"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/c17f20412b86a190ce099d4966d1e994beebb54a3c1b02688a4cc55565eb77806badf8054637f7f6530c104e548154a547a90f96d1ce1158303f4b935afed19c
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/c2b11eabdd0cfbb9a95bbdf7b8d37ec6c4e114be91dc79d643212e4a635bac7964b77d1226bf0575cdb168bc78963123c26ab9237da1f8208d1c491a3f1ab495
   languageName: node
   linkType: hard
 
@@ -29384,128 +29374,121 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega-transforms@npm:~4.12.1":
-  version: 4.12.1
-  resolution: "vega-transforms@npm:4.12.1"
+"vega-transforms@npm:~4.12.0":
+  version: 4.12.0
+  resolution: "vega-transforms@npm:4.12.0"
   dependencies:
     d3-array: "npm:^3.2.2"
-    vega-dataflow: "npm:^5.7.7"
+    vega-dataflow: "npm:^5.7.6"
     vega-statistics: "npm:^1.9.0"
-    vega-time: "npm:^2.1.3"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/1f6d383c9a9ca99b784bff30d5e698259ee5562700f3c84260a0fc14db0d6cdab5f07eb6dd8ad35444d34d76343a7851a258d6af0b1230d5a1ca2e9f434063c0
+    vega-time: "npm:^2.1.2"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/fd68ccd6af8544109c311368db831835d08e274a1dc646fe8482954bc45b0b7a6fdc7b9b742e9f4e08527c92fe0726527f8c8a0e3b0ca9a3a0ca64fb7bdd9943
   languageName: node
   linkType: hard
 
-"vega-typings@npm:~1.5.0":
-  version: 1.5.0
-  resolution: "vega-typings@npm:1.5.0"
+"vega-typings@npm:~1.3.1":
+  version: 1.3.1
+  resolution: "vega-typings@npm:1.3.1"
   dependencies:
     "@types/geojson": "npm:7946.0.4"
     vega-event-selector: "npm:^3.0.1"
-    vega-expression: "npm:^5.2.0"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/488ffc29a0d170e13186e17a9c6c4d4e5fb2433b2196401049ceebc799424e5f979b195615e8155eb389567bd2a6d493d2116ac64c0a0f61c02707ef1f16fe6d
+    vega-expression: "npm:^5.1.1"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/2fae89cfa64bbecf8cedd7e27ef34dc25ba0f5f380773f511c76f4b408786f095edc64f905aeb5c1e2d757878adeb6382b3a9817c4ec777bcc401554c926a2ad
   languageName: node
   linkType: hard
 
-"vega-util@npm:^1.17.2, vega-util@npm:~1.17.2":
+"vega-util@npm:^1.17.1, vega-util@npm:^1.17.2, vega-util@npm:~1.17.2":
   version: 1.17.2
   resolution: "vega-util@npm:1.17.2"
   checksum: 10c0/a1ebf62234dbb0d0ecc5d01b9016f6ed9f40e77bac93ea0213dd24299fe0e2c80d33418f4c4c703532c380eb4f16d0f4df7028ec9249f3f0741ec8271c190b2e
   languageName: node
   linkType: hard
 
-"vega-util@npm:^1.17.3":
-  version: 1.17.3
-  resolution: "vega-util@npm:1.17.3"
-  checksum: 10c0/10fd9d80ef09914dbb6538c0205e98bb7bf2eb21debb33c5f103a637377b6fdfd6bd7d2148cec4755050e3c802b805bec865ad3eb28068fd4dee76ef33d35a08
-  languageName: node
-  linkType: hard
-
-"vega-view-transforms@npm:~4.6.1":
-  version: 4.6.1
-  resolution: "vega-view-transforms@npm:4.6.1"
+"vega-view-transforms@npm:~4.6.0":
+  version: 4.6.0
+  resolution: "vega-view-transforms@npm:4.6.0"
   dependencies:
-    vega-dataflow: "npm:^5.7.7"
-    vega-scenegraph: "npm:^4.13.1"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/657cc78fc65e18b6b746306813e02f20778441c439331815ed28190701366d3681dd673ed9fc9f74ff5045e105ece773d41c3c8bf115f1fc4f06abd3a65d7cb4
+    vega-dataflow: "npm:^5.7.6"
+    vega-scenegraph: "npm:^4.13.0"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/fc719b4302f53dfea69e780a9931ed6a347ead7e2e1cf676366628c02a0dfd52eab123e861053b4b63cb1ee5f515175d26e81184a43eb24601676d8bb6b7687e
   languageName: node
   linkType: hard
 
-"vega-view@npm:~5.16.0":
-  version: 5.16.0
-  resolution: "vega-view@npm:5.16.0"
+"vega-view@npm:~5.13.0":
+  version: 5.13.0
+  resolution: "vega-view@npm:5.13.0"
   dependencies:
     d3-array: "npm:^3.2.2"
     d3-timer: "npm:^3.0.1"
-    vega-dataflow: "npm:^5.7.7"
-    vega-format: "npm:^1.1.3"
-    vega-functions: "npm:^5.18.0"
-    vega-runtime: "npm:^6.2.1"
-    vega-scenegraph: "npm:^4.13.1"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/9944fb1bd277c67e6509f0c8e1a9f4a631367537ed3566b4cddf86a8a3e6973079e82c47dc8e1ee5b463a97f9b8fc912c276ad2b17319f5bdc087da837b8f312
+    vega-dataflow: "npm:^5.7.6"
+    vega-format: "npm:^1.1.2"
+    vega-functions: "npm:^5.15.0"
+    vega-runtime: "npm:^6.2.0"
+    vega-scenegraph: "npm:^4.13.0"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/25aaabc1b094676502ad8b634d01c7b7e12ca4998fad4c54d663fd0dee9025cb80b0b4acca1c1310b7851eb9790be4c4a120161a461440b70c448ce92b573487
   languageName: node
   linkType: hard
 
-"vega-voronoi@npm:~4.2.4":
-  version: 4.2.4
-  resolution: "vega-voronoi@npm:4.2.4"
+"vega-voronoi@npm:~4.2.3":
+  version: 4.2.3
+  resolution: "vega-voronoi@npm:4.2.3"
   dependencies:
     d3-delaunay: "npm:^6.0.2"
-    vega-dataflow: "npm:^5.7.7"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/2cb4cb7682cb7ff88015220a60da261d380116a2aae19e8ab8350a7f19b3ee6412bb961dc2044d2836ce3254bc15d61f893eeb8e1a2085a41983edd30fee8189
+    vega-dataflow: "npm:^5.7.6"
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/632f6dd2fc901c81d08452d6a3019e806b602895bd8080466f3157108c49229d6222842885cee6500949fb4d23284103786199a1598e3653f7320ea5af9a9d30
   languageName: node
   linkType: hard
 
-"vega-wordcloud@npm:~4.1.6":
-  version: 4.1.6
-  resolution: "vega-wordcloud@npm:4.1.6"
+"vega-wordcloud@npm:~4.1.5":
+  version: 4.1.5
+  resolution: "vega-wordcloud@npm:4.1.5"
   dependencies:
     vega-canvas: "npm:^1.2.7"
-    vega-dataflow: "npm:^5.7.7"
-    vega-scale: "npm:^7.4.2"
+    vega-dataflow: "npm:^5.7.6"
+    vega-scale: "npm:^7.4.1"
     vega-statistics: "npm:^1.9.0"
-    vega-util: "npm:^1.17.3"
-  checksum: 10c0/71254e7937e53e646cb93e6388f424d7629de1c2c0efaaf1d856b33202b5377e9db5a95363cd178b95ef4b2fa7dd54e4a87cf79c99e56e25dfbb546c23272eaa
+    vega-util: "npm:^1.17.2"
+  checksum: 10c0/13592bb8448965253e075d39762062235ab91e56045fff2a03974d4df5208f215fd341fd36be093debb65ed4b263396cca60f5d84c1a33a854ad0967400b7274
   languageName: node
   linkType: hard
 
 "vega@npm:^5.28.0":
-  version: 5.33.0
-  resolution: "vega@npm:5.33.0"
+  version: 5.30.0
+  resolution: "vega@npm:5.30.0"
   dependencies:
-    vega-crossfilter: "npm:~4.1.3"
-    vega-dataflow: "npm:~5.7.7"
-    vega-encode: "npm:~4.10.2"
+    vega-crossfilter: "npm:~4.1.2"
+    vega-dataflow: "npm:~5.7.6"
+    vega-encode: "npm:~4.10.1"
     vega-event-selector: "npm:~3.0.1"
-    vega-expression: "npm:~5.2.0"
-    vega-force: "npm:~4.2.2"
-    vega-format: "npm:~1.1.3"
-    vega-functions: "npm:~5.18.0"
-    vega-geo: "npm:~4.4.3"
-    vega-hierarchy: "npm:~4.1.3"
-    vega-label: "npm:~1.3.1"
-    vega-loader: "npm:~4.5.3"
-    vega-parser: "npm:~6.6.0"
-    vega-projection: "npm:~1.6.2"
-    vega-regression: "npm:~1.3.1"
-    vega-runtime: "npm:~6.2.1"
-    vega-scale: "npm:~7.4.2"
-    vega-scenegraph: "npm:~4.13.1"
+    vega-expression: "npm:~5.1.1"
+    vega-force: "npm:~4.2.1"
+    vega-format: "npm:~1.1.2"
+    vega-functions: "npm:~5.15.0"
+    vega-geo: "npm:~4.4.2"
+    vega-hierarchy: "npm:~4.1.2"
+    vega-label: "npm:~1.3.0"
+    vega-loader: "npm:~4.5.2"
+    vega-parser: "npm:~6.4.0"
+    vega-projection: "npm:~1.6.1"
+    vega-regression: "npm:~1.3.0"
+    vega-runtime: "npm:~6.2.0"
+    vega-scale: "npm:~7.4.1"
+    vega-scenegraph: "npm:~4.13.0"
     vega-statistics: "npm:~1.9.0"
-    vega-time: "npm:~2.1.3"
-    vega-transforms: "npm:~4.12.1"
-    vega-typings: "npm:~1.5.0"
+    vega-time: "npm:~2.1.2"
+    vega-transforms: "npm:~4.12.0"
+    vega-typings: "npm:~1.3.1"
     vega-util: "npm:~1.17.2"
-    vega-view: "npm:~5.16.0"
-    vega-view-transforms: "npm:~4.6.1"
-    vega-voronoi: "npm:~4.2.4"
-    vega-wordcloud: "npm:~4.1.6"
-  checksum: 10c0/4229162cdfe0649b75118424a87d3ec36314ec396ae440ccf44fd8e1fb72ce463697e84d1784d13809b5b13bbcfa3125f13cec2eab6ac00a19f5551baa84b218
+    vega-view: "npm:~5.13.0"
+    vega-view-transforms: "npm:~4.6.0"
+    vega-voronoi: "npm:~4.2.3"
+    vega-wordcloud: "npm:~4.1.5"
+  checksum: 10c0/3f149b23f94c1be7f511e76d42d888dd4dd9ad26fe236768088cbe8ad69ee3f9f8eb69d5c009ca03e982adc597395dfea1157eb90359324f733249c37ecf18ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts carbon-design-system/carbon-labs#573

Looks like web components builds started failing after this update, reverting.