### PR TITLE
fix(side-nav): don't close on submenu

### DIFF
--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -552,7 +552,10 @@ function SideNavRenderFunction(
       `.${prefix}--side-nav a, .${prefix}--side-nav button`
     );
     const isInRail = isNavItemClick?.closest(`.${prefix}--side-nav--rail`);
-    if (isNavItemClick) {
+    if (
+      isNavItemClick &&
+      !isNavItemClick.classList.contains(`${prefix}--side-nav__submenu`)
+    ) {
       isInRail ? handleToggle(false, false) : onSideNavBlur?.();
     }
   });


### PR DESCRIPTION
Closes #

The SideNav was closing on submenu's but it should only close on buttons and links

#### Changelog



**Changed**

- make sure it doesn't close on submenu's like the "home" section in the demo



#### Testing / Reviewing

clicking on a submenu should keep the sidenav open