### PR TITLE
fix(Resizer): update entry points for package

### DIFF
--- a/packages/react/src/components/Resizer/package.json
+++ b/packages/react/src/components/Resizer/package.json
@@ -14,8 +14,15 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/Resizer"
   },
-  "main": "./src/index.js",
-  "module": "./src/index.js",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js"
+    },
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./scss/*": "./scss/*"
+  },
   "files": [
     "es",
     "lib",

--- a/packages/react/src/components/Resizer/package.json
+++ b/packages/react/src/components/Resizer/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/Resizer"
   },
+  "types": "./es/index.d.ts",
   "exports": {
     ".": {
       "import": "./es/index.js",


### PR DESCRIPTION
Fixing up `Resizer` so that we can prep for bringing it into `SidePanel` from labs.

#### Changelog

**Changed**

- `packages/react/src/components/Resizer/package.json`

#### Testing / Reviewing

Built `Resizer` package and validated it contains both `es` and `lib` directories.
