### PR TITLE
fix(SideNavMenu): expanding issue if not primary

### DIFF
--- a/packages/react/src/components/UIShell/components/SideNavMenu.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavMenu.tsx
@@ -428,10 +428,8 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
     }, [isExpanded]);
 
     useEffect(() => {
-      if (primary && currentPrimaryMenu !== uniqueId) {
-        setIsExpanded(false);
-      } else {
-        setIsExpanded(true);
+      if (primary) {
+        setIsExpanded(currentPrimaryMenu === uniqueId);
       }
     }, [currentPrimaryMenu]);
     // reset to opened/collapsed menu state when Panel SideNav is toggled


### PR DESCRIPTION
Closes #677

before the SideNav default would automatically load all the menu's as expanded. This issue was happening because for `primary`  menu's we always want one open which is not applicable for the default

now the default should all show closed:
<img width="275" alt="Screenshot 2025-06-30 at 10 12 22 AM" src="https://github.com/user-attachments/assets/b7bb5de7-7d32-4bbf-b879-fd2381478942" />

#### Changelog


**Changed**

- cleaned up useEffect if statement setting `setIsExpanded`

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
