### PR TITLE
chore: update storybook publish workflow node version

### DIFF
--- a/.github/workflows/storybook-publish.yml
+++ b/.github/workflows/storybook-publish.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
Has been failing for past two weeks, since storybook 9 upgrade https://github.com/carbon-design-system/carbon-labs/actions/workflows/storybook-publish.yml