### PR TITLE
fix: add main and module entry point in package.json

### DIFF
--- a/packages/react/src/components/Resizer/package.json
+++ b/packages/react/src/components/Resizer/package.json
@@ -7,6 +7,8 @@
     "provenance": true
   },
   "type": "module",
+  "main": "lib/index.js",
+  "module": "es/index.js",
   "description": "Carbon Labs - Resize Bar",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Should fix issues with teams using this component within next.js apps.

#### Changelog

**Changed**

- `packages/react/src/components/Resizer/package.json`

