### PR TITLE
fix(uishell): profile overflow scroll

### DIFF
--- a/packages/react/src/components/UIShell/components/styles/_profile.scss
+++ b/packages/react/src/components/UIShell/components/styles/_profile.scss
@@ -27,7 +27,7 @@ $prefix: 'cds' !default;
   gap: 0;
   inline-size: convert.to-rem(256px);
   max-block-size: 100vh;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   > * {
     padding: $spacing-05;


### PR DESCRIPTION
Closes #721 

only show scroll bars when the profile needs to scroll

https://github.com/user-attachments/assets/b28e2838-dfcd-4045-841d-123292adc641

this shows the profile menu only showing scroll bars when necessary and the scroll bars don't push the profile menu over but instead go inside the profile container. 


#### Changelog

**Changed**

- overflow-y should just be auto not scroll always


#### Testing / Reviewing

open the profile menu and test the scroll bars by shrinking the height of the browser. Turn scroll bars to always on in system settings