### PR TITLE
Revert "feat(processing): set default theme to g10"

### DIFF
--- a/packages/react/src/components/Processing/components/processing.scss
+++ b/packages/react/src/components/Processing/components/processing.scss
@@ -6,16 +6,11 @@
  */
 
 // Carbon setting imports
-@use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/spacing' as *;
 
 $prefix: 'clabs--processing' !default;
-
-:root {
-  @include theme(themes.$g10);
-}
 
 #storybook-root:has(.#{$prefix}) {
   display: grid;
@@ -35,7 +30,6 @@ $prefix: 'clabs--processing' !default;
   transform: translateY(0);
 }
 
-:root .#{$prefix}__dot,
 [data-carbon-theme='white'] .#{$prefix}__dot,
 [data-carbon-theme='g10'] .#{$prefix}__dot {
   stroke: $blue-90;


### PR DESCRIPTION
Reverts carbon-design-system/carbon-labs#535

This change is causing the labs storybook to load in g10 theme for all stories not just this one, will need to look into a different way of handling this for this specific component. 