### PR TITLE
fix: update stylepicker react example to work

### DIFF
--- a/examples/react/StylePicker/src/App.tsx
+++ b/examples/react/StylePicker/src/App.tsx
@@ -7,11 +7,66 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import { StylePicker } from '@carbon-labs/react-style-picker';
+import React, { useState } from 'react';
+import { Layer, IconButton } from '@carbon/react';
+import {
+  ColorPalette,
+  TrashCan,
+  OverflowMenuVertical,
+} from '@carbon/react/icons';
+import {
+  StylePicker,
+  StylePickerColor,
+  StylePickerGroup,
+  StylePickerOption,
+  StylePickerSection,
+} from '@carbon-labs/react-style-picker';
 
-function App() {
-  return <StylePicker />;
-}
+const colors = ['red', 'blue', 'green'];
+
+const App = () => {
+  const [open, setOpen] = useState(true);
+
+  const handleOpen = () => {
+    setOpen(!open);
+  };
+
+  const handleOptionChange = () => {
+    console.log('change');
+  };
+
+  return (
+    <div className="style-picker-example-container">
+      <Layer className="toolbar-layer">
+        <StylePicker open={open} heading="Choose color" enableSearch>
+          <div className="trigger-slot" slot="trigger">
+            <IconButton label="Color palette" kind="ghost" onClick={handleOpen}>
+              <ColorPalette />
+            </IconButton>
+          </div>
+          <StylePickerSection>
+            <StylePickerGroup heading="Color">
+              {colors.map((color) => (
+                <StylePickerOption
+                  key={color}
+                  value={color}
+                  label={color}
+                  onChange={handleOptionChange}>
+                  <StylePickerColor color={color} label={color} />
+                </StylePickerOption>
+              ))}
+            </StylePickerGroup>
+          </StylePickerSection>
+        </StylePicker>
+        <IconButton label="Delete" kind="ghost">
+          <TrashCan />
+        </IconButton>
+        <IconButton label="More" kind="ghost">
+          <OverflowMenuVertical />
+        </IconButton>
+      </Layer>
+    </div>
+  );
+};
 
 export default App;

--- a/examples/react/StylePicker/src/index.scss
+++ b/examples/react/StylePicker/src/index.scss
@@ -6,4 +6,13 @@
  */
 
 @use '@carbon/react';
-@use '@carbon-labs/react-style-picker/scss/style-picker';
+
+.trigger-slot {
+  display: contents;
+}
+
+.style-picker-example-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
updates the example code in `examples/react/StylePicker` to actually work when run.