### PR TITLE
fix(side-nav): seconary animation jumping

### DIFF
--- a/packages/react/src/components/UIShell/components/styles/_side-nav.scss
+++ b/packages/react/src/components/UIShell/components/styles/_side-nav.scss
@@ -312,7 +312,6 @@ div:has(.#{$prefix}--header)
   inset-block-start: 0;
   inset-inline-start: 100%;
   transform: translateX(-100%);
-  transition: $fast-02 motion(exit, productive);
   will-change: inline-size;
 }
 
@@ -322,8 +321,6 @@ div:has(.#{$prefix}--header)
   inline-size: 16rem;
   overflow-y: auto;
   transform: translateX(0);
-  transition: $moderate-01 motion(standard, productive);
-  transition-delay: 40ms;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #760

the sidenav secondary panel should not animate when changing products
#### Changelog

**Removed**

- animation

#### Testing / Reviewing

check storybook and change the products in the demo story