### PR TITLE
feat(SideNav): add pinning functionality

### DIFF
--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -70,7 +70,6 @@ import {
   Share,
   User,
   VirtualColumnKey,
-  Menu,
   IbmCloudKeyProtect,
   Group,
   Money,
@@ -620,11 +619,9 @@ export const Demo = () => {
                 hideRailBreakpointDown="md"
                 isChildOfHeader={false}
                 isRail
+                enableRailPin
                 aria-label="Product navigation">
                 <SideNavItems>
-                  <SideNavSlot renderIcon={Menu}>
-                    <Menu />
-                  </SideNavSlot>
                   <SideNavSlot renderIcon={VirtualColumnKey}>
                     <Dropdown
                       id="default"

--- a/packages/react/src/components/UIShell/components/SideNav.tsx
+++ b/packages/react/src/components/UIShell/components/SideNav.tsx
@@ -177,10 +177,8 @@ function SideNavRenderFunction(
     [`${prefix}--side-nav__overlay-active`]: expanded || expandedViaHoverState,
   });
 
-  let childrenToRender = children;
-
   // Pass the expansion state as a prop, so children can update themselves to match
-  childrenToRender = React.Children.map(children, (child) => {
+  const childrenToRender = React.Children.map(children, (child) => {
     // if we are controlled, check for if we have hovered over or the expanded state, else just use the expanded state (uncontrolled)
     const currentExpansionState = controlled
       ? expandedViaHoverState || expanded

--- a/packages/react/src/components/UIShell/components/SideNavPin.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavPin.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, { useContext } from 'react';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import { Menu, Pin, PinFilled } from '@carbon/icons-react';
+import { usePrefix } from '../internal/usePrefix';
+import { SideNavContext } from './SideNav';
+
+export interface SideNavPinProps {
+  handlePin?: () => void;
+  onSideNavPinClick?: () => void;
+  pinned?: boolean;
+  renderIcon?: React.ComponentType;
+}
+
+export default function SideNavPin({
+  handlePin,
+  onSideNavPinClick,
+  pinned,
+  renderIcon: IconElement = Menu,
+}: SideNavPinProps) {
+  const prefix = usePrefix();
+  const className = cx({
+    [`${prefix}--side-nav__pin`]: true,
+    [`${prefix}--side-nav__item`]: true,
+  });
+  const Icon = () =>
+    IconElement && (
+      <div className={`${prefix}--side-nav__icon`}>
+        <IconElement />
+      </div>
+    );
+  const PinIcon = (props?: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={`${prefix}--side-nav__icon`} {...props}>
+      {pinned ? <PinFilled /> : <Pin />}
+    </div>
+  );
+  const { expanded } = useContext(SideNavContext);
+  return (
+    <div className={className}>
+      <Icon />
+      {expanded && (
+        <PinIcon
+          onClick={() => {
+            onSideNavPinClick?.();
+            handlePin?.();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+SideNavPin.propTypes = {
+  /**
+   * Function to handle pinning the side navigation
+   */
+  handlePin: PropTypes.func,
+
+  /**
+   * Function to handle pin click event
+   */
+  onSideNavPinClick: PropTypes.func,
+
+  /**
+   * Whether the side navigation is pinned
+   */
+  pinned: PropTypes.bool,
+
+  /**
+   * The icon to render in the side navigation rail
+   */
+  renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+};

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -649,3 +649,15 @@ div:has(.#{$prefix}--header)
     }
   }
 }
+
+// Side nav pin
+.#{$prefix}--side-nav__pin {
+  @include focus-outline('reset');
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: $spacing-05 $spacing-05 0;
+  min-block-size: $spacing-05;
+}


### PR DESCRIPTION
Closes #652

This PR implements sidenav pinning functionality by enabling the `enableRailPin` prop. Options for custom icon rendering and click handlers can be configured fia the `sideNavPinProps` prop which accepts an object

#### Changelog

**New**

- `SideNavPin` component
- `enableRailPin` and `sideNavPinProps` props on `SideNav`

#### Testing / Reviewing

confirm that the side nav can be pinned and unpinned as expected according to the component spec