### PR TITLE
fix(styles): remove unnessary button imports

### DIFF
--- a/packages/react/src/components/Resizer/components/resizer.scss
+++ b/packages/react/src/components/Resizer/components/resizer.scss
@@ -8,7 +8,6 @@
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/motion' as *;
-@use '@carbon/styles/scss/components/button' as *;
 
 $prefix: 'clabs' !default;
 

--- a/packages/react/src/components/SplitPanel/components/split-panel.scss
+++ b/packages/react/src/components/SplitPanel/components/split-panel.scss
@@ -8,7 +8,6 @@
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/motion' as *;
-@use '@carbon/styles/scss/components/button' as *;
 
 $prefix: 'clabs' !default;
 


### PR DESCRIPTION
Ref #681

Fixes part of the issue above so the Theme switcher doesn't load blue on first load

#### Changelog

**Removed**

-  remove unnessary button style imports being added

#### Testing / Reviewing

make sure other stories aren't effected, but i removed the import from resizer and split-panel... neither which use a button