### PR TITLE
fix(uishell): update delay for flyout menu

### DIFF
--- a/packages/react/src/components/UIShell/components/SideNavFlyoutMenu.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavFlyoutMenu.tsx
@@ -112,7 +112,7 @@ function SideNavFlyoutMenu<T extends React.ElementType>({
   label,
   description,
   enterDelayMs = 100,
-  leaveDelayMs = 300,
+  leaveDelayMs = 100,
   defaultOpen = false,
   dropShadow = true,
   highContrast = false,


### PR DESCRIPTION
per conversation with @cameroncalder remove the extra delay on the flyoutmenu popovers



#### Changelog



**Changed**

- delay to 100ms from 300ms



#### Testing / Reviewing

Check delay on flyout menu looks correct