### PR TITLE
fix(mdx-components): update package entrypoint

### DIFF
--- a/packages/react/src/components/MDXComponents/components/article-card/article-card.tsx
+++ b/packages/react/src/components/MDXComponents/components/article-card/article-card.tsx
@@ -12,7 +12,7 @@ import {
   Email,
   Error,
   Launch,
-} from '@carbon/react/icons';
+} from '@carbon/react/icons/index.js';
 import { clsx } from 'clsx';
 import PropTypes from 'prop-types';
 import React, { ReactNode } from 'react';

--- a/packages/react/src/components/MDXComponents/components/code/path.tsx
+++ b/packages/react/src/components/MDXComponents/components/code/path.tsx
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Launch } from '@carbon/react/icons';
+import { Launch } from '@carbon/react/icons/index.js';
 import PropTypes from 'prop-types';
 import React, { ReactNode } from 'react';
 

--- a/packages/react/src/components/MDXComponents/components/do-dont/do-dont.tsx
+++ b/packages/react/src/components/MDXComponents/components/do-dont/do-dont.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Column, Theme } from '@carbon/react';
-import { CheckmarkFilled, Misuse } from '@carbon/react/icons';
+import { CheckmarkFilled, Misuse } from '@carbon/react/icons/index.js';
 import { clsx } from 'clsx';
 import PropTypes from 'prop-types';
 import React, { ReactNode } from 'react';

--- a/packages/react/src/components/MDXComponents/components/gif-player/gif-player.tsx
+++ b/packages/react/src/components/MDXComponents/components/gif-player/gif-player.tsx
@@ -9,7 +9,7 @@ import {
   PauseOutlineFilled,
   PlayOutline,
   PlayOutlineFilled,
-} from '@carbon/react/icons';
+} from '@carbon/react/icons/index.js';
 import { clsx } from 'clsx';
 import PropTypes from 'prop-types';
 import React, { Children, ReactNode, useState } from 'react';

--- a/packages/react/src/components/MDXComponents/components/inline-notification/inline-notification.tsx
+++ b/packages/react/src/components/MDXComponents/components/inline-notification/inline-notification.tsx
@@ -11,7 +11,7 @@ import {
   ErrorFilled,
   InformationFilled,
   WarningFilled,
-} from '@carbon/react/icons';
+} from '@carbon/react/icons/index.js';
 import { clsx } from 'clsx';
 import PropTypes from 'prop-types';
 import React, { ReactNode } from 'react';

--- a/packages/react/src/components/MDXComponents/components/markdown/autolink-header/autolink-header.tsx
+++ b/packages/react/src/components/MDXComponents/components/markdown/autolink-header/autolink-header.tsx
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Link } from '@carbon/react/icons';
+import { Link } from '@carbon/react/icons/index.js';
 import { clsx } from 'clsx';
 import PropTypes from 'prop-types';
 import React, { ReactNode } from 'react';

--- a/packages/react/src/components/MDXComponents/components/mini-card/mini-card.tsx
+++ b/packages/react/src/components/MDXComponents/components/mini-card/mini-card.tsx
@@ -11,7 +11,7 @@ import {
   Download,
   Email,
   Launch,
-} from '@carbon/react/icons';
+} from '@carbon/react/icons/index.js';
 import { clsx } from 'clsx';
 import PropTypes from 'prop-types';
 import React, { ReactNode } from 'react';

--- a/packages/react/src/components/MDXComponents/components/resource-card/resource-card.tsx
+++ b/packages/react/src/components/MDXComponents/components/resource-card/resource-card.tsx
@@ -13,7 +13,7 @@ import {
   Email,
   Error,
   Launch,
-} from '@carbon/react/icons';
+} from '@carbon/react/icons/index.js';
 import { clsx } from 'clsx';
 import PropTypes from 'prop-types';
 import React, { ReactNode } from 'react';

--- a/packages/react/src/components/MDXComponents/components/video/video.tsx
+++ b/packages/react/src/components/MDXComponents/components/video/video.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { Column, Grid } from '@carbon/react';
-import { Pause, Play } from '@carbon/react/icons';
+import { Pause, Play } from '@carbon/react/icons/index.js';
 import { clsx } from 'clsx';
 import PropTypes from 'prop-types';
 import React, {

--- a/packages/react/src/components/MDXComponents/package.json
+++ b/packages/react/src/components/MDXComponents/package.json
@@ -13,8 +13,9 @@
     "url": "https://github.com/carbon-design-system/carbon-labs",
     "directory": "src/components/MDXComponents"
   },
-  "main": "./src/index.js",
-  "module": "./src/index.js",
+  "main": "./es/index.js",
+  "module": "./es/index.js",
+  "types": "./es/index.d.ts",
   "files": [
     "es",
     "lib",


### PR DESCRIPTION
Closes #810 

This updates the entrypoint for `MDXComponents`, which currently point to files which don't exist. Also fixes icon import paths to include `index.js`, as ES modules do not support directory imports.

@alisonjoseph I see that this was reverted once already (https://github.com/carbon-design-system/carbon-labs/pull/623). Is there a use case or example of why it needs to be `./src/`?

#### Changelog

**Changed**

- change package entrypoint to `./es/index.js`
- add `index.js` to icon import paths

#### Testing / Reviewing

There should be no errors when importing a component from `@carbon-labs/mdx-components` root, e.g.
```js
import { ResourceCard } from '@carbon-labs/mdx-components';
```
