### PR TITLE
Onboard and upgrade Telemetry instrumentation

### DIFF
--- a/packages/react/src/components/Resizer/package.json
+++ b/packages/react/src/components/Resizer/package.json
@@ -28,13 +28,19 @@
   "files": [
     "es",
     "lib",
-    "scss"
+    "scss",
+    "telemetry.yml"
   ],
   "scripts": {
     "build": "node ../../../tasks/build.js",
-    "clean": "rimraf es lib scss"
+    "clean": "rimraf es lib scss",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id c3e81c63-8688-4d9d-9f8f-2c0c369a780a --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "devDependencies": {
     "@carbon-labs/utilities": "canary"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.10.1"
   }
 }

--- a/packages/react/src/components/Resizer/telemetry.yml
+++ b/packages/react/src/components/Resizer/telemetry.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: c3e81c63-8688-4d9d-9f8f-2c0c369a780a
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # Resizer
+        - children
+        - className
+        - onDoubleClick
+        - onResize
+        - onResizeEnd
+        - orientation
+        - thickness
+        # React
+        - key
+        - ref
+      allowedAttributeStringValues:
+        # Resizer - orientation
+        - horizontal
+        - vertical
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/web-components/src/components/empty-state/README.md
+++ b/packages/web-components/src/components/empty-state/README.md
@@ -1,0 +1,34 @@
+<p align="center">
+  <a href="https://www.carbondesignsystem.com">
+    <img alt="Carbon Design System" src="https://user-images.githubusercontent.com/3901764/57545698-ce5f2380-7320-11e9-8682-903df232d7b0.png" width="100%" />
+  </a>
+</p>
+<h1 align="center">
+  Carbon Labs
+</h1>
+
+> A community-driven incubation space enabling rapid prototyping, development,
+> and deployment of Carbon-based components.
+
+## Getting started
+
+Install `@carbon-labs/wc-empty-state` to use this package.
+
+### Storybook
+
+You can view the current state of the
+[component](https://labs.carbondesignsystem.com/web-components/).
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/web-components/src/components/empty-state/package.json
+++ b/packages/web-components/src/components/empty-state/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "es/",
-    "lib/"
+    "lib/",
+    "telemetry.yml"
   ],
   "types": "./src/index.d.ts",
   "customElements": "custom-elements.json",
@@ -31,12 +32,15 @@
     "build": "node ../../../tasks/build.js",
     "build:dist": "rm -rf dist && rollup --config ../../../tasks/build-dist.js",
     "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary",
-    "clean": "rimraf es lib"
+    "clean": "rimraf es lib",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 0a1bd1db2-dbe9-49bc-9ba9-8a7debf5b76a --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(ts|tsx|js|jsx) --wc"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
     "@carbon-labs/utilities": "0.14.0",
     "@carbon/web-components": "2.36.0",
+    "@ibm/telemetry-js": "^1.10.1",
     "uuid": "^9.0.1"
   }
 }

--- a/packages/web-components/src/components/empty-state/telemetry.yml
+++ b/packages/web-components/src/components/empty-state/telemetry.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: 0a1bd1db2-dbe9-49bc-9ba9-8a7debf5b76a
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  wc:
+    elements:
+      allowedAttributeNames:
+        # clabs-empty-state
+        - illustrationTheme
+        - kind
+        - size
+        - subtitle
+        - title
+      allowedAttributeStringValues:
+        # General - boolean attributes
+        - "true"
+        - "false"
+        # clabs-empty-state - illustrationTheme
+        - dark
+        - light
+        # clabs-empty-state - kind
+        - error
+        - noData
+        - noTags
+        - notFound
+        - notifications
+        - unauthorized
+        # clabs-empty-state - size
+        - lg
+        - sm
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/web-components/src/components/style-picker/package.json
+++ b/packages/web-components/src/components/style-picker/package.json
@@ -21,7 +21,8 @@
   },
   "files": [
     "es/",
-    "lib/"
+    "lib/",
+    "telemetry.yml"
   ],
   "types": "./src/index.d.ts",
   "customElements": "custom-elements.json",
@@ -29,13 +30,16 @@
     "build": "node ../../../tasks/build.js",
     "build:dist": "rm -rf dist && rollup --config ../../../tasks/build-dist.js",
     "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary",
-    "clean": "rimraf es lib"
+    "clean": "rimraf es lib",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 64062a7c-df09-48a9-b109-4464ed8b4211 --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(ts|tsx|js|jsx) --wc"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
     "@carbon-labs/utilities": "0.14.0",
     "@carbon-labs/wc-empty-state": "workspace:^",
     "@carbon/web-components": "^2.36.0",
+    "@ibm/telemetry-js": "^1.10.1",
     "@lit/context": "^1.1.5"
   }
 }

--- a/packages/web-components/src/components/style-picker/telemetry.yml
+++ b/packages/web-components/src/components/style-picker/telemetry.yml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: 64062a7c-df09-48a9-b109-4464ed8b4211
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  wc:
+    elements:
+      allowedAttributeNames:
+        # General
+        - heading
+        # clabs-style-picker
+        - align
+        - empty-state-subtitle
+        - empty-state-title
+        - enable-search
+        - kind
+        - open
+        - search-close-button-label
+        - search-input-placeholder
+        # clabs-style-picker-color
+        - color
+        - label
+        # clabs-style-picker-section
+        - size
+      allowedAttributeStringValues:
+        # General - boolean attributes
+        - "true"
+        - "false"
+        # clabs-style-picker - kind
+        - disclosed
+        - flat
+        - single
+        # clabs-style-picker-section - size
+        - lg
+        - sm
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -2703,6 +2703,7 @@ __metadata:
   resolution: "@carbon-labs/react-resizer@workspace:packages/react/src/components/Resizer"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
+    "@ibm/telemetry-js": "npm:^1.10.1"
   languageName: unknown
   linkType: soft
 
@@ -2903,6 +2904,7 @@ __metadata:
     "@babel/runtime": "npm:^7.23.2"
     "@carbon-labs/utilities": "npm:0.14.0"
     "@carbon/web-components": "npm:2.36.0"
+    "@ibm/telemetry-js": "npm:^1.10.1"
     uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
@@ -2939,6 +2941,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.14.0"
     "@carbon-labs/wc-empty-state": "workspace:^"
     "@carbon/web-components": "npm:^2.36.0"
+    "@ibm/telemetry-js": "npm:^1.10.1"
     "@lit/context": "npm:^1.1.5"
   languageName: unknown
   linkType: soft
@@ -4403,6 +4406,15 @@ __metadata:
   version: 6.0.0-next.6
   resolution: "@ibm/plex@npm:6.0.0-next.6"
   checksum: 10c0/7f47f9535def1047dff51703fd1041c2f2915df1d405f1d62e785cc55b56478ea91af2e95b838692ef4142835ea765217935e2e336bac5a4437a9092ec0cfb4f
+  languageName: node
+  linkType: hard
+
+"@ibm/telemetry-js@npm:^1.10.1":
+  version: 1.10.1
+  resolution: "@ibm/telemetry-js@npm:1.10.1"
+  bin:
+    ibmtelemetry: dist/collect.js
+  checksum: 10c0/7c4930f99362fc81b82ac07880af5120e40c65792037a120b8d941c3ba81badb867c1481b860799b89e2d253f63d52e92b1a9c9851b11fa0bfc0e5a441957611
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/ibm-products/issues/8034

Installs IBM Telemetry for a couple packages, and upgrades all packages to use the latest Telemetry JS version.

#### Changelog

**New**

- Generated Telemetry project ids and onboarded these packages
  - @carbon-labs/wc-empty-state
  - @carbon-labs/wc-style-picker
  - @carbon-labs/react-resizer

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
