### PR TITLE
fix(uishell): hide rail spacing at small screens when inside layer

### DIFF
--- a/packages/react/src/components/UIShell/components/styles/_content.scss
+++ b/packages/react/src/components/UIShell/components/styles/_content.scss
@@ -35,7 +35,9 @@ div:has(.#{$prefix}--side-nav--panel.#{$prefix}--side-nav--expanded)
 // when rail is hidden, remove spacing that accounts for rail
 @each $breakpoint in ('sm', 'md', 'lg', 'xlg', 'max') {
   .#{$prefix}--side-nav--rail.#{$prefix}--side-nav--hide-rail-breakpoint-down-#{$breakpoint}
-    ~ .#{$prefix}--content {
+    ~ .#{$prefix}--content,
+  div:has(.#{$prefix}--side-nav--hide-rail-breakpoint-down-#{$breakpoint})
+    + .#{$prefix}--content {
     @include breakpoint-down($breakpoint) {
       margin-inline-start: 0;
     }


### PR DESCRIPTION
Closes #704



#### Changelog

- Add additional scss selector to account for when the nav is nested within a Layer component

#### Testing / Reviewing

Check Demo story at mobile breakpoint, there shouldn't be any extra left margin anymore