### PR TITLE
feat(uishell): add new SideNavSlot component and rail updates

### DIFF
--- a/examples/react/UIShell/src/App.tsx
+++ b/examples/react/UIShell/src/App.tsx
@@ -21,6 +21,7 @@ import {
   HeaderPopoverButton,
   HeaderPopoverContent,
   TrialCountdown,
+  SideNavSlot,
 } from '@carbon-labs/react-ui-shell';
 import {
   SkipToContent,
@@ -38,6 +39,7 @@ import {
   ExpandableSearch,
   Link,
   Button,
+  Dropdown,
 } from '@carbon/react';
 import {
   Fade,
@@ -49,6 +51,7 @@ import {
   User,
   ShoppingCart,
   Switcher,
+  Menu,
 } from '@carbon/icons-react';
 
 const StoryContent = () => (
@@ -276,6 +279,21 @@ function App() {
                 renderIcon={SquareOutline}
                 title="Sub-menu level 1"
                 primary>
+                <SideNavSlot renderIcon={Fade}>
+                  <Dropdown
+                    aria-label="Choose an option"
+                    id="default"
+                    size="sm"
+                    itemToString={(item) => (item ? item.text : '')}
+                    items={[
+                      { text: 'Option 1' },
+                      { text: 'Option 2' },
+                      { text: 'Option 3' },
+                    ]}
+                    label="Choose an option"
+                  />
+                </SideNavSlot>
+                <SideNavDivider />
                 <SideNavMenuItem renderIcon={SquareOutline} href="#">
                   Item level 2
                 </SideNavMenuItem>
@@ -322,6 +340,23 @@ function App() {
             isChildOfHeader={false}
             aria-label="Side navigation">
             <SideNavItems>
+              <SideNavSlot renderIcon={Menu}>
+                <Menu />
+              </SideNavSlot>
+              <SideNavSlot renderIcon={VirtuFadelColumnKey}>
+                <Dropdown
+                  id="default"
+                  size="sm"
+                  itemToString={(item) => (item ? item.text : '')}
+                  items={[
+                    { text: 'Option 1' },
+                    { text: 'Option 2' },
+                    { text: 'Option 3' },
+                  ]}
+                  label="Choose an option"
+                />
+              </SideNavSlot>
+              <SideNavDivider />
               <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
                 <SideNavMenuItem href="#">Item level 2</SideNavMenuItem>
                 <SideNavMenuItem href="#">Item level 2</SideNavMenuItem>

--- a/packages/react/src/components/UIShell/README.md
+++ b/packages/react/src/components/UIShell/README.md
@@ -29,17 +29,19 @@ To use this package you will need to import components from both `@carbon/react`
 and `@carbon-labs/react-ui-shell` to compose the UI Shell. The following
 components are provided by `@carbon-labs/react-ui-shell`:
 
+- `HeaderDivider`
+- `HeaderPanel`
+- `HeaderPopover`
+- `HeaderPopoverActions`
+- `HeaderPopoverButton`
+- `HeaderPopoverContent`
 - `SideNav`
 - `SideNavItems`
 - `SideNavLink`
 - `SideNavMenu`
 - `SideNavMenuItem`
-- `HeaderPopover`
-- `HeaderPopoverActions`
-- `HeaderPopoverButton`
-- `HeaderPopoverContent`
-- `HeaderDivider`
-- `SharkFinIcon`
+- `SideNavSlot`
+- `TrialCountdown`
 
 ```jsx
 import { SideNav } from '@carbon-labs/react-ui-shell';

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -187,9 +187,7 @@ element and accepts `children` to display a custom component inside the side
 navigation. An optional `renderIcon` prop allows you to specify an icon that
 displays when the navigation is in rail mode (`isRail`) and collapsed.
 
-#### Example
-
-````jsx
+```jsx
 <SideNavItems>
   <SideNavSlot renderIcon={SearchIcon}>
     <Search
@@ -201,7 +199,6 @@ displays when the navigation is in rail mode (`isRail`) and collapsed.
   </SideNavSlot>
 </SideNavItems>
 ```
-
 
 ### Treeview
 
@@ -255,7 +252,7 @@ function App() {
 }
 
 export default App;
-````
+```
 
 ## Component API
 

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -46,7 +46,6 @@ components are provided by `@carbon-labs/react-ui-shell`:
 - `HeaderPopoverActions`
 - `HeaderPopoverButton`
 - `HeaderPopoverContent`
-- `SharkFinIcon`
 - `SideNav`
 - `SideNavItems`
 - `SideNavLink`

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -186,9 +186,6 @@ export default App;
 element and accepts `children` to display a custom component inside the side
 navigation.
 
-This is useful for rendering elements like a `Search` (for filtering) or a
-`Menu`.
-
 An optional `renderIcon` prop allows you to specify an icon that displays when
 the navigation is in rail mode (`isRail`) and collapsed.
 

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -28,7 +28,7 @@ example implementation.
   - [JS](#js-imports)
 - [Examples](#examples)
   - [Header popover](#header-popover)
-  - [Panel navigation type](#panel-navigation-type)
+  - [SideNavSlot](#sidenavslot)
   - [Treeview](#treeview)
 - [Component API](#component-api)
 
@@ -180,44 +180,32 @@ function App() {
 export default App;
 ```
 
-### Panel navigation type
+### `SideNavSlot`
 
-When using `navType="panel"` and a `SideNavMenu` component, when the `SideNav`
-is in its collapsed state, the menu's icon on the side panel will link to its
-first link automatically. Upon `SideNav` expansion, this functionality will be
-disabled, and click events will be reverted, meaning a click will expand the
-`SideNavMenu` as usual.
+`SideNavSlot` is a child component of `SideNavItems`. It renders a `<li>`
+element and accepts `children` to display a custom component inside the side
+navigation.
 
-```jsx
-import {
-  SIDE_NAV_TYPE,
-  SideNav,
-  SideNavItems,
-  SideNavMenu,
-  SideNavMenuItem,
-} from '@carbon-labs/react-ui-shell';
-import { Fade } from '@carbon/icons-react';
+This is useful for rendering elements like a `Search` (for filtering) or a
+`Menu`.
 
-function App() {
-  return (
-    <SideNav
-      navType={SIDE_NAV_TYPE.PANEL}
-      isChildOfHeader={false}
-      hideOverlay
-      aria-label="Product navigation">
-      <SideNavItems>
-        <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
-          <SideNavMenuItem href="#">Link 1</SideNavMenuItem>
-          <SideNavMenuItem href="#">Link 2</SideNavMenuItem>
-          <SideNavMenuItem href="#">Link 3</SideNavMenuItem>
-        </SideNavMenu>
-      </SideNavItems>
-    </SideNav>
-  );
-}
+An optional `renderIcon` prop allows you to specify an icon that displays when
+the navigation is in rail mode (`isRail`) and collapsed.
 
-export default App;
-```
+#### Example
+
+````jsx
+<SideNavItems>
+  <SideNavSlot renderIcon={SearchIcon}>
+    <Search
+      size="sm"
+      placeholder="Filter"
+      closeButtonLabelText="Clear input"
+      id="filter-1"
+    />
+  </SideNavSlot>
+</SideNavItems>
+
 
 ### Treeview
 
@@ -271,7 +259,7 @@ function App() {
 }
 
 export default App;
-```
+````
 
 ## Component API
 

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -92,7 +92,6 @@ along with any icons needed from `@carbon/icons-react` to build your UI Shell.
 
 ```javascript
 import {
-  SIDE_NAV_TYPE,
   SideNav,
   SideNavItems,
   SideNavMenu,
@@ -211,7 +210,6 @@ levels of content within the component.
 
 ```jsx
 import {
-  SIDE_NAV_TYPE,
   SideNav,
   SideNavItems,
   SideNavLink,

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -184,10 +184,8 @@ export default App;
 
 `SideNavSlot` is a child component of `SideNavItems`. It renders a `<li>`
 element and accepts `children` to display a custom component inside the side
-navigation.
-
-An optional `renderIcon` prop allows you to specify an icon that displays when
-the navigation is in rail mode (`isRail`) and collapsed.
+navigation. An optional `renderIcon` prop allows you to specify an icon that
+displays when the navigation is in rail mode (`isRail`) and collapsed.
 
 #### Example
 
@@ -202,6 +200,7 @@ the navigation is in rail mode (`isRail`) and collapsed.
     />
   </SideNavSlot>
 </SideNavItems>
+```
 
 
 ### Treeview

--- a/packages/react/src/components/UIShell/__stories__/UIShell.mdx
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.mdx
@@ -40,18 +40,19 @@ To use this package you will need to import components from both `@carbon/react`
 and `@carbon-labs/react-ui-shell` to compose the UI Shell. The following
 components are provided by `@carbon-labs/react-ui-shell`:
 
+- `HeaderDivider`
+- `HeaderPanel`
+- `HeaderPopover`
+- `HeaderPopoverActions`
+- `HeaderPopoverButton`
+- `HeaderPopoverContent`
+- `SharkFinIcon`
 - `SideNav`
 - `SideNavItems`
 - `SideNavLink`
 - `SideNavMenu`
 - `SideNavMenuItem`
-- `HeaderPopover`
-- `HeaderPopoverActions`
-- `HeaderPopoverButton`
-- `HeaderPopoverContent`
-- `HeaderPanel`
-- `HeaderDivider`
-- `SharkFinIcon`
+- `SideNavSlot`
 - `TrialCountdown`
 
 <Canvas of={UIShellStories.Default} />

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -340,6 +340,7 @@ export const Default = () => {
                 defaultExpanded>
                 <SideNavSlot renderIcon={VirtualColumnKey}>
                   <Dropdown
+                    aria-label="Choose an option"
                     id="default"
                     size="sm"
                     itemToString={(item) => (item ? item.text : '')}
@@ -677,6 +678,21 @@ export const SideNavDoubleWideStory = () => (
         title="Sub-menu level 1"
         primary
         defaultExpanded>
+        <SideNavSlot>
+          <Dropdown
+            aria-label="Choose an option"
+            id="default"
+            size="sm"
+            itemToString={(item) => (item ? item.text : '')}
+            items={[
+              { text: 'Option 1' },
+              { text: 'Option 2' },
+              { text: 'Option 3' },
+            ]}
+            label="Choose an option"
+          />
+        </SideNavSlot>
+        <SideNavDivider />
         <SideNavMenu renderIcon={Fade} title="Sub-menu level 2">
           <SideNavMenuItem href="http://www.carbondesignsystem.com">
             Item level 3
@@ -813,6 +829,7 @@ export const SideNavRail = () => (
     <SideNavItems>
       <SideNavSlot renderIcon={VirtualColumnKey}>
         <Dropdown
+          aria-label="Choose an option"
           id="default"
           size="sm"
           itemToString={(item) => (item ? item.text : '')}

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -41,7 +41,7 @@ import {
   Link,
   Button,
   Search,
-  MenuItem,
+  Dropdown,
 } from '@carbon/react';
 import {
   Add,
@@ -68,6 +68,7 @@ import {
   Share,
   User,
   Search as SearchIcon,
+  VirtualColumnKey,
 } from '@carbon/icons-react';
 
 import {
@@ -511,7 +512,7 @@ export const SideNavStory = () => (
     isChildOfHeader={false}
     aria-label="Side navigation">
     <SideNavItems>
-      <SideNavSlot>
+      <SideNavSlot renderIcon={SearchIcon}>
         <Search
           size="sm"
           placeholder="Filter"
@@ -520,14 +521,20 @@ export const SideNavStory = () => (
         />
       </SideNavSlot>
       <SideNavDivider />
-      {/* <SideNavSlot>
-        <MenuButton size="sm" kind="tertiary" label="Menu button">
-          <MenuItem label="First action" />
-          <MenuItem label="Second action" />
-          <MenuItem label="Third action" />
-        </MenuButton>
+      <SideNavSlot renderIcon={VirtualColumnKey}>
+        <Dropdown
+          id="default"
+          size="sm"
+          itemToString={(item) => (item ? item.text : '')}
+          items={[
+            { text: 'Option 1' },
+            { text: 'Option 2' },
+            { text: 'Option 3' },
+          ]}
+          label="Dropdown"
+        />
       </SideNavSlot>
-      <SideNavDivider /> */}
+      <SideNavDivider />
       <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
         <SideNavMenuItem href="http://www.carbondesignsystem.com">
           Link
@@ -682,6 +689,20 @@ export const SideNavRail = () => (
           placeholder="Filter"
           closeButtonLabelText="Clear input"
           id="filter-1"
+        />
+      </SideNavSlot>
+      <SideNavDivider />
+      <SideNavSlot renderIcon={VirtualColumnKey}>
+        <Dropdown
+          id="default"
+          size="sm"
+          itemToString={(item) => (item ? item.text : '')}
+          items={[
+            { text: 'Option 1' },
+            { text: 'Option 2' },
+            { text: 'Option 3' },
+          ]}
+          label="Dropdown"
         />
       </SideNavSlot>
       <SideNavDivider />

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -9,7 +9,7 @@
 
 import React, { useState, useRef } from 'react';
 import mdx from './UIShell.mdx';
-import { SIDE_NAV_TYPE, SideNav } from '../components/SideNav';
+import { SideNav } from '../components/SideNav';
 import { SideNavItems } from '../components/SideNavItems';
 import { SideNavMenu } from '../components/SideNavMenu';
 import { SideNavMenuItem } from '../components/SideNavMenuItem';

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -14,6 +14,7 @@ import { SideNavItems } from '../components/SideNavItems';
 import { SideNavMenu } from '../components/SideNavMenu';
 import { SideNavMenuItem } from '../components/SideNavMenuItem';
 import { SideNavLink } from '../components/SideNavLink';
+import { SideNavSlot } from '../components/SideNavSlot';
 import {
   HeaderPopover,
   HeaderPopoverActions,
@@ -39,6 +40,7 @@ import {
   ExpandableSearch,
   Link,
   Button,
+  Search,
 } from '@carbon/react';
 import {
   Add,
@@ -64,6 +66,7 @@ import {
   ShoppingCart,
   Share,
   User,
+  Search as SearchIcon,
 } from '@carbon/icons-react';
 
 import {
@@ -506,6 +509,15 @@ export const SideNavStory = () => (
     isChildOfHeader={false}
     aria-label="Side navigation">
     <SideNavItems>
+      <SideNavSlot>
+        <Search
+          size="sm"
+          placeholder="Filter"
+          closeButtonLabelText="Clear input"
+          id="filter-1"
+        />
+      </SideNavSlot>
+      <SideNavDivider />
       <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
         <SideNavMenuItem href="http://www.carbondesignsystem.com">
           Link
@@ -654,6 +666,15 @@ export const SideNavRail = () => (
     isChildOfHeader={false}
     aria-label="Product navigation">
     <SideNavItems>
+      <SideNavSlot renderIcon={SearchIcon}>
+        <Search
+          size="sm"
+          placeholder="Filter"
+          closeButtonLabelText="Clear input"
+          id="filter-1"
+        />
+      </SideNavSlot>
+      <SideNavDivider />
       <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
         <SideNavMenuItem href="http://www.carbondesignsystem.com">
           Item level 2
@@ -720,120 +741,6 @@ export const SideNavRail = () => (
       </SideNavLink>
     </SideNavItems>
   </SideNav>
-);
-
-/**
- * Story for SideNav panel
- * @returns {React.ReactElement} The JSX for the story
- */
-export const SideNavPanel = () => (
-  <>
-    <SideNav
-      navType={SIDE_NAV_TYPE.PANEL}
-      isChildOfHeader={false}
-      hideOverlay
-      aria-label="Product navigation">
-      <SideNavItems>
-        <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-        </SideNavMenu>
-        <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-        </SideNavMenu>
-        <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-        </SideNavMenu>
-        <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-          <SideNavMenuItem href="http://www.carbondesignsystem.com">
-            Item level 2
-          </SideNavMenuItem>
-        </SideNavMenu>
-        <SideNavDivider />
-        <SideNavLink renderIcon={Fade} href="http://www.carbondesignsystem.com">
-          Link
-        </SideNavLink>
-        <SideNavLink renderIcon={Fade} href="http://www.carbondesignsystem.com">
-          Link
-        </SideNavLink>
-        <SideNavLink renderIcon={Fade} href="http://www.carbondesignsystem.com">
-          Link
-        </SideNavLink>
-        <SideNavLink renderIcon={Fade} href="http://www.carbondesignsystem.com">
-          Link
-        </SideNavLink>
-        <SideNavDivider />
-        <SideNavLink renderIcon={Fade} href="http://www.carbondesignsystem.com">
-          Link
-        </SideNavLink>
-        <SideNavLink renderIcon={Fade} href="http://www.carbondesignsystem.com">
-          Link
-        </SideNavLink>
-      </SideNavItems>
-    </SideNav>
-    <Content>
-      <Grid align="start">
-        <Column sm={4} md={8} lg={12}>
-          <h2 style={{ margin: '0 0 30px 0' }}>Purpose and function</h2>
-          <p>
-            The shell is perhaps the most crucial piece of any UI built with{' '}
-            {''}
-            <a href="www.carbondesignsystem.com">Carbon</a>. It contains the
-            shared navigation framework for the entire design system and ties
-            the products in IBM’s portfolio together in a cohesive and elegant
-            way. The shell is the home of the topmost navigation, where users
-            can quickly and dependably gain their bearings and move between
-            pages.
-            <br />
-            <br />
-            The shell was designed with maximum flexibility built in, to serve
-            the needs of a broad range of products and users. Adopting the shell
-            ensures compliance with IBM design standards, simplifies development
-            efforts, and provides great user experiences. All IBM products built
-            with Carbon are required to use the shell’s header.
-            <br />
-            <br />
-            To better understand the purpose and function of the UI shell,
-            consider the “shell” of MacOS, which contains the Apple menu,
-            top-level navigation, and universal, OS-level controls at the top of
-            the screen, as well as a universal dock along the bottom or side of
-            the screen. The Carbon UI shell is roughly analogous in function to
-            these parts of the Mac UI. For example, the app switcher portion of
-            the shell can be compared to the dock in MacOS.
-          </p>
-        </Column>
-      </Grid>
-    </Content>
-  </>
 );
 
 /**

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -507,6 +507,7 @@ Default.parameters = {
  */
 export const SideNavStory = () => (
   <SideNav
+    isTreeview
     isFixedNav
     expanded
     isChildOfHeader={false}

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -67,7 +67,6 @@ import {
   ShoppingCart,
   Share,
   User,
-  Search as SearchIcon,
   VirtualColumnKey,
 } from '@carbon/icons-react';
 
@@ -512,15 +511,6 @@ export const SideNavStory = () => (
     isChildOfHeader={false}
     aria-label="Side navigation">
     <SideNavItems>
-      <SideNavSlot renderIcon={SearchIcon}>
-        <Search
-          size="sm"
-          placeholder="Filter"
-          closeButtonLabelText="Clear input"
-          id="filter-1"
-        />
-      </SideNavSlot>
-      <SideNavDivider />
       <SideNavSlot renderIcon={VirtualColumnKey}>
         <Dropdown
           id="default"
@@ -531,7 +521,7 @@ export const SideNavStory = () => (
             { text: 'Option 2' },
             { text: 'Option 3' },
           ]}
-          label="Dropdown"
+          label="Choose an option"
         />
       </SideNavSlot>
       <SideNavDivider />
@@ -683,15 +673,6 @@ export const SideNavRail = () => (
     isChildOfHeader={false}
     aria-label="Product navigation">
     <SideNavItems>
-      <SideNavSlot renderIcon={SearchIcon}>
-        <Search
-          size="sm"
-          placeholder="Filter"
-          closeButtonLabelText="Clear input"
-          id="filter-1"
-        />
-      </SideNavSlot>
-      <SideNavDivider />
       <SideNavSlot renderIcon={VirtualColumnKey}>
         <Dropdown
           id="default"
@@ -702,7 +683,7 @@ export const SideNavRail = () => (
             { text: 'Option 2' },
             { text: 'Option 3' },
           ]}
-          label="Dropdown"
+          label="Choose an option"
         />
       </SideNavSlot>
       <SideNavDivider />

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -41,6 +41,7 @@ import {
   Link,
   Button,
   Search,
+  MenuItem,
 } from '@carbon/react';
 import {
   Add,
@@ -93,6 +94,7 @@ export default {
     SideNavLink,
     SideNavMenu,
     SideNavMenuItem,
+    SideNavSlot,
     TrialCountdown,
   },
   parameters: {
@@ -518,6 +520,14 @@ export const SideNavStory = () => (
         />
       </SideNavSlot>
       <SideNavDivider />
+      {/* <SideNavSlot>
+        <MenuButton size="sm" kind="tertiary" label="Menu button">
+          <MenuItem label="First action" />
+          <MenuItem label="Second action" />
+          <MenuItem label="Third action" />
+        </MenuButton>
+      </SideNavSlot>
+      <SideNavDivider /> */}
       <SideNavMenu renderIcon={Fade} title="Sub-menu level 1">
         <SideNavMenuItem href="http://www.carbondesignsystem.com">
           Link

--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -255,6 +255,11 @@ function SideNavRenderFunction(
       const backButton = sideNavRef?.current.querySelector(
         `.${prefix}--side-nav__back-button`
       ) as HTMLElement;
+
+      const slotElement = sideNavRef?.current.querySelector(
+        `.${prefix}--side-nav__slot`
+      ) as HTMLElement;
+
       const firstElement = sideNavRef?.current?.querySelector(
         'a, button'
       ) as HTMLElement;
@@ -271,6 +276,17 @@ function SideNavRenderFunction(
           }
         } else if (firstElement) {
           firstElement.tabIndex = 0;
+
+          if (slotElement) {
+            const firstElementAfterSlot =
+              slotElement.nextElementSibling?.nextElementSibling?.querySelector(
+                'a, button'
+              ) as HTMLElement;
+
+            if (firstElementAfterSlot) {
+              firstElementAfterSlot.tabIndex = 0;
+            }
+          }
         }
       }
     }
@@ -547,7 +563,8 @@ function SideNavRenderFunction(
     items.forEach((item) => {
       if (
         item.classList.contains(`${prefix}--side-nav__toggle`) ||
-        item.classList.contains(`${prefix}--side-nav__back-button`)
+        item.classList.contains(`${prefix}--side-nav__back-button`) ||
+        item.closest(`.${prefix}--side-nav__slot-item`)
       ) {
         return;
       }

--- a/packages/react/src/components/UIShell/components/SideNavMenu.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavMenu.tsx
@@ -318,6 +318,17 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
         const isExpanded = node.getAttribute('aria-expanded');
         const parent = parentSideNavMenu(node) as HTMLElement;
 
+        if (match(event, keys.Tab)) {
+          const slotElement = node.closest(`.${prefix}--side-nav__slot`);
+          if (slotElement) {
+            (
+              slotElement.nextElementSibling?.nextElementSibling?.querySelector(
+                'a, button'
+              ) as HTMLElement
+            ).tabIndex = 0;
+          }
+        }
+
         if (match(event, keys.ArrowLeft)) {
           event.stopPropagation();
 

--- a/packages/react/src/components/UIShell/components/SideNavSlot.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavSlot.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React, { ComponentType } from 'react';
+import { usePrefix } from '../internal/usePrefix';
+
+export interface SideNavSlotProps {
+  /**
+   * Provide children to be rendered inside the `SideNavSlot`
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Provide an optional class to be applied to the containing node
+   */
+  className?: string;
+
+  /**
+   * Provide an icon to render when the SideNav is in rail mode and collapsed.
+   * The icon will be shown instead of child component when collapsed.
+   */
+  renderIcon?: ComponentType;
+}
+
+export const SideNavSlot: React.FC<SideNavSlotProps> = ({
+  children,
+  className: customClassName,
+  renderIcon: IconElement,
+}) => {
+  const prefix = usePrefix();
+  const className = cx(`${prefix}--side-nav__slot`, customClassName);
+
+  return (
+    <li className={className}>
+      {IconElement && (
+        <div className={`${prefix}--side-nav__icon`}>
+          <IconElement />
+        </div>
+      )}
+      <div className={`${prefix}--side-nav__slot-item`}>{children}</div>
+    </li>
+  );
+};
+
+SideNavSlot.propTypes = {
+  /**
+   * Provide children to be rendered inside the `SideNavSlot`
+   */
+  children: PropTypes.node as unknown as React.Validator<React.ReactNode>,
+
+  /**
+   * Provide an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Provide an icon to render when the SideNav is in rail mode and collapsed.
+   * The icon will be shown instead of child component when collapsed.
+   */
+  // @ts-expect-error - PropTypes are unable to cover this case.
+  renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+};

--- a/packages/react/src/components/UIShell/components/SideNavSlot.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavSlot.tsx
@@ -7,7 +7,7 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { ComponentType } from 'react';
+import React, { ComponentType, KeyboardEvent, useCallback } from 'react';
 import { usePrefix } from '../internal/usePrefix';
 
 export interface SideNavSlotProps {
@@ -36,6 +36,10 @@ export const SideNavSlot: React.FC<SideNavSlotProps> = ({
   const prefix = usePrefix();
   const className = cx(`${prefix}--side-nav__slot`, customClassName);
 
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  }, []);
+
   return (
     <li className={className}>
       {IconElement && (
@@ -43,7 +47,13 @@ export const SideNavSlot: React.FC<SideNavSlotProps> = ({
           <IconElement />
         </div>
       )}
-      <div className={`${prefix}--side-nav__slot-item`}>{children}</div>
+      <div
+        role="presentation"
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className={`${prefix}--side-nav__slot-item`}>
+        {children}
+      </div>
     </li>
   );
 };

--- a/packages/react/src/components/UIShell/components/SideNavSlot.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavSlot.tsx
@@ -37,7 +37,7 @@ export const SideNavSlot: React.FC<SideNavSlotProps> = ({
   const className = cx(`${prefix}--side-nav__slot`, customClassName);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    if (e.key === 'ArrowDown') {
       e.stopPropagation();
     }
   };

--- a/packages/react/src/components/UIShell/components/SideNavSlot.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavSlot.tsx
@@ -36,9 +36,11 @@ export const SideNavSlot: React.FC<SideNavSlotProps> = ({
   const prefix = usePrefix();
   const className = cx(`${prefix}--side-nav__slot`, customClassName);
 
-  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
-    e.stopPropagation();
-  }, []);
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.stopPropagation();
+    }
+  };
 
   return (
     <li className={className}>

--- a/packages/react/src/components/UIShell/components/styles/_content.scss
+++ b/packages/react/src/components/UIShell/components/styles/_content.scss
@@ -32,12 +32,7 @@ div:has(.#{$prefix}--side-nav--panel.#{$prefix}--side-nav--expanded)
   margin-inline-start: $spacing-09;
 }
 
-// remove margin when rail is hidden
-// .cds--side-nav--rail.cds--side-nav--hide-rail-breakpoint-down-md
-//   ~ .#{$prefix}--content {
-//   margin-inline-start: 0;
-// }
-
+// when rail is hidden, remove spacing that accounts for rail
 @each $breakpoint in ('sm', 'md', 'lg', 'xlg', 'max') {
   .#{$prefix}--side-nav--rail.#{$prefix}--side-nav--hide-rail-breakpoint-down-#{$breakpoint}
     ~ .#{$prefix}--content {

--- a/packages/react/src/components/UIShell/components/styles/_content.scss
+++ b/packages/react/src/components/UIShell/components/styles/_content.scss
@@ -8,6 +8,7 @@
 @use '@carbon/styles/scss/utilities/convert' as convert;
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/breakpoint' as *;
 
 $prefix: 'cds' !default;
 
@@ -29,4 +30,19 @@ div:has(.#{$prefix}--side-nav--panel.#{$prefix}--side-nav--expanded)
 .#{$prefix}--side-nav--with-overlay.#{$prefix}--side-nav--expanded
   ~ .#{$prefix}--content {
   margin-inline-start: $spacing-09;
+}
+
+// remove margin when rail is hidden
+// .cds--side-nav--rail.cds--side-nav--hide-rail-breakpoint-down-md
+//   ~ .#{$prefix}--content {
+//   margin-inline-start: 0;
+// }
+
+@each $breakpoint in ('sm', 'md', 'lg', 'xlg', 'max') {
+  .#{$prefix}--side-nav--rail.#{$prefix}--side-nav--hide-rail-breakpoint-down-#{$breakpoint}
+    ~ .#{$prefix}--content {
+    @include breakpoint-down($breakpoint) {
+      margin-inline-start: 0;
+    }
+  }
 }

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -370,10 +370,10 @@ div:has(.#{$prefix}--header)
 //----------------------------------------------------------------------------
 
 .#{$prefix}--side-nav__slot {
-  margin: 0 $spacing-05;
-  block-size: 2rem;
   display: flex;
   align-items: center;
+  margin: 0 $spacing-05;
+  block-size: 2rem;
 }
 
 // icon shown when rail is collapsed

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -408,16 +408,3 @@ div:has(.#{$prefix}--header)
   .#{$prefix}--side-nav__slot-item {
   display: block;
 }
-
-//dropdown within slot
-// .#{$prefix}--side-nav__slot .#{$prefix}--dropdown__wrapper {
-//   width: 100%;
-// }
-
-// .cds--list-box {
-//   width: 100%;
-// }
-
-// .cds--dropdown__field {
-//   width: 100%;
-// }

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -368,12 +368,15 @@ div:has(.#{$prefix}--header)
 //----------------------------------------------------------------------------
 // Slot
 //----------------------------------------------------------------------------
-
 .#{$prefix}--side-nav__slot {
   display: flex;
   align-items: center;
   margin: 0 $spacing-05;
   block-size: 2rem;
+}
+
+.#{$prefix}--side-nav__slot-item {
+  inline-size: 100%;
 }
 
 // icon shown when rail is collapsed
@@ -396,3 +399,16 @@ div:has(.#{$prefix}--header)
   .#{$prefix}--side-nav__slot-item {
   display: block;
 }
+
+//dropdown within slot
+// .#{$prefix}--side-nav__slot .#{$prefix}--dropdown__wrapper {
+//   width: 100%;
+// }
+
+// .cds--list-box {
+//   width: 100%;
+// }
+
+// .cds--dropdown__field {
+//   width: 100%;
+// }

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -26,7 +26,7 @@ div:has(.#{$prefix}--header)
 }
 
 //----------------------------------------------------------------------------
-// Side-nav Collapsible
+// Collapsible
 //----------------------------------------------------------------------------
 .#{$prefix}--side-nav--collapsible.#{$prefix}--side-nav--ux {
   inline-size: 0;
@@ -37,7 +37,7 @@ div:has(.#{$prefix}--header)
 }
 
 //----------------------------------------------------------------------------
-// Treeview Side-nav
+// Treeview
 //----------------------------------------------------------------------------
 
 .#{$prefix}--side-nav__icon:not(.#{$prefix}--side-nav__submenu-chevron) {
@@ -112,7 +112,7 @@ div:has(.#{$prefix}--header)
 }
 
 //----------------------------------------------------------------------------
-// Side-nav Panel
+// Panel
 //----------------------------------------------------------------------------
 .#{$prefix}--side-nav--panel {
   z-index: 7999; /* needs to be below header */
@@ -363,4 +363,36 @@ div:has(.#{$prefix}--header)
   opacity: 1;
   transition: opacity $transition-expansion $standard-easing,
     background-color $transition-expansion $standard-easing;
+}
+
+//----------------------------------------------------------------------------
+// Slot
+//----------------------------------------------------------------------------
+
+.#{$prefix}--side-nav__slot {
+  margin: 0 $spacing-05;
+  block-size: 2rem;
+  display: flex;
+  align-items: center;
+}
+
+// icon shown when rail is collapsed
+.#{$prefix}--side-nav__slot .#{$prefix}--side-nav__icon {
+  display: none;
+}
+
+.#{$prefix}--side-nav--rail:not(.#{$prefix}--side-nav--expanded)
+  .#{$prefix}--side-nav__slot
+  .#{$prefix}--side-nav__icon {
+  display: block;
+}
+
+// hide slot item when rail collapsed
+.#{$prefix}--side-nav--rail .#{$prefix}--side-nav__slot-item {
+  display: none;
+}
+
+.#{$prefix}--side-nav--rail.#{$prefix}--side-nav--expanded
+  .#{$prefix}--side-nav__slot-item {
+  display: block;
 }

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -396,6 +396,7 @@ div:has(.#{$prefix}--header)
 //----------------------------------------------------------------------------
 .#{$prefix}--side-nav--rail {
   z-index: 7999; /* needs to be below header */
+  border-inline-end: 1px solid $border-subtle;
 }
 
 @each $breakpoint in ('sm', 'md', 'lg', 'xlg', 'max') {

--- a/packages/react/src/components/UIShell/index.ts
+++ b/packages/react/src/components/UIShell/index.ts
@@ -23,3 +23,4 @@ export { HeaderPanel } from './components/HeaderPanel';
 export { SharkFinIcon } from './components/SharkFinIcon';
 export { HeaderDivider } from './components/HeaderDivider';
 export { TrialCountdown } from './components/TrialCountdown';
+export { SideNavSlot } from './components/SideNavSlot';


### PR DESCRIPTION
Closes #613 
Closes #618

New `SideNavSlot` component to allow rendering of custom components within the navigation.
Added border to is Rail variant of SideNav

#### Changelog

**New**

- `SideNavSlot` component
- Added example with `Dropdown` (tenent switcher)
- Add Layer component internally to SideNavMenu 
- Add border to isRail variant of SideNav
- Add decorate `Menu` icon to the local nav rail. 

**Changed**
- small fix for content margin when rail is hidden

**Removed**

- SideNav panel story
- Panel docs from overview page

#### Testing / Reviewing

Check `Default, `Side Nav` and `Side Nav Rail` stories
