### PR TITLE
chore(wc-global-header): run unit tests for global-header separately

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -23,8 +23,9 @@
     "storybook": "storybook dev -p 6007",
     "generate": "node tasks/generate",
     "storybook:build": "npx storybook build",
-    "test": "yarn build && web-test-runner \"src/components/**/*.test.js\" --node-resolve",
-    "test:updateSnapshot": "yarn build && web-test-runner \"src/components/**/*.test.js\" --node-resolve --update-snapshots"
+    "test": "yarn build && web-test-runner \"src/components/**/*.test.js\" --node-resolve && yarn test:wc-global-header",
+    "test:updateSnapshot": "yarn build && web-test-runner \"src/components/**/*.test.js\" --node-resolve --update-snapshots",
+    "test:wc-global-header": "lerna run test --scope '@carbon-labs/wc-global-header'"
   },
   "dependencies": {
     "@carbon/styles": "^1.88.0",

--- a/packages/web-components/src/components/global-header/package.json
+++ b/packages/web-components/src/components/global-header/package.json
@@ -30,12 +30,17 @@
     "build": "node ../../../tasks/build.js",
     "build:dist": "rm -rf dist && rollup --config ../../../tasks/build-dist.js",
     "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary",
-    "clean": "rimraf es lib"
+    "clean": "rimraf es lib",
+    "test": "web-test-runner"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
     "@carbon-labs/utilities": "0.14.0",
     "@carbon/web-components": "2.36.0",
     "@lit-labs/motion": "^1.0.9"
+  },
+  "devDependencies": {
+    "@remcovaes/web-test-runner-vite-plugin": "^1.3.0",
+    "@web/test-runner": "^0.20.2"
   }
 }

--- a/packages/web-components/src/components/global-header/web-test-runner.config.mjs
+++ b/packages/web-components/src/components/global-header/web-test-runner.config.mjs
@@ -1,0 +1,50 @@
+import {
+  vitePlugin,
+  removeViteLogging,
+} from '@remcovaes/web-test-runner-vite-plugin';
+
+export default {
+  concurrency: 1,
+  files: ['components/global-header/src/**/*.test.ts'],
+  filterBrowserLogs: removeViteLogging,
+  testRunnerHtml: (testFramework) =>
+    `<!doctype html>
+        <html lang="en">
+          <head>
+            <meta charset="UTF-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <title>Vite + Lit + TS</title>
+            <script type="module" src="${testFramework}"></script>
+            <script type="module">
+                /* Hack to disable Lit dev mode warnings */
+                const systemWarn = window.console.warn;
+                window.console.warn = (...args) => {
+                    if (args[0].indexOf('Lit is in dev mode.') === 0) {
+                        return;
+                    }
+                    if (args[0].indexOf('Multiple versions of Lit loaded.') === 0) {
+                        return;
+                    }
+                    systemWarn(...args);
+                };
+            </script>
+          </head>
+          <body>
+            
+          </body>
+        </html>
+        `,
+  plugins: [vitePlugin()],
+  coverageConfig: {
+    report: true,
+    reportDir: 'test-coverage',
+    threshold: {
+      statements: 98,
+      branches: 91,
+      functions: 97,
+      lines: 98,
+    },
+    include: ['src/**/*.ts'],
+    exclude: ['**/node_modules/**'],
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,6 +1801,8 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.14.0"
     "@carbon/web-components": "npm:2.36.0"
     "@lit-labs/motion": "npm:^1.0.9"
+    "@remcovaes/web-test-runner-vite-plugin": "npm:^1.3.0"
+    "@web/test-runner": "npm:^0.20.2"
   languageName: unknown
   linkType: soft
 
@@ -5585,6 +5587,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@remcovaes/web-test-runner-vite-plugin@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@remcovaes/web-test-runner-vite-plugin@npm:1.3.0"
+  peerDependencies:
+    vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+  checksum: 10c0/679224092289682574bb60d320c303075e4db6af180284b59446bb7dfb5b1cf81e95f1fd3916ef2655086ecd28001e44c670f120a59a91b07dddc5705e4e5098
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-alias@npm:^5.1.1":
   version: 5.1.1
   resolution: "@rollup/plugin-alias@npm:5.1.1"
@@ -8217,7 +8228,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@web/test-runner@npm:^0.20.0":
+"@web/test-runner@npm:^0.20.0, @web/test-runner@npm:^0.20.2":
   version: 0.20.2
   resolution: "@web/test-runner@npm:0.20.2"
   dependencies:


### PR DESCRIPTION
Our unit tests use a different setup, so run them separately to the others