### PR TITLE
fix: netlify deploy error

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -40,7 +40,6 @@
     "@carbon/pictograms": "^12.58.0",
     "@carbon/themes": "11.58.0",
     "@carbon/type": "11.45.0",
-    "@carbon/web-components": "^2.36.0",
     "@custom-elements-manifest/analyzer": "^0.10.0",
     "@lit/react": "^1.0.1",
     "@open-wc/testing": "^4.0.0",

--- a/packages/web-components/src/patterns/FirstTimeOrientation/__stories__/FirstTimeOrientation.stories.js
+++ b/packages/web-components/src/patterns/FirstTimeOrientation/__stories__/FirstTimeOrientation.stories.js
@@ -8,7 +8,7 @@
  */
 
 import { html } from 'lit';
-import '../../../../../../examples/web-components/first-time-orientation/src/first-time-orientation';
+// import '../../../../../../examples/web-components/first-time-orientation/src/first-time-orientation';
 
 import styles from './story-styles.scss?lit';
 
@@ -27,6 +27,6 @@ export const FirstTimeOrientation = {
       <style>
         ${styles}
       </style>
-      <clabs-first-time-orientation></clabs-first-time-orientation>
+      // <clabs-first-time-orientation></clabs-first-time-orientation>
     </div> `,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,7 +2956,6 @@ __metadata:
     "@carbon/styles": "npm:^1.88.0"
     "@carbon/themes": "npm:11.58.0"
     "@carbon/type": "npm:11.45.0"
-    "@carbon/web-components": "npm:^2.36.0"
     "@custom-elements-manifest/analyzer": "npm:^0.10.0"
     "@lit/react": "npm:^1.0.1"
     "@open-wc/testing": "npm:^4.0.0"


### PR DESCRIPTION
All Netlify builds are failing for the React storybook, we traced it back to this [PR](https://github.com/carbon-design-system/carbon-labs/pull/762) where @carbon/web-components and @carbon/ibm-products-web-components were added to the package.json. 

FYI @amal-k-joy I created an issue https://github.com/carbon-design-system/carbon-labs/issues/788

#### Changelog


**Changed**

- temporarily commented out the FirstOrientation pattern story 

**Removed**

- @carbon/ibm-products-web-components and @carbon/web-components from devDependencies

#### Testing / Reviewing

Netlify storybook previews should build