### PR TITLE
chore(telemetry): bump to v1.10.2

### DIFF
--- a/packages/react/src/components/AnimatedHeader/package.json
+++ b/packages/react/src/components/AnimatedHeader/package.json
@@ -38,7 +38,7 @@
     "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 40597fb8-d0ed-45fb-a95a-5b1751e22c36 --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "jest-canvas-mock": "^2.5.2",
     "lottie-web": "^5.12.2"
   },

--- a/packages/react/src/components/FirstTimeOrientation/package.json
+++ b/packages/react/src/components/FirstTimeOrientation/package.json
@@ -30,6 +30,6 @@
     "@carbon/ibm-products": "^2.72.1"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/packages/react/src/components/MDXComponents/package.json
+++ b/packages/react/src/components/MDXComponents/package.json
@@ -28,7 +28,7 @@
     "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 2f9e5850-9687-434e-9ce0-8aa5ac05fa3f --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "clsx": "^1.2.1",
     "slugify": "^1.6.6"
   },

--- a/packages/react/src/components/Processing/package.json
+++ b/packages/react/src/components/Processing/package.json
@@ -39,6 +39,6 @@
     "@carbon-labs/utilities": "canary"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/packages/react/src/components/Resizer/package.json
+++ b/packages/react/src/components/Resizer/package.json
@@ -41,6 +41,6 @@
     "@carbon-labs/utilities": "canary"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/packages/react/src/components/SplitPanel/package.json
+++ b/packages/react/src/components/SplitPanel/package.json
@@ -39,6 +39,6 @@
     "@carbon-labs/utilities": "canary"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/packages/react/src/components/TextHighlighter/package.json
+++ b/packages/react/src/components/TextHighlighter/package.json
@@ -39,6 +39,6 @@
     "@carbon-labs/utilities": "canary"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/packages/react/src/components/ThemeSettings/package.json
+++ b/packages/react/src/components/ThemeSettings/package.json
@@ -39,6 +39,6 @@
     "@carbon-labs/utilities": "canary"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/packages/react/src/components/UIShell/package.json
+++ b/packages/react/src/components/UIShell/package.json
@@ -40,6 +40,6 @@
     "@carbon/ibm-products": "^2.72.1"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/packages/react/src/components/WhatsNew/package.json
+++ b/packages/react/src/components/WhatsNew/package.json
@@ -44,6 +44,6 @@
     "@carbon/ibm-products": "^2.72.1"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/packages/web-components/src/components/chat/package.json
+++ b/packages/web-components/src/components/chat/package.json
@@ -40,7 +40,7 @@
     "@babel/runtime": "^7.23.2",
     "@carbon-labs/utilities": "0.17.0",
     "@carbon/web-components": "2.36.0",
-    "@ibm/telemetry-js": "^1.10.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "highlightjs": "^9.16.2",
     "mathjax": "^3.2.2",
     "mermaid": "^11.2.1",

--- a/packages/web-components/src/components/empty-state/package.json
+++ b/packages/web-components/src/components/empty-state/package.json
@@ -40,7 +40,7 @@
     "@babel/runtime": "^7.23.2",
     "@carbon-labs/utilities": "0.14.0",
     "@carbon/web-components": "2.36.0",
-    "@ibm/telemetry-js": "^1.10.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "uuid": "^9.0.1"
   }
 }

--- a/packages/web-components/src/components/feedback/package.json
+++ b/packages/web-components/src/components/feedback/package.json
@@ -42,7 +42,7 @@
     "@carbon-labs/utilities": "0.17.0",
     "@carbon/grid": "^11.21.0",
     "@carbon/web-components": "2.36.0",
-    "@ibm/telemetry-js": "^1.10.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "uuid": "^9.0.1"
   }
 }

--- a/packages/web-components/src/components/network-graph/package.json
+++ b/packages/web-components/src/components/network-graph/package.json
@@ -41,7 +41,7 @@
     "@carbon-labs/utilities": "0.17.0",
     "@carbon/grid": "^11.21.0",
     "@carbon/web-components": "2.36.0",
-    "@ibm/telemetry-js": "^1.10.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "force-graph": "^1.43.5"
   }
 }

--- a/packages/web-components/src/components/style-picker/package.json
+++ b/packages/web-components/src/components/style-picker/package.json
@@ -39,7 +39,7 @@
     "@carbon-labs/utilities": "0.14.0",
     "@carbon-labs/wc-empty-state": "workspace:^",
     "@carbon/web-components": "^2.36.0",
-    "@ibm/telemetry-js": "^1.10.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "@lit/context": "^1.1.5"
   }
 }

--- a/packages/web-components/src/components/tag/package.json
+++ b/packages/web-components/src/components/tag/package.json
@@ -41,6 +41,6 @@
     "@carbon-labs/utilities": "0.8.0",
     "@carbon/grid": "^11.41.0",
     "@carbon/web-components": "2.36.0",
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/packages/web-components/src/components/ux-control/package.json
+++ b/packages/web-components/src/components/ux-control/package.json
@@ -42,6 +42,6 @@
     "@carbon-labs/utilities": "0.8.0",
     "@carbon/grid": "^11.21.0",
     "@carbon/web-components": "2.36.0",
-    "@ibm/telemetry-js": "^1.10.1"
+    "@ibm/telemetry-js": "^1.10.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,7 +2630,7 @@ __metadata:
     "@babel/runtime": "npm:^7.23.2"
     "@carbon-labs/utilities": "npm:0.17.0"
     "@carbon/web-components": "npm:2.36.0"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
     "@types/highlightjs": "npm:^9"
     highlightjs: "npm:^9.16.2"
     mathjax: "npm:^3.2.2"
@@ -2647,7 +2647,7 @@ __metadata:
   resolution: "@carbon-labs/mdx-components@workspace:packages/react/src/components/MDXComponents"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
     clsx: "npm:^1.2.1"
     slugify: "npm:^1.6.6"
   languageName: unknown
@@ -2658,7 +2658,7 @@ __metadata:
   resolution: "@carbon-labs/react-animated-header@workspace:packages/react/src/components/AnimatedHeader"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
     jest-canvas-mock: "npm:^2.5.2"
     lottie-web: "npm:^5.12.2"
   languageName: unknown
@@ -2678,7 +2678,7 @@ __metadata:
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
     "@carbon/ibm-products": "npm:^2.72.1"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   languageName: unknown
   linkType: soft
 
@@ -2687,7 +2687,7 @@ __metadata:
   resolution: "@carbon-labs/react-processing@workspace:packages/react/src/components/Processing"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   languageName: unknown
   linkType: soft
 
@@ -2703,7 +2703,7 @@ __metadata:
   resolution: "@carbon-labs/react-resizer@workspace:packages/react/src/components/Resizer"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   languageName: unknown
   linkType: soft
 
@@ -2712,7 +2712,7 @@ __metadata:
   resolution: "@carbon-labs/react-split-panel@workspace:packages/react/src/components/SplitPanel"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   languageName: unknown
   linkType: soft
 
@@ -2721,7 +2721,7 @@ __metadata:
   resolution: "@carbon-labs/react-text-highlighter@workspace:packages/react/src/components/TextHighlighter"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   languageName: unknown
   linkType: soft
 
@@ -2730,7 +2730,7 @@ __metadata:
   resolution: "@carbon-labs/react-theme-settings@workspace:packages/react/src/components/ThemeSettings"
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   languageName: unknown
   linkType: soft
 
@@ -2740,7 +2740,7 @@ __metadata:
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
     "@carbon/ibm-products": "npm:^2.72.1"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   languageName: unknown
   linkType: soft
 
@@ -2750,7 +2750,7 @@ __metadata:
   dependencies:
     "@carbon-labs/utilities": "npm:canary"
     "@carbon/ibm-products": "npm:^2.72.1"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   peerDependencies:
     "@carbon/ibm-products": ^2.72.1
   languageName: unknown
@@ -2867,7 +2867,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.17.0"
     "@carbon/grid": "npm:^11.21.0"
     "@carbon/web-components": "npm:2.36.0"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
     uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
@@ -2881,7 +2881,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.8.0"
     "@carbon/grid": "npm:^11.41.0"
     "@carbon/web-components": "npm:2.36.0"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   languageName: unknown
   linkType: soft
 
@@ -2894,7 +2894,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.8.0"
     "@carbon/grid": "npm:^11.21.0"
     "@carbon/web-components": "npm:2.36.0"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
   languageName: unknown
   linkType: soft
 
@@ -2905,7 +2905,7 @@ __metadata:
     "@babel/runtime": "npm:^7.23.2"
     "@carbon-labs/utilities": "npm:0.14.0"
     "@carbon/web-components": "npm:2.36.0"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
     uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
@@ -2929,7 +2929,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.17.0"
     "@carbon/grid": "npm:^11.21.0"
     "@carbon/web-components": "npm:2.36.0"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
     force-graph: "npm:^1.43.5"
   languageName: unknown
   linkType: soft
@@ -2942,7 +2942,7 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.14.0"
     "@carbon-labs/wc-empty-state": "workspace:^"
     "@carbon/web-components": "npm:^2.36.0"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
     "@lit/context": "npm:^1.1.5"
   languageName: unknown
   linkType: soft
@@ -4419,12 +4419,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/telemetry-js@npm:^1.10.1":
-  version: 1.10.1
-  resolution: "@ibm/telemetry-js@npm:1.10.1"
+"@ibm/telemetry-js@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@ibm/telemetry-js@npm:1.10.2"
   bin:
     ibmtelemetry: dist/collect.js
-  checksum: 10c0/7c4930f99362fc81b82ac07880af5120e40c65792037a120b8d941c3ba81badb867c1481b860799b89e2d253f63d52e92b1a9c9851b11fa0bfc0e5a441957611
+  checksum: 10c0/92c81b90ad0f4f250f821a1bc08f0527117cab8a708a46bfc6d692da2b56884b16cc209fdd2b0e95d742a9adb14cb2932b099b193adfa8d093d57f301bc05318
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes N/A

For a bit of context, I'll give a brief rundown of how `@ibm/telemetry-js` works. 

When any repo using carbon packages is doing its `npm install`, all carbon packages are being installed at once. To avoid them running our `postinstall` collection script at the same time and affecting CI performance, we make it so the first package that runs the script will become an IPC server. All others will become IPC clients, and send over their "work to do" over to the server. The server then processes all the package's sequentially, in order to avoid using up too many resources. 

However, if the package that becomes a server is using any version of telemetry that is not `v1.10.0` or higher, then it won't have the code required to run the Web Components scope for data collection. In other words, unless our Carbon Web Components package becomes the server, the chances of collecting WC data would be very rare, especially because we've found that CWC is one of the last packages to install, probably due to being one of the last carbon packages in a `package.json` if ordered alphabetically.

To circumvent this, this new `1.10.2` version will always have Web Components data collection work to be sent to its own WC IPC server, instead of the default server. This ensures that, if any repo is using any WC package, we will always be collecting WC data no matter what the default IPC server's version of telemetry is.

TL;DR: we are spinning up a WC-only IPC server to ensure WC data collection

### Changelog

**Changed**

- update `@ibm/telemetry-js` package to `v1.10.2`
- web components data will be collected under a different IPC server

#### Testing / Reviewing
N/A
