### PR TITLE
fix(uishell): update style import for ibm-products

### DIFF
--- a/packages/react/src/components/AnimatedHeader/__tests__/__snapshots__/AnimatedHeader-test.tsx.snap
+++ b/packages/react/src/components/AnimatedHeader/__tests__/__snapshots__/AnimatedHeader-test.tsx.snap
@@ -341,7 +341,7 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
                   >
                     <button
                       aria-labelledby="tooltip-:rc:"
-                      class="clabs--animated-header__ai-prompt-tile--icon-button  cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--disabled cds--btn--icon-only"
+                      class="cds--btn--icon-only clabs--animated-header__ai-prompt-tile--icon-button  cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--disabled"
                       disabled=""
                       type="button"
                     >

--- a/packages/react/src/components/ThemeSettings/__tests__/__snapshots__/ThemeSettings-test.js.snap
+++ b/packages/react/src/components/ThemeSettings/__tests__/__snapshots__/ThemeSettings-test.js.snap
@@ -25,8 +25,9 @@ exports[`ThemeSettings renders as expected - Component API should match snapshot
           >
             <button
               aria-label="Light"
+              aria-labelledby="tooltip-:r1:"
               aria-selected="false"
-              class="cds--content-switcher-btn cds--btn cds--btn--lg cds--layout--size-lg cds--btn--primary cds--btn--icon-only"
+              class="cds--btn--icon-only cds--content-switcher-btn cds--btn cds--layout--size-lg cds--btn--primary"
               role="tab"
               tabindex="-1"
               type="button"
@@ -99,8 +100,9 @@ exports[`ThemeSettings renders as expected - Component API should match snapshot
           >
             <button
               aria-label="System"
+              aria-labelledby="tooltip-:r5:"
               aria-selected="false"
-              class="cds--content-switcher-btn cds--btn cds--btn--lg cds--layout--size-lg cds--btn--primary cds--btn--icon-only"
+              class="cds--btn--icon-only cds--content-switcher-btn cds--btn cds--layout--size-lg cds--btn--primary"
               role="tab"
               tabindex="-1"
               type="button"
@@ -160,8 +162,9 @@ exports[`ThemeSettings renders as expected - Component API should match snapshot
           >
             <button
               aria-label="Dark"
+              aria-labelledby="tooltip-:r9:"
               aria-selected="false"
-              class="cds--content-switcher-btn cds--btn cds--btn--lg cds--layout--size-lg cds--btn--primary cds--btn--icon-only"
+              class="cds--btn--icon-only cds--content-switcher-btn cds--btn cds--layout--size-lg cds--btn--primary"
               role="tab"
               tabindex="-1"
               type="button"

--- a/packages/react/src/components/UIShell/components/styles/_profile.scss
+++ b/packages/react/src/components/UIShell/components/styles/_profile.scss
@@ -10,7 +10,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/react/scss/utilities/convert' as convert;
 @use '@carbon/styles/scss/utilities/custom-property' as custom-property;
-@use '@carbon/ibm-products/scss' as *;
+@use '@carbon/ibm-products/scss/components/UserAvatar';
 
 $prefix: 'cds' !default;
 


### PR DESCRIPTION
Fix for odd style bug that showed up after we imported ibm-products scss
<img width="374" alt="Screenshot 2025-06-30 at 11 39 43 AM" src="https://github.com/user-attachments/assets/2f42a4b0-444d-4a24-ad8c-cec1ecae1f4f" />


#### Changelog



**Changed**

- import only UserAvatar styles from ibm-products


#### Testing / Reviewing
Check Demo story