### PR TITLE
fix(style-picker): update types import

### DIFF
--- a/packages/web-components/src/components/style-picker/__stories__/_placeholders.ts
+++ b/packages/web-components/src/components/style-picker/__stories__/_placeholders.ts
@@ -57,7 +57,7 @@ import TelAviv from '@carbon/pictograms/lib/tel-aviv';
 import TokyoGates from '@carbon/pictograms/lib/tokyo--gates';
 import CairoGizaPlateau from '@carbon/pictograms/lib/cairo--giza-plateau';
 import Melbourne from '@carbon/pictograms/lib/melbourne';
-import { Group, Item } from '../defs/style-picker-group.types';
+import { Group, Item } from '../defs';
 import { SVGTemplateResult } from 'lit';
 import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
 


### PR DESCRIPTION
Fixes an import issue in `style-picker` that was causing the react netlify deploy to fail in @asfordmatt's global header PR.

#### Changelog

**Changed**

- `packages/web-components/src/components/style-picker/__stories__/_placeholders.ts`

#### Testing / Reviewing

Both web component and react deploys build from netlify
