### PR TITLE
fix(ui-shell): tabbing fixes

### DIFF
--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -547,7 +547,11 @@ function SideNavRenderFunction(
     items.forEach((item) => {
       if (
         item.classList.contains(`${prefix}--side-nav__toggle`) ||
-        item.classList.contains(`${prefix}--side-nav__back-button`)
+        item.classList.contains(`${prefix}--side-nav__back-button`) ||
+        // checks if a link is in primary nav
+        (item.classList.contains(`${prefix}--side-nav__link`) &&
+          (item as HTMLElement).closest(`ul`)?.getAttribute('aria-label') ===
+            ariaLabel)
       ) {
         return;
       }

--- a/packages/react/src/components/UIShell/components/SideNavItems.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavItems.tsx
@@ -43,7 +43,7 @@ export const SideNavItems: React.FC<SideNavItemsProps> = ({
   isSideNavExpanded,
   accessibilityLabel: accessibilityLabel,
 }) => {
-  const { isTreeview } = useContext(SideNavContext);
+  const { isTreeview, currentPrimaryMenu } = useContext(SideNavContext);
   const listRef = useRef<HTMLUListElement>(null); // Adjust type if necessary
   const prefix = usePrefix();
   const className = cx([`${prefix}--side-nav__items`], customClassName);
@@ -86,6 +86,7 @@ export const SideNavItems: React.FC<SideNavItemsProps> = ({
       {...(isTreeview && accessibilityLabel)}
       ref={listRef}
       className={className}
+      tabIndex={currentPrimaryMenu ? -1 : undefined}
       role={isTreeview ? 'tree' : ''}>
       {childrenWithExpandedState}
     </ul>

--- a/packages/react/src/components/UIShell/components/SideNavMenu.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavMenu.tsx
@@ -509,7 +509,7 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
           </SideNavIcon>
         </button>
 
-        {primary && (
+        {primary ? (
           <div className={primaryClassNames}>
             <SideNavItems
               accessibilityLabel={{ 'aria-label': `${title} submenu` }}>
@@ -527,11 +527,11 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
               {childrenToRender}
             </SideNavItems>
           </div>
+        ) : (
+          <ul className={`${prefix}--side-nav__menu`} role="group">
+            {childrenToRender}
+          </ul>
         )}
-
-        <ul className={`${prefix}--side-nav__menu`} role="group">
-          {childrenToRender}
-        </ul>
       </li>
     );
 


### PR DESCRIPTION
Ref #649 

>  Tabbing in Firefox. It's a bit unclear to me where the focus is going (within the panels somewhere?) when I hit the tab key on Firefox. Two examples in the video, and also attaching a screen shot of the odd focus indicator that seems like it's between panels?

^there shouldn't be any weird tabbing anymore in any browser

#### Changelog

**Changed**

- edited so if it's a primary menu it renders one section of code or the other and not both 
- set tabIndex = -1 if it's a primary menu
- ignores setting a link in a primary sidenavmenu to tabindex = -1 

#### Testing / Reviewing

tab through the sidenav and make sure in firefox that you aren't seeing any random blue lines