### PR TITLE
fix(sidenav): focus on active

### DIFF
--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -266,7 +266,6 @@ function SideNavRenderFunction(
       if (navType == SIDE_NAV_TYPE.PANEL || expanded) {
         if (isSm && backButton) {
           backButton.tabIndex = 0;
-          backButton.focus();
           const firstElementAfterBack =
             backButton.nextElementSibling?.querySelector(
               'a, button'
@@ -279,7 +278,6 @@ function SideNavRenderFunction(
           currentElement.closest(`[id="${currentPrimaryMenu}"]`)
         ) {
           currentElement.tabIndex = 0;
-          currentElement.focus();
         } else if (firstElement) {
           firstElement.tabIndex = 0;
         }

--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -259,9 +259,14 @@ function SideNavRenderFunction(
         'a, button'
       ) as HTMLElement;
 
+      const currentElement = sideNavRef?.current?.querySelector(
+        `.cds--side-nav__link--current`
+      ) as HTMLElement;
+
       if (navType == SIDE_NAV_TYPE.PANEL || expanded) {
         if (isSm && backButton) {
           backButton.tabIndex = 0;
+          backButton.focus();
           const firstElementAfterBack =
             backButton.nextElementSibling?.querySelector(
               'a, button'
@@ -269,6 +274,12 @@ function SideNavRenderFunction(
           if (firstElementAfterBack) {
             firstElementAfterBack.tabIndex = 0;
           }
+        } else if (
+          currentElement &&
+          currentElement.closest(`[id="${currentPrimaryMenu}"]`)
+        ) {
+          currentElement.tabIndex = 0;
+          currentElement.focus();
         } else if (firstElement) {
           firstElement.tabIndex = 0;
         }

--- a/packages/react/src/components/UIShell/components/SideNavMenu.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavMenu.tsx
@@ -439,6 +439,11 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
       } else {
         // setIsExpanded(lastExpandedState);
       }
+
+      // will always open to the menu with an active element
+      if(primary && (active || hasActiveDescendant(children))){
+        setIsExpanded(true)
+      }
     }, [sideNavExpanded]);
 
     const [openPopover, setOpenPopover] = React.useState(false);

--- a/packages/react/src/components/UIShell/components/SideNavMenu.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavMenu.tsx
@@ -421,7 +421,7 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
     }, [isExpanded]);
 
     useEffect(() => {
-      if (currentPrimaryMenu !== uniqueId) {
+      if (primary && currentPrimaryMenu !== uniqueId) {
         setIsExpanded(false);
       } else {
         setIsExpanded(true);
@@ -429,15 +429,15 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
     }, [currentPrimaryMenu]);
 
     // save expanded state before SideNav collapse
-    const [lastExpandedState, setLastExpandedState] = useState(isExpanded);
+    // const [lastExpandedState, setLastExpandedState] = useState(isExpanded); // this seems to be causing issues and not really needed?
 
     // reset to opened/collapsed menu state when Panel SideNav is toggled
     useEffect(() => {
       if (navType == SIDE_NAV_TYPE.PANEL && !sideNavExpanded) {
-        setLastExpandedState(isExpanded);
+        // setLastExpandedState(isExpanded);
         setIsExpanded(false);
       } else {
-        setIsExpanded(lastExpandedState);
+        // setIsExpanded(lastExpandedState);
       }
     }, [sideNavExpanded]);
 
@@ -480,7 +480,7 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
               // window.location.href = firstLink.current;
             } else if (isSm || !primary || currentPrimaryMenu !== uniqueId) {
               setIsExpanded(!isExpanded);
-              setLastExpandedState(!isExpanded);
+              // setLastExpandedState(!isExpanded);
             }
 
             if (isSm && backButtonRef.current) {

--- a/packages/react/src/components/UIShell/components/SideNavMenu.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavMenu.tsx
@@ -427,22 +427,15 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
         setIsExpanded(true);
       }
     }, [currentPrimaryMenu]);
-
-    // save expanded state before SideNav collapse
-    // const [lastExpandedState, setLastExpandedState] = useState(isExpanded); // this seems to be causing issues and not really needed?
-
     // reset to opened/collapsed menu state when Panel SideNav is toggled
     useEffect(() => {
       if (navType == SIDE_NAV_TYPE.PANEL && !sideNavExpanded) {
-        // setLastExpandedState(isExpanded);
         setIsExpanded(false);
-      } else {
-        // setIsExpanded(lastExpandedState);
       }
 
       // will always open to the menu with an active element
-      if(primary && (active || hasActiveDescendant(children))){
-        setIsExpanded(true)
+      if (primary && (active || hasActiveDescendant(children))) {
+        setIsExpanded(true);
       }
     }, [sideNavExpanded]);
 
@@ -485,7 +478,6 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
               // window.location.href = firstLink.current;
             } else if (isSm || !primary || currentPrimaryMenu !== uniqueId) {
               setIsExpanded(!isExpanded);
-              // setLastExpandedState(!isExpanded);
             }
 
             if (isSm && backButtonRef.current) {

--- a/packages/react/src/components/UIShell/components/SideNavMenu.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavMenu.tsx
@@ -308,7 +308,7 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
     }
 
     function handleKeyDown(event) {
-      if (match(event, keys.Escape)) {
+      if (match(event, keys.Escape) && !primary) {
         setIsExpanded(false);
 
         if (onMenuToggle) {

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -152,6 +152,7 @@ div:has(.#{$prefix}--header)
 
 .#{$prefix}--side-nav__menu-secondary-wrapper-expanded {
   inline-size: 16rem;
+  overflow-y: auto;
   transform: translateX(0);
 }
 


### PR DESCRIPTION
Closes #649 

if there is an active link then focus should go to that item first on load

- {{new thing}}

**Changed**

- update focus on first item if there is an active link
- add an overflow to the seconary menu
- make sure escape key is handled
- commented out the `lastExpandedState` seemed to be causing errors and not doing much from what I can tell

#### Testing / Reviewing

check on load tabbing
