### PR TITLE
fix: add breakpoint utility for responsive side-nav rail

### DIFF
--- a/examples/react/UIShell/src/App.tsx
+++ b/examples/react/UIShell/src/App.tsx
@@ -314,7 +314,7 @@ function App() {
             </SideNavItems>
           </SideNav>
           <SideNav
-            hideOnBreakpoint="sm"
+            hideRailBreakpointDown="md"
             isRail
             isChildOfHeader={false}
             aria-label="Side navigation">

--- a/examples/react/UIShell/src/App.tsx
+++ b/examples/react/UIShell/src/App.tsx
@@ -313,7 +313,11 @@ function App() {
               </SideNavMenu>
             </SideNavItems>
           </SideNav>
-          <SideNav isRail isChildOfHeader={false} aria-label="Side navigation">
+          <SideNav
+            hideOnBreakpoint="sm"
+            isRail
+            isChildOfHeader={false}
+            aria-label="Side navigation">
             <SideNavItems>
               <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
                 <SideNavMenuItem href="#">Item level 2</SideNavMenuItem>

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -402,6 +402,7 @@ export const Default = () => {
             </SideNavItems>
           </SideNav>
           <SideNav
+            hideOnBreakpoint="sm"
             isChildOfHeader={false}
             isRail
             aria-label="Product navigation">

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -402,7 +402,7 @@ export const Default = () => {
             </SideNavItems>
           </SideNav>
           <SideNav
-            hideOnBreakpoint="sm"
+            hideRailBreakpointDown="md"
             isChildOfHeader={false}
             isRail
             aria-label="Product navigation">

--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -62,6 +62,7 @@ export interface SideNavProps
     event: FocusEvent<HTMLElement> | KeyboardEvent<HTMLElement> | boolean,
     value: boolean
   ) => void;
+  hideOnBreakpoint?: 'sm' | 'md' | 'lg' | 'xlg' | 'max';
   href?: string;
   isFixedNav?: boolean;
   isRail?: boolean;
@@ -100,6 +101,7 @@ function SideNavRenderFunction(
     children,
     onToggle,
     className: customClassName,
+    hideOnBreakpoint,
     href,
     isFixedNav = false,
     isRail,
@@ -155,6 +157,7 @@ function SideNavRenderFunction(
     [`${prefix}--side-nav`]: true,
     [`${prefix}--side-nav--expanded`]: expanded || expandedViaHoverState,
     [`${prefix}--side-nav--collapsed`]: !expanded && isFixedNav,
+    [`${prefix}--side-nav--hide-on-${hideOnBreakpoint}`]: hideOnBreakpoint,
     [`${prefix}--side-nav--rail`]: isRail,
     [`${prefix}--side-nav--panel`]: navType === SIDE_NAV_TYPE.PANEL,
     [`${prefix}--side-nav--ux`]: isChildOfHeader,
@@ -598,6 +601,12 @@ SideNav.propTypes = {
    * Using this prop causes SideNav to become a controled component.
    */
   expanded: PropTypes.bool,
+
+  /**
+   * Specify the breakpoint at which the SideNav will be hidden.
+   * Can be one of `sm`, `md`, `lg`, `xlg`, or `max`.
+   */
+  hideOnBreakpoint: PropTypes.oneOf(['sm', 'md', 'lg', 'xlg', 'max']),
 
   /**
    * If `true`, the overlay will be hidden. Defaults to `false`.

--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -605,6 +605,7 @@ SideNav.propTypes = {
   /**
    * Specify the breakpoint at which the SideNav will be hidden.
    * Can be one of `sm`, `md`, `lg`, `xlg`, or `max`.
+   * Only applies when `isRail` is `true`.
    */
   hideOnBreakpoint: PropTypes.oneOf(['sm', 'md', 'lg', 'xlg', 'max']),
 

--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -62,7 +62,7 @@ export interface SideNavProps
     event: FocusEvent<HTMLElement> | KeyboardEvent<HTMLElement> | boolean,
     value: boolean
   ) => void;
-  hideOnBreakpoint?: 'sm' | 'md' | 'lg' | 'xlg' | 'max';
+  hideRailBreakpointDown?: 'sm' | 'md' | 'lg' | 'xlg' | 'max';
   href?: string;
   isFixedNav?: boolean;
   isRail?: boolean;
@@ -101,7 +101,7 @@ function SideNavRenderFunction(
     children,
     onToggle,
     className: customClassName,
-    hideOnBreakpoint,
+    hideRailBreakpointDown,
     href,
     isFixedNav = false,
     isRail,
@@ -157,7 +157,8 @@ function SideNavRenderFunction(
     [`${prefix}--side-nav`]: true,
     [`${prefix}--side-nav--expanded`]: expanded || expandedViaHoverState,
     [`${prefix}--side-nav--collapsed`]: !expanded && isFixedNav,
-    [`${prefix}--side-nav--hide-on-${hideOnBreakpoint}`]: hideOnBreakpoint,
+    [`${prefix}--side-nav--hide-rail-breakpoint-down-${hideRailBreakpointDown}`]:
+      hideRailBreakpointDown,
     [`${prefix}--side-nav--rail`]: isRail,
     [`${prefix}--side-nav--panel`]: navType === SIDE_NAV_TYPE.PANEL,
     [`${prefix}--side-nav--ux`]: isChildOfHeader,
@@ -603,16 +604,16 @@ SideNav.propTypes = {
   expanded: PropTypes.bool,
 
   /**
+   * If `true`, the overlay will be hidden. Defaults to `false`.
+   */
+  hideOverlay: PropTypes.bool,
+
+  /**
    * Specify the breakpoint at which the SideNav will be hidden.
    * Can be one of `sm`, `md`, `lg`, `xlg`, or `max`.
    * Only applies when `isRail` is `true`.
    */
-  hideOnBreakpoint: PropTypes.oneOf(['sm', 'md', 'lg', 'xlg', 'max']),
-
-  /**
-   * If `true`, the overlay will be hidden. Defaults to `false`.
-   */
-  hideOverlay: PropTypes.bool,
+  hideRailBreakpointDown: PropTypes.oneOf(['sm', 'md', 'lg', 'xlg', 'max']),
 
   /**
    * Provide the `href` to the id of the element on your package that is the

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/utilities/custom-property' as custom-property;
 @use '@carbon/styles/scss/utilities/button-reset' as button-reset;
 @use '@carbon/styles/scss/utilities/focus-outline' as *;
+@use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/type' as *;
@@ -352,6 +353,10 @@ div:has(.#{$prefix}--header)
 //----------------------------------------------------------------------------
 .#{$prefix}--side-nav--rail {
   z-index: 7999; /* needs to be below header */
+
+  @include breakpoint-down('lg') {
+    display: none;
+  }
 }
 
 // allow overlay to display at all breakpoints

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -353,9 +353,13 @@ div:has(.#{$prefix}--header)
 //----------------------------------------------------------------------------
 .#{$prefix}--side-nav--rail {
   z-index: 7999; /* needs to be below header */
+}
 
-  @include breakpoint-down('md') {
-    display: none;
+@each $breakpoint in ('sm', 'md', 'lg', 'xlg', 'max') {
+  .#{$prefix}--side-nav--rail.#{$prefix}--side-nav--hide-on-#{$breakpoint} {
+    @include breakpoint-down($breakpoint) {
+      display: none;
+    }
   }
 }
 

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -354,7 +354,7 @@ div:has(.#{$prefix}--header)
 .#{$prefix}--side-nav--rail {
   z-index: 7999; /* needs to be below header */
 
-  @include breakpoint-down('lg') {
+  @include breakpoint-down('md') {
     display: none;
   }
 }

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -356,7 +356,7 @@ div:has(.#{$prefix}--header)
 }
 
 @each $breakpoint in ('sm', 'md', 'lg', 'xlg', 'max') {
-  .#{$prefix}--side-nav--rail.#{$prefix}--side-nav--hide-on-#{$breakpoint} {
+  .#{$prefix}--side-nav--rail.#{$prefix}--side-nav--hide-rail-breakpoint-down-#{$breakpoint} {
     @include breakpoint-down($breakpoint) {
       display: none;
     }


### PR DESCRIPTION
Related #618

this PR adds a media query to hide the side navigation rail on smaller screens

#### Changelog

**Changed**

- sidenav rail styles

#### Testing / Reviewing

confirm that the local sidenav rail is not visible at smaller screen sizes