### PR TITLE
feat(sidenav): new sideNavTitle

### DIFF
--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -529,7 +529,7 @@ export const Demo = () => {
                     renderIcon={Layers}>
                     Infrastructure
                   </SideNavLink>
-                  <SideNavTitle>Experience services</SideNavTitle>
+                  <SideNavTitle title="Experience services"></SideNavTitle>
                   <SideNavLink
                     href="http://www.carbondesignsystem.com"
                     renderIcon={Dashboard}>
@@ -697,7 +697,7 @@ export const Demo = () => {
                     renderIcon={Layers}>
                     Infrastructure
                   </SideNavLink>
-                  <SideNavTitle>Experience services</SideNavTitle>
+                  <SideNavTitle title="Experience services"></SideNavTitle>
                   <SideNavLink
                     href="http://www.carbondesignsystem.com"
                     renderIcon={Dashboard}>
@@ -1013,7 +1013,7 @@ export const DemoPanel = () => {
                     renderIcon={Layers}>
                     Infrastructure
                   </SideNavLink>
-                  <SideNavTitle>Experience services</SideNavTitle>
+                  <SideNavTitle title="Experience services"></SideNavTitle>
                   <SideNavLink
                     href="http://www.carbondesignsystem.com"
                     renderIcon={Dashboard}>
@@ -1152,7 +1152,7 @@ export const DemoPanel = () => {
                     renderIcon={Layers}>
                     Infrastructure
                   </SideNavLink>
-                  <SideNavTitle>Experience services</SideNavTitle>
+                  <SideNavTitle title="Experience services"></SideNavTitle>
                   <SideNavLink
                     href="http://www.carbondesignsystem.com"
                     renderIcon={Dashboard}>

--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -15,6 +15,7 @@ import { SideNavMenu } from '../components/SideNavMenu';
 import { SideNavMenuItem } from '../components/SideNavMenuItem';
 import { SideNavLink } from '../components/SideNavLink';
 import { SideNavSlot } from '../components/SideNavSlot';
+import { SideNavTitle } from '../components/SideNavTitle';
 import { Profile } from '../index';
 import {
   HeaderPopover,
@@ -528,7 +529,7 @@ export const Demo = () => {
                     renderIcon={Layers}>
                     Infrastructure
                   </SideNavLink>
-                  <SideNavDivider />
+                  <SideNavTitle>Experience services</SideNavTitle>
                   <SideNavLink
                     href="http://www.carbondesignsystem.com"
                     renderIcon={Dashboard}>
@@ -696,7 +697,7 @@ export const Demo = () => {
                     renderIcon={Layers}>
                     Infrastructure
                   </SideNavLink>
-                  <SideNavDivider />
+                  <SideNavTitle>Experience services</SideNavTitle>
                   <SideNavLink
                     href="http://www.carbondesignsystem.com"
                     renderIcon={Dashboard}>
@@ -1012,7 +1013,7 @@ export const DemoPanel = () => {
                     renderIcon={Layers}>
                     Infrastructure
                   </SideNavLink>
-                  <SideNavDivider />
+                  <SideNavTitle>Experience services</SideNavTitle>
                   <SideNavLink
                     href="http://www.carbondesignsystem.com"
                     renderIcon={Dashboard}>
@@ -1151,7 +1152,7 @@ export const DemoPanel = () => {
                     renderIcon={Layers}>
                     Infrastructure
                   </SideNavLink>
-                  <SideNavDivider />
+                  <SideNavTitle>Experience services</SideNavTitle>
                   <SideNavLink
                     href="http://www.carbondesignsystem.com"
                     renderIcon={Dashboard}>

--- a/packages/react/src/components/UIShell/components/SideNavTitle.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavTitle.tsx
@@ -13,9 +13,9 @@ import { SideNavDivider } from '@carbon/react';
 
 export interface SideNavTitleProps {
   /**
-   * Provide children to be rendered inside the `SideNavTitle`
+   * Provide a title to `SideNavTitle`
    */
-  children?: React.ReactNode;
+  title?: string;
 
   /**
    * Provide an optional class to be applied to the containing node
@@ -24,7 +24,7 @@ export interface SideNavTitleProps {
 }
 
 export const SideNavTitle: React.FC<SideNavTitleProps> = ({
-  children,
+  title,
   className: customClassName,
 }) => {
   const prefix = usePrefix();
@@ -32,7 +32,7 @@ export const SideNavTitle: React.FC<SideNavTitleProps> = ({
 
   return (
     <>
-      <div className={className}>{children}</div>
+      <div className={className}>{title}</div>
       <SideNavDivider></SideNavDivider>
     </>
   );
@@ -40,9 +40,9 @@ export const SideNavTitle: React.FC<SideNavTitleProps> = ({
 
 SideNavTitle.propTypes = {
   /**
-   * Provide children to be rendered inside the `SideNavTitle`
+   * Provide a title to `SideNavTitle`
    */
-  children: PropTypes.node as unknown as React.Validator<React.ReactNode>,
+  title: PropTypes.string,
 
   /**
    * Provide an optional class to be applied to the containing node

--- a/packages/react/src/components/UIShell/components/SideNavTitle.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavTitle.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { usePrefix } from '../internal/usePrefix';
+import { SideNavDivider } from '@carbon/react';
+
+export interface SideNavTitleProps {
+  /**
+   * Provide children to be rendered inside the `SideNavTitle`
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Provide an optional class to be applied to the containing node
+   */
+  className?: string;
+}
+
+export const SideNavTitle: React.FC<SideNavTitleProps> = ({
+  children,
+  className: customClassName,
+}) => {
+  const prefix = usePrefix();
+  const className = cx(`${prefix}--side-nav__title`, customClassName);
+
+  return (
+    <>
+      <div className={className}>{children}</div>
+      <SideNavDivider></SideNavDivider>
+    </>
+  );
+};
+
+SideNavTitle.propTypes = {
+  /**
+   * Provide children to be rendered inside the `SideNavTitle`
+   */
+  children: PropTypes.node as unknown as React.Validator<React.ReactNode>,
+
+  /**
+   * Provide an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+};

--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -139,6 +139,21 @@ div:has(.#{$prefix}--header)
   }
 }
 
+// SideNavTitle
+.#{$prefix}--side-nav__title {
+  @include type-style('label-01');
+
+  color: $text-secondary;
+  padding-block-start: $spacing-05;
+  padding-inline-start: $spacing-05;
+  visibility: hidden;
+  white-space: nowrap;
+}
+
+.#{$prefix}--side-nav--expanded .#{$prefix}--side-nav__title {
+  visibility: visible;
+}
+
 // SideNavMenu
 // Level 2 / Doublewide Level 3
 // without icon


### PR DESCRIPTION
Closes #749

Add new SideNavTitle 
<img width="448" height="729" alt="Screenshot 2025-08-15 at 10 01 05 AM" src="https://github.com/user-attachments/assets/405b05a6-a69e-40d7-ae2e-d515950cc61a" />

#### Changelog

**New**

- SideNavTitle component 
- accepts title text
- always adds a divider
- hide text when rail is collapsed 

#### Testing / Reviewing

Check demo stories