### PR TITLE
fix: stylepicker replace icons

### DIFF
--- a/packages/web-components/src/components/style-picker/__stories__/_placeholders.ts
+++ b/packages/web-components/src/components/style-picker/__stories__/_placeholders.ts
@@ -8,12 +8,12 @@
  */
 
 import * as carbonColors from '@carbon/colors';
-import Apple16 from '@carbon/web-components/es/icons/apple/16';
-import Corn16 from '@carbon/web-components/es/icons/corn/16';
-import Fish16 from '@carbon/web-components/es/icons/fish/16';
-import Wheat16 from '@carbon/web-components/es/icons/wheat/16';
-import FruitBowl16 from '@carbon/web-components/es/icons/fruit-bowl/16';
-import Strawberry16 from '@carbon/web-components/es/icons/strawberry/16';
+import Apple16 from '@carbon/icons/es/apple/16';
+import Corn16 from '@carbon/icons/es/corn/16';
+import Fish16 from '@carbon/icons/es/fish/16';
+import Wheat16 from '@carbon/icons/es/wheat/16';
+import FruitBowl16 from '@carbon/icons/es/fruit-bowl/16';
+import Strawberry16 from '@carbon/icons/es/strawberry/16';
 import AmsterdamWindmill from '@carbon/pictograms/lib/amsterdam--windmill';
 import Barcelona from '@carbon/pictograms/lib/barcelona';
 import BerlinBrandenburgGate from '@carbon/pictograms/lib/berlin--brandenburg-gate';
@@ -59,6 +59,7 @@ import CairoGizaPlateau from '@carbon/pictograms/lib/cairo--giza-plateau';
 import Melbourne from '@carbon/pictograms/lib/melbourne';
 import { Group, Item } from '../defs/style-picker-group.types';
 import { SVGTemplateResult } from 'lit';
+import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 
 type ColorItem = {
   color: string;
@@ -113,7 +114,7 @@ export const icons: Item<IconItem>[] = [
 ].map(([label, icon]) => ({
   value: label?.toString().toLowerCase().split(' ').join('-'),
   label: label as string,
-  renderIcon: icon,
+  renderIcon: iconLoader(icon),
 }));
 
 export const pictograms: Group<Item<PictogramItem>>[] = [

--- a/packages/web-components/src/components/style-picker/__stories__/_placeholders.ts
+++ b/packages/web-components/src/components/style-picker/__stories__/_placeholders.ts
@@ -59,7 +59,7 @@ import CairoGizaPlateau from '@carbon/pictograms/lib/cairo--giza-plateau';
 import Melbourne from '@carbon/pictograms/lib/melbourne';
 import { Group, Item } from '../defs/style-picker-group.types';
 import { SVGTemplateResult } from 'lit';
-import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
+import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
 
 type ColorItem = {
   color: string;

--- a/packages/web-components/src/components/style-picker/__stories__/style-picker.disclosed.stories.js
+++ b/packages/web-components/src/components/style-picker/__stories__/style-picker.disclosed.stories.js
@@ -10,9 +10,10 @@
 import { css, html, render } from 'lit';
 
 // Icons
-import TrashCan16 from '@carbon/web-components/es/icons/trash-can/16';
-import ColorPalette16 from '@carbon/web-components/es/icons/color-palette/16';
-import OverflowMenuVertical16 from '@carbon/web-components/es/icons/overflow-menu--vertical/16';
+import TrashCan16 from '@carbon/icons/es/trash-can/16';
+import ColorPalette16 from '@carbon/icons/es/color-palette/16';
+import OverflowMenuVertical16 from '@carbon/icons/es/overflow-menu--vertical/16';
+import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
 
 // Carbon
 import '@carbon/web-components/es/components/layer/index.js';
@@ -114,9 +115,9 @@ const changeIcon = (ev) => {
 
   const headerIconEl = document.getElementById('inline-tile-icon');
 
-  const iconTemplate = icons
-    .find((icon) => icon.value === selectedIcon)
-    .renderIcon();
+  const iconTemplate = icons.find(
+    (icon) => icon.value === selectedIcon
+  ).renderIcon;
   const container = document.createElement('div');
   render(iconTemplate, container);
   headerIconEl.innerHTML = '';
@@ -229,7 +230,7 @@ export const ColorAndIcon = {
               @click=${toggleButton}
               aria-expanded="${args.open}"
               aria-controls="style-picker">
-              ${ColorPalette16({ slot: 'icon' })}
+              ${iconLoader(ColorPalette16, { slot: 'icon' })}
               <span slot="tooltip-content">Color palette</span>
             </cds-icon-button>
             <clabs-style-picker-sections>
@@ -244,7 +245,7 @@ export const ColorAndIcon = {
                         @clabs-style-picker-option-select=${(ev) =>
                           changeIcon(ev)}>
                         <clabs-style-picker-icon>
-                          ${item.renderIcon()}
+                          ${item.renderIcon}
                         </clabs-style-picker-icon>
                       </clabs-style-picker-option>
                     `
@@ -274,18 +275,18 @@ export const ColorAndIcon = {
             </clabs-style-picker-sections>
           </clabs-style-picker>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${TrashCan16({ slot: 'icon' })}
+            ${iconLoader(TrashCan16, { slot: 'icon' })}
             <span slot="tooltip-content">Delete</span>
           </cds-icon-button>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${OverflowMenuVertical16({ slot: 'icon' })}
+            ${iconLoader(OverflowMenuVertical16, { slot: 'icon' })}
             <span slot="tooltip-content">More</span>
           </cds-icon-button>
         </cds-layer>
         <div class="inline-tile-holder">
           <cds-tile class="inline-tile">
             <div class="inline-tile-header">
-              <span id="inline-tile-icon">${icons[0].renderIcon()}</span>
+              <span id="inline-tile-icon">${icons[0].renderIcon}</span>
               <h6>Primary text</h6>
             </div>
             <br />
@@ -342,7 +343,7 @@ export const IconColorPictogram = {
               @click="${toggleButton}"
               aria-expanded="${args.open}"
               aria-controls="style-picker">
-              ${ColorPalette16({ slot: 'icon' })}
+              ${iconLoader(ColorPalette16, { slot: 'icon' })}
               <span slot="tooltip-content">Pictogram list</span>
             </cds-icon-button>
             <clabs-style-picker-sections>
@@ -357,7 +358,7 @@ export const IconColorPictogram = {
                         @clabs-style-picker-option-select=${(ev) =>
                           changeIcon(ev)}>
                         <clabs-style-picker-icon>
-                          ${item.renderIcon()}
+                          ${item.renderIcon}
                         </clabs-style-picker-icon>
                       </clabs-style-picker-option>
                     `
@@ -414,11 +415,11 @@ export const IconColorPictogram = {
             </clabs-style-picker-sections>
           </clabs-style-picker>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${TrashCan16({ slot: 'icon' })}
+            ${iconLoader(TrashCan16, { slot: 'icon' })}
             <span slot="tooltip-content">Delete</span>
           </cds-icon-button>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${OverflowMenuVertical16({ slot: 'icon' })}
+            ${iconLoader(OverflowMenuVertical16, { slot: 'icon' })}
             <span slot="tooltip-content">More</span>
           </cds-icon-button>
         </cds-layer>
@@ -435,7 +436,7 @@ export const IconColorPictogram = {
             </div>
             <br />
             <div class="inline-tile-header">
-              <span id="inline-tile-icon">${icons[0].renderIcon()}</span>
+              <span id="inline-tile-icon">${icons[0].renderIcon}</span>
               <h6>Primary text</h6>
             </div>
             <div class="inline-pictogram-secondary-text">

--- a/packages/web-components/src/components/style-picker/__stories__/style-picker.flat.stories.js
+++ b/packages/web-components/src/components/style-picker/__stories__/style-picker.flat.stories.js
@@ -10,9 +10,10 @@
 import { css, html, render } from 'lit';
 
 // Icons
-import TrashCan16 from '@carbon/web-components/es/icons/trash-can/16';
-import ColorPalette16 from '@carbon/web-components/es/icons/color-palette/16';
-import OverflowMenuVertical16 from '@carbon/web-components/es/icons/overflow-menu--vertical/16';
+import TrashCan16 from '@carbon/icons/es/trash-can/16';
+import ColorPalette16 from '@carbon/icons/es/color-palette/16';
+import OverflowMenuVertical16 from '@carbon/icons/es/overflow-menu--vertical/16';
+import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
 
 // Carbon
 import '@carbon/web-components/es/components/layer/index.js';
@@ -109,9 +110,9 @@ const changeColor = (ev) => {
  */
 const changeIcon = (ev) => {
   const selectedIcon = ev.detail.value;
-  const iconTemplate = icons
-    .find((icon) => icon.value === selectedIcon)
-    .renderIcon();
+  const iconTemplate = icons.find(
+    (icon) => icon.value === selectedIcon
+  ).renderIcon;
   const headerIconEl = document.getElementById('inline-tile-icon');
   const container = document.createElement('div');
   render(iconTemplate, container);
@@ -225,7 +226,7 @@ export const ColorAndIcon = {
               @click=${toggleButton}
               aria-expanded="${args.open}"
               aria-controls="style-picker">
-              ${ColorPalette16({ slot: 'icon' })}
+              ${iconLoader(ColorPalette16, { slot: 'icon' })}
               <span slot="tooltip-content">Color palette</span>
             </cds-icon-button>
             <clabs-style-picker-section heading="Colors">
@@ -255,7 +256,7 @@ export const ColorAndIcon = {
                       @clabs-style-picker-option-select=${(ev) =>
                         changeIcon(ev)}>
                       <clabs-style-picker-icon>
-                        ${item.renderIcon()}
+                        ${item.renderIcon}
                       </clabs-style-picker-icon>
                     </clabs-style-picker-option>
                   `
@@ -263,18 +264,18 @@ export const ColorAndIcon = {
             </clabs-style-picker-section>
           </clabs-style-picker>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${TrashCan16({ slot: 'icon' })}
+            ${iconLoader(TrashCan16, { slot: 'icon' })}
             <span slot="tooltip-content">Delete</span>
           </cds-icon-button>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${OverflowMenuVertical16({ slot: 'icon' })}
+            ${iconLoader(OverflowMenuVertical16, { slot: 'icon' })}
             <span slot="tooltip-content">More</span>
           </cds-icon-button>
         </cds-layer>
         <div class="inline-tile-holder">
           <cds-tile class="inline-tile">
             <div class="inline-tile-header">
-              <span id="inline-tile-icon">${icons[0].renderIcon()}</span>
+              <span id="inline-tile-icon">${icons[0].renderIcon}</span>
               <h6>Primary text</h6>
             </div>
             <br />
@@ -331,7 +332,7 @@ export const ColorAndPictogram = {
               @click=${toggleButton}
               aria-expanded="${args.open}"
               aria-controls="style-picker">
-              ${ColorPalette16({ slot: 'icon' })}
+              ${iconLoader(ColorPalette16, { slot: 'icon' })}
               <span slot="tooltip-content">Pictogram list</span>
             </cds-icon-button>
             <clabs-style-picker-section heading="Colors">
@@ -374,11 +375,11 @@ export const ColorAndPictogram = {
             </clabs-style-picker-section>
           </clabs-style-picker>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${TrashCan16({ slot: 'icon' })}
+            ${iconLoader(TrashCan16, { slot: 'icon' })}
             <span slot="tooltip-content">Delete</span>
           </cds-icon-button>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${OverflowMenuVertical16({ slot: 'icon' })}
+            ${iconLoader(OverflowMenuVertical16, { slot: 'icon' })}
             <span slot="tooltip-content">More</span>
           </cds-icon-button>
         </cds-layer>

--- a/packages/web-components/src/components/style-picker/__stories__/style-picker.single.stories.js
+++ b/packages/web-components/src/components/style-picker/__stories__/style-picker.single.stories.js
@@ -10,9 +10,10 @@
 import { css, html, render } from 'lit';
 
 // Icons
-import TrashCan16 from '@carbon/web-components/es/icons/trash-can/16';
-import ColorPalette16 from '@carbon/web-components/es/icons/color-palette/16';
-import OverflowMenuVertical16 from '@carbon/web-components/es/icons/overflow-menu--vertical/16';
+import TrashCan16 from '@carbon/icons/es/trash-can/16';
+import ColorPalette16 from '@carbon/icons/es/color-palette/16';
+import OverflowMenuVertical16 from '@carbon/icons/es/overflow-menu--vertical/16';
+import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
 
 // Carbon
 import '@carbon/web-components/es/components/layer/index.js';
@@ -114,9 +115,9 @@ const changeIcon = (ev) => {
   const selectedIcon = ev.detail.value;
 
   const iconHolderEl = document.getElementById('inline-tile-icon');
-  const iconTemplate = icons
-    .find((icon) => icon.value === selectedIcon)
-    .renderIcon();
+  const iconTemplate = icons.find(
+    (icon) => icon.value === selectedIcon
+  ).renderIcon;
   const container = document.createElement('div');
   render(iconTemplate, container);
   iconHolderEl.innerHTML = '';
@@ -227,7 +228,7 @@ export const Color = {
               @click=${toggleButton}
               aria-expanded="${args.open}"
               aria-controls="style-picker">
-              ${ColorPalette16({ slot: 'icon' })}
+              ${iconLoader(ColorPalette16, { slot: 'icon' })}
               <span slot="tooltip-content">Color palette</span>
             </cds-icon-button>
             <clabs-style-picker-section heading="Colors">
@@ -253,11 +254,11 @@ export const Color = {
             </clabs-style-picker-section>
           </clabs-style-picker>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${TrashCan16({ slot: 'icon' })}
+            ${iconLoader(TrashCan16, { slot: 'icon' })}
             <span slot="tooltip-content">Delete</span>
           </cds-icon-button>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${OverflowMenuVertical16({ slot: 'icon' })}
+            ${iconLoader(OverflowMenuVertical16, { slot: 'icon' })}
             <span slot="tooltip-content">More</span>
           </cds-icon-button>
         </cds-layer>
@@ -306,7 +307,7 @@ export const Icon = {
               @click=${toggleButton}
               aria-expanded="${args.open}"
               aria-controls="style-picker">
-              ${ColorPalette16({ slot: 'icon' })}
+              ${iconLoader(ColorPalette16, { slot: 'icon' })}
               <span slot="tooltip-content">Icon list</span>
             </cds-icon-button>
             <clabs-style-picker-section heading="Icons">
@@ -320,7 +321,7 @@ export const Icon = {
                       @clabs-style-picker-option-select=${(ev) =>
                         changeIcon(ev)}>
                       <clabs-style-picker-icon>
-                        ${item.renderIcon()}
+                        ${item.renderIcon}
                       </clabs-style-picker-icon>
                     </clabs-style-picker-option>
                   `
@@ -328,18 +329,18 @@ export const Icon = {
             </clabs-style-picker-section>
           </clabs-style-picker>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${TrashCan16({ slot: 'icon' })}
+            ${iconLoader(TrashCan16, { slot: 'icon' })}
             <span slot="tooltip-content">Delete</span>
           </cds-icon-button>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${OverflowMenuVertical16({ slot: 'icon' })}
+            ${iconLoader(OverflowMenuVertical16, { slot: 'icon' })}
             <span slot="tooltip-content">More</span>
           </cds-icon-button>
         </cds-layer>
         <div class="inline-tile-holder">
           <cds-tile class="inline-tile">
             <div class="inline-tile-header">
-              <span id="inline-tile-icon">${icons[0].renderIcon()}</span>
+              <span id="inline-tile-icon">${icons[0].renderIcon}</span>
               <h6>Primary text</h6>
             </div>
             <br />
@@ -394,7 +395,7 @@ export const Pictogram = {
               @click=${toggleButton}
               aria-expanded="${args.open}"
               aria-controls="style-picker">
-              ${ColorPalette16({ slot: 'icon' })}
+              ${iconLoader(ColorPalette16, { slot: 'icon' })}
               <span slot="tooltip-content">Pictogram list</span>
             </cds-icon-button>
             <clabs-style-picker-section size="lg" heading="Pictograms">
@@ -426,11 +427,11 @@ export const Pictogram = {
             </clabs-style-picker-section>
           </clabs-style-picker>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${TrashCan16({ slot: 'icon' })}
+            ${iconLoader(TrashCan16, { slot: 'icon' })}
             <span slot="tooltip-content">Delete</span>
           </cds-icon-button>
           <cds-icon-button kind=${BUTTON_KIND.GHOST}>
-            ${OverflowMenuVertical16({ slot: 'icon' })}
+            ${iconLoader(OverflowMenuVertical16, { slot: 'icon' })}
             <span slot="tooltip-content">More</span>
           </cds-icon-button>
         </cds-layer>

--- a/packages/web-components/src/components/style-picker/__tests__/style-picker.test.js
+++ b/packages/web-components/src/components/style-picker/__tests__/style-picker.test.js
@@ -10,11 +10,12 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { BUTTON_KIND } from '@carbon/web-components/es/components/button/defs.js';
 import { POPOVER_ALIGNMENT } from '@carbon/web-components/es/components/popover/defs.js';
-import ColorPalette16 from '@carbon/web-components/es/icons/color-palette/16.js';
+import ColorPalette16 from '@carbon/icons/es/color-palette/16.js';
 import * as carbonColors from '@carbon/colors';
-import Apple16 from '@carbon/web-components/es/icons/apple/16.js';
-import Corn16 from '@carbon/web-components/es/icons/corn/16.js';
-import Fish16 from '@carbon/web-components/es/icons/fish/16.js';
+import Apple16 from '@carbon/icons/es/apple/16.js';
+import Corn16 from '@carbon/icons/es/corn/16.js';
+import Fish16 from '@carbon/icons/es/fish/16.js';
+import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
 // import AmsterdamWindmill from '@carbon/pictograms/es/amsterdam--windmill/index.js';
 // import Barcelona from '@carbon/pictograms/es/barcelona/index.js';
 // import BerlinBrandenburgGate from '@carbon/pictograms/es/berlin--brandenburg-gate/index.js';
@@ -106,7 +107,7 @@ const colorTemplate = (props = defaultProps) => html`
     ?open=${props.open}
     heading=${props.heading}>
     <cds-icon-button slot="trigger" kind=${BUTTON_KIND.GHOST}>
-      ${ColorPalette16({ slot: 'icon' })}
+      ${iconLoader(ColorPalette16, { slot: 'icon' })}
       <span slot="tooltip-content">Color palette</span>
     </cds-icon-button>
     <clabs-style-picker-section heading="Colors">
@@ -142,7 +143,7 @@ const iconTemplate = (props = defaultProps) => html`
     ?open=${props.open}
     heading=${props.heading}>
     <cds-icon-button slot="trigger" kind=${BUTTON_KIND.GHOST}>
-      ${ColorPalette16({ slot: 'icon' })}
+      ${iconLoader(ColorPalette16, { slot: 'icon' })}
       <span slot="tooltip-content">Icon picker</span>
     </cds-icon-button>
     <clabs-style-picker-section heading="Icons">
@@ -154,7 +155,7 @@ const iconTemplate = (props = defaultProps) => html`
               label=${item.label}
               ?selected=${item.value === 'apple'}>
               <clabs-style-picker-icon>
-                ${item.renderIcon()}
+                ${item.renderIcon}
               </clabs-style-picker-icon>
             </clabs-style-picker-option>
           `

--- a/packages/web-components/src/components/style-picker/components/style-picker-option/src/style-picker-option.template.ts
+++ b/packages/web-components/src/components/style-picker/components/style-picker-option/src/style-picker-option.template.ts
@@ -8,7 +8,8 @@
  */
 
 import { html } from 'lit';
-import CheckmarkFilled16 from '@carbon/web-components/es/icons/checkmark--filled/16.js';
+import CheckmarkFilled16 from '@carbon/icons/es/checkmark--filled/16.js';
+import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
 
 /**
  * Lit template for style-picker-option component
@@ -24,7 +25,7 @@ export const stylePickerOptionTemplate = (customElementClass) => {
     <div class=${`${blockClass}__container ${blockClass}__container--${size}`}>
       <slot></slot>
       <div class=${`${blockClass}__selection-indicator`} aria-hidden=${false}>
-        ${CheckmarkFilled16()}
+        ${iconLoader(CheckmarkFilled16)}
       </div>
     </div>
   `;

--- a/packages/web-components/src/components/style-picker/package.json
+++ b/packages/web-components/src/components/style-picker/package.json
@@ -38,7 +38,7 @@
     "@babel/runtime": "^7.23.2",
     "@carbon-labs/utilities": "0.14.0",
     "@carbon-labs/wc-empty-state": "workspace:^",
-    "@carbon/web-components": "^2.36.0",
+    "@carbon/web-components": "^2.38.0",
     "@ibm/telemetry-js": "^1.10.2",
     "@lit/context": "^1.1.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2963,7 +2963,7 @@ __metadata:
     "@babel/runtime": "npm:^7.23.2"
     "@carbon-labs/utilities": "npm:0.14.0"
     "@carbon-labs/wc-empty-state": "workspace:^"
-    "@carbon/web-components": "npm:^2.36.0"
+    "@carbon/web-components": "npm:^2.38.0"
     "@ibm/telemetry-js": "npm:^1.10.2"
     "@lit/context": "npm:^1.1.5"
   languageName: unknown
@@ -3359,7 +3359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/styles@npm:^1.89.0":
+"@carbon/styles@npm:^1.89.0, @carbon/styles@npm:^1.90.0":
   version: 1.90.0
   resolution: "@carbon/styles@npm:1.90.0"
   dependencies:
@@ -3507,6 +3507,22 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     tslib: "npm:^2.6.3"
   checksum: 10c0/758e23c128343b6a70ef3c76ab2e0896e0464163086e44b7aa15e17eb5625ffdb7e8af8fe9d88032a06420d57266e693e31b9640c20effa7c38238f650ae3557
+  languageName: node
+  linkType: hard
+
+"@carbon/web-components@npm:^2.38.0":
+  version: 2.38.0
+  resolution: "@carbon/web-components@npm:2.38.0"
+  dependencies:
+    "@carbon/styles": "npm:^1.90.0"
+    "@floating-ui/dom": "npm:^1.6.3"
+    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@lit/context": "npm:^1.1.3"
+    flatpickr: "npm:4.6.13"
+    lit: "npm:^3.1.0"
+    lodash-es: "npm:^4.17.21"
+    tslib: "npm:^2.6.3"
+  checksum: 10c0/953bf8e26be9fb71e538a3636c97bec61b174503665d84ed8825995e435ce6d21e63792476a577c8b5ec27e83b06fd791b282868cf01b2c459dea5798394d46e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/ibm-products/issues/8251

updates icons in the `style-picker` web component from `@carbon/web-components` to `@carbon/icons` 