### PR TITLE
Use prefix in toplevel elements

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/AuthContext/__stories__/AuthContext.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/AuthContext/__stories__/AuthContext.stories.ts
@@ -23,7 +23,7 @@ const meta: Meta = {
 export default meta;
 
 const renderAuthContext = (args) =>
-  html` <apaas-common-header .headerProps="${args}"></common-header> `;
+  html` <clabs-global-header-apaas .headerProps="${args}"></common-header> `;
 
 export const Default = renderAuthContext.bind({});
 Default.args = {

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/CommonHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/CommonHeader.ts
@@ -10,6 +10,7 @@
 
 import { LitElement, css, html, nothing, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import '@carbon/web-components/es-custom/components/ui-shell/index.js';
 import '@carbon/web-components/es-custom/components/popover/index.js';
 import { HeaderProps } from '../../types/Header.types';
@@ -25,10 +26,12 @@ import '../SideNavItem/SideNavItem';
 import '../HeaderContext/HeaderContext';
 import useScript from '../../globals/useScript';
 
+const { stablePrefix: clabsPrefix } = settings;
+
 /**
  * Main global header component
  */
-@customElement('apaas-common-header')
+@customElement(`${clabsPrefix}-global-header-apaas`)
 export class CommonHeader extends LitElement {
   createRenderRoot() {
     return super.createRenderRoot(); // Default Shadow DOM behavior

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/CommonHeader.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/CommonHeader.stories.ts
@@ -403,7 +403,7 @@ type Story = StoryObj<typeof CommonHeader>;
 export const Basic: Story = {
   render: () => html`
 		<div role="main">
-			<apaas-common-header .headerProps="${headerProps}"></common-header>
+			<clabs-global-header-apaas .headerProps="${headerProps}"></common-header>
 		</div>
 	`,
 };
@@ -411,7 +411,7 @@ export const Basic: Story = {
 export const UnauthenticatedContext: Story = {
   render: () => html`
 		<div role="main">
-			<apaas-common-header .headerProps="${headerPropsUnauthenticated}"></common-header>
+			<clabs-global-header-apaas .headerProps="${headerPropsUnauthenticated}"></common-header>
 		</div>
 	`,
 };
@@ -420,7 +420,7 @@ export const IbmMockProduct: Story = {
   name: 'IBM Mock Product',
   render: () => html`
 		<div role="main">
-			<apaas-common-header .headerProps="${hybridIPaasHeaderProps}"></common-header>
+			<clabs-global-header-apaas .headerProps="${hybridIPaasHeaderProps}"></common-header>
 		</div>
 	`,
 };
@@ -428,7 +428,7 @@ export const IbmMockProduct: Story = {
 export const HelpLinks: Story = {
   render: () => html`
 		<div role="main">
-			<apaas-common-header .headerProps="${headerPropsWithHelpLinks}"></common-header>
+			<clabs-global-header-apaas .headerProps="${headerPropsWithHelpLinks}"></common-header>
 		</div>
 	`,
 };
@@ -436,7 +436,7 @@ export const HelpLinks: Story = {
 export const ChatBot: Story = {
   render: () => html`
 		<div role="main">
-			<apaas-common-header .headerProps="${{
+			<clabs-global-header-apaas .headerProps="${{
         ...headerProps,
         chatBotConfigs,
       }}"></common-header>
@@ -447,7 +447,7 @@ export const ChatBot: Story = {
 export const Notifications: Story = {
   render: () => html`
 		<div role="main">
-			<apaas-common-header .headerProps="${{
+			<clabs-global-header-apaas .headerProps="${{
         ...headerProps,
         notificationConfigs,
       }}"></common-header>
@@ -458,7 +458,7 @@ export const Notifications: Story = {
 export const Search: Story = {
   render: () => html`
 		<div role="main">
-			<apaas-common-header .headerProps="${{
+			<clabs-global-header-apaas .headerProps="${{
         ...headerProps,
         searchConfigs,
       }}"></common-header>

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/SideNav.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/SideNav.stories.ts
@@ -266,7 +266,7 @@ type Story = StoryObj<typeof CommonHeader>;
 export const SideNavBasic: Story = {
   render: () => html`
 		<div role="main">
-			<apaas-common-header
+			<clabs-global-header-apaas
 				.headerProps="${{
           ...headerProps,
           sideNav: sideNavBasic,
@@ -278,7 +278,7 @@ export const SideNavBasic: Story = {
 export const SideNavWithGroups: Story = {
   render: () => html`
 		<div role="main">
-			<apaas-common-header
+			<clabs-global-header-apaas
 				.headerProps="${{
           ...headerProps,
           sideNav: sideNavGroups,
@@ -290,7 +290,7 @@ export const SideNavWithGroups: Story = {
 export const SideNavWithPropsV2: Story = {
   render: () => html`
 		<div role="main">
-			<apaas-common-header
+			<clabs-global-header-apaas
 				.headerProps="${{
           ...headerProps,
           sideNavPropsV2: sideNavWithV2,

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/CommonHeader.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/CommonHeader.test.ts
@@ -16,7 +16,7 @@ import sinon from 'sinon';
 describe('CommonHeader tests', () => {
   it('renders with no props', async () => {
     const el = await fixture<CommonHeader>(
-      html`<apaas-common-header></apaas-common-header>`
+      html`<clabs-global-header-apaas></clabs-global-header-apaas>`
     );
     expect(el).not.to.be.null;
 
@@ -41,7 +41,7 @@ describe('CommonHeader tests', () => {
     };
 
     const el = await fixture(
-      html`<apaas-common-header .headerProps="${props}"></apaas-common-header>`
+      html`<clabs-global-header-apaas .headerProps="${props}"></clabs-global-header-apaas>`
     );
     expect(el).not.to.be.null;
 
@@ -72,8 +72,8 @@ describe('CommonHeader tests', () => {
     };
     it('adds the "assist-me-script-status" event listener when assistMe config is passed in', async () => {
       const el = await fixture<CommonHeader>(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 
@@ -89,8 +89,8 @@ describe('CommonHeader tests', () => {
 
     it('sets assistMeScriptLoaded to true is event is fired with "load"', async () => {
       const el = await fixture<CommonHeader>(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 
@@ -108,8 +108,8 @@ describe('CommonHeader tests', () => {
     it('throws console error if event is fired with "error"', async () => {
       const consoleErrorStub = sinon.stub(console, 'error');
       const el = await fixture<CommonHeader>(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 
@@ -137,8 +137,8 @@ describe('CommonHeader tests', () => {
       };
 
       const el = await fixture<CommonHeader>(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
 
       expect(el).not.to.be.null;
@@ -188,8 +188,8 @@ describe('CommonHeader tests', () => {
       };
 
       const el = await fixture(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 
@@ -222,8 +222,8 @@ describe('CommonHeader tests', () => {
       };
 
       const el = await fixture(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 
@@ -284,8 +284,8 @@ describe('CommonHeader tests', () => {
         },
       };
       const el = await fixture(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 
@@ -321,8 +321,8 @@ describe('CommonHeader tests', () => {
       };
 
       const el = await fixture<CommonHeader>(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 
@@ -372,8 +372,8 @@ describe('CommonHeader tests', () => {
       };
 
       const el = await fixture(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 
@@ -434,8 +434,8 @@ describe('CommonHeader tests', () => {
       };
 
       const el = await fixture(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 
@@ -467,8 +467,8 @@ describe('CommonHeader tests', () => {
         },
       };
       const el = await fixture(
-        html`<apaas-common-header
-          .headerProps="${props}"></apaas-common-header>`
+        html`<clabs-global-header-apaas
+          .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -222,9 +222,9 @@ export class HybridIpaasHeader extends LitElement {
 
   render() {
     return html`<div id="ipaas-header-container">
-      <apaas-common-header
+      <clabs-global-header-apaas
         ?hasNewNotifications="${this.hasNewNotifications}"
-        .headerProps="${this.headerOptions}"></apaas-common-header>
+        .headerProps="${this.headerOptions}"></clabs-global-header-apaas>
     </div>`;
   }
 }

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -10,6 +10,7 @@
 
 import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import { INITIAL_AUTOMATION_HEADER_PROPS } from '../../constant';
 import {
   GlobalActionConfig,
@@ -19,10 +20,12 @@ import {
 } from '../../types/Header.types';
 import '../CommonHeader/CommonHeader';
 
+const { stablePrefix: clabsPrefix } = settings;
+
 /**
  * Wrapper component that obtains header options from a backend route
  */
-@customElement('hybrid-ipaas-header')
+@customElement(`${clabsPrefix}-global-header-hybrid-ipaas`)
 export class HybridIpaasHeader extends LitElement {
   @property({ type: String }) productName = null;
   @property({ type: String }) productKey = '';

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__stories__/HybridIPaasHeader.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__stories__/HybridIPaasHeader.stories.ts
@@ -80,10 +80,10 @@ export const Basic: Story = {
   },
   render: () => html`
     <div role="main">
-      <hybrid-ipaas-header
+      <clabs-global-header-hybrid-ipaas
         productName="App Connect"
         productKey="appconnect"
-        .notificationOpenCallback="${callback}"></hybrid-ipaas-header>
+        .notificationOpenCallback="${callback}"></clabs-global-header-hybrid-ipaas>
     </div>
   `,
 };
@@ -100,10 +100,10 @@ export const BasicWithTrial: Story = {
   },
   render: () => html`
     <div role="main">
-      <hybrid-ipaas-header
+      <clabs-global-header-hybrid-ipaas
         productName="App Connect"
         productKey="appconnect"
-        .notificationOpenCallback="${callback}"></hybrid-ipaas-header>
+        .notificationOpenCallback="${callback}"></clabs-global-header-hybrid-ipaas>
     </div>
   `,
 };
@@ -120,10 +120,10 @@ export const WithAIChat: Story = {
   },
   render: () => html`
     <div role="main">
-      <hybrid-ipaas-header
+      <clabs-global-header-hybrid-ipaas
         productName="App Connect"
         productKey="appconnect"
-        aiCallbackEvent="ai-callback-event"></hybrid-ipaas-header>
+        aiCallbackEvent="ai-callback-event"></clabs-global-header-hybrid-ipaas>
     </div>
   `,
 };
@@ -165,10 +165,10 @@ export const CustomFooter: Story = {
   },
   render: () => html`
     <div role="main">
-      <hybrid-ipaas-header
+      <clabs-global-header-hybrid-ipaas
         productName="App Connect"
         productKey="appconnect"
-        .capabilityProfileFooterLinks="${capabilityProfileFooterLinks}"></hybrid-ipaas-header>
+        .capabilityProfileFooterLinks="${capabilityProfileFooterLinks}"></clabs-global-header-hybrid-ipaas>
     </div>
   `,
 };
@@ -185,12 +185,12 @@ export const LogoutCallback: Story = {
   },
   render: () => html`
     <div role="main">
-      <hybrid-ipaas-header
+      <clabs-global-header-hybrid-ipaas
         productName="App Connect"
         productKey="appconnect"
         .capabilityProfileFooterLinks="${capabilityProfileFooterLinks}"
         .logoutCallback="${() =>
-          console.log('Logout callback triggered!')}"></hybrid-ipaas-header>
+          console.log('Logout callback triggered!')}"></clabs-global-header-hybrid-ipaas>
     </div>
   `,
 };
@@ -207,10 +207,10 @@ export const CustomActions: Story = {
   },
   render: () => html`
     <div role="main">
-      <hybrid-ipaas-header
+      <clabs-global-header-hybrid-ipaas
         productName="App Connect"
         productKey="appconnect"
-        .capabilityGlobalActions="${capabilityGlobalActions}"></hybrid-ipaas-header>
+        .capabilityGlobalActions="${capabilityGlobalActions}"></clabs-global-header-hybrid-ipaas>
     </div>
   `,
 };
@@ -237,10 +237,10 @@ export const SearchCallback: Story = {
   },
   render: () => html`
     <div role="main">
-      <hybrid-ipaas-header
+      <clabs-global-header-hybrid-ipaas
         productName="App Connect"
         productKey="appconnect"
-        .searchConfigs="${searchConfigs}"></hybrid-ipaas-header>
+        .searchConfigs="${searchConfigs}"></clabs-global-header-hybrid-ipaas>
     </div>
   `,
 };

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__tests__/HybridIpaasHeader.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__tests__/HybridIpaasHeader.test.ts
@@ -116,7 +116,7 @@ describe('HybridIpaasHeader Component', () => {
   };
   it('renders the component', async () => {
     const element = await fixture(
-      html`<hybrid-ipaas-header></hybrid-ipaas-header>`
+      html`<clabs-global-header-hybrid-ipaas></clabs-global-header-hybrid-ipaas>`
     );
 
     expect(element).to.exist;
@@ -125,7 +125,7 @@ describe('HybridIpaasHeader Component', () => {
   it('should log an error if productKey is missing', async () => {
     const consoleErrorStub = sinon.stub(console, 'error');
     await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header></hybrid-ipaas-header>`
+      html`<clabs-global-header-hybrid-ipaas></clabs-global-header-hybrid-ipaas>`
     );
 
     expect(consoleErrorStub.calledOnce).to.be.true;
@@ -141,7 +141,7 @@ describe('HybridIpaasHeader Component', () => {
   it('should log an error if productKey is missing', async () => {
     const consoleErrorStub = sinon.stub(console, 'error');
     await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header></hybrid-ipaas-header>`
+      html`<clabs-global-header-hybrid-ipaas></clabs-global-header-hybrid-ipaas>`
     );
 
     expect(consoleErrorStub.calledOnce).to.be.true;
@@ -164,7 +164,7 @@ describe('HybridIpaasHeader Component', () => {
     );
 
     await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header productKey="valid-key"></hybrid-ipaas-header>`
+      html`<clabs-global-header-hybrid-ipaas productKey="valid-key"></clabs-global-header-hybrid-ipaas>`
     );
 
     expect(consoleErrorStub.calledOnce).to.be.true;
@@ -177,10 +177,10 @@ describe('HybridIpaasHeader Component', () => {
       .stub(window, 'fetch')
       .resolves(new Response('{}', { status: 200 }));
     await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header
+      html`<clabs-global-header-hybrid-ipaas
         .fetchHeaders=${{ 'Content-Type': 'application/json' }}
         basePath="/api"
-        productKey="test-productKey"></hybrid-ipaas-header>`
+        productKey="test-productKey"></clabs-global-header-hybrid-ipaas>`
     );
 
     expect(fetchStub.calledOnce).to.be.true;
@@ -202,14 +202,14 @@ describe('HybridIpaasHeader Component', () => {
     );
 
     const el = await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header
+      html`<clabs-global-header-hybrid-ipaas
         productName="Test Product"
         productKey="test-productKey"
         basePath="/base"
         displayName="Test User"
         userEmail="test@example.com"
         productVersion="2.0.0"
-        assistMeKey="assist-key"></hybrid-ipaas-header>`
+        assistMeKey="assist-key"></clabs-global-header-hybrid-ipaas>`
     );
     await waitUntil(
       () => el.headerOptions.profile?.email === 'test@example.com',
@@ -242,12 +242,12 @@ describe('HybridIpaasHeader Component', () => {
     const logoutCallbackSpy = sinon.spy();
 
     const el = await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header
+      html`<clabs-global-header-hybrid-ipaas
         productName="Test Product"
         productKey="test-productKey"
         basePath="/base"
         assistMeKey="assist-key"
-        .logoutCallback="${logoutCallbackSpy}"></hybrid-ipaas-header>`
+        .logoutCallback="${logoutCallbackSpy}"></clabs-global-header-hybrid-ipaas>`
     );
     await waitUntil(
       () => el.headerOptions.capabilityName?.label === 'Test Product',
@@ -278,13 +278,13 @@ describe('HybridIpaasHeader Component', () => {
     const notificationCallbackSpy = sinon.spy();
 
     const el = await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header
+      html`<clabs-global-header-hybrid-ipaas
         productName="Test Product"
         productKey="test-productKey"
         basePath="/base"
         assistMeKey="assist-key"
         .notificationOpenCallback="${notificationCallbackSpy}"
-        .hasNewNotifications="${false}"></hybrid-ipaas-header>`
+        .hasNewNotifications="${false}"></clabs-global-header-hybrid-ipaas>`
     );
     await waitUntil(
       () => el.headerOptions.capabilityName?.label === 'Test Product',
@@ -311,12 +311,12 @@ describe('HybridIpaasHeader Component', () => {
     const aiCallbackSpy = sinon.spy();
 
     const el = await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header
+      html`<clabs-global-header-hybrid-ipaas
         productName="Test Product"
         productKey="test-productKey"
         basePath="/base"
         assistMeKey="assist-key"
-        .aiCallback="${aiCallbackSpy}"></hybrid-ipaas-header>`
+        .aiCallback="${aiCallbackSpy}"></clabs-global-header-hybrid-ipaas>`
     );
     await waitUntil(
       () => el.headerOptions.capabilityName?.label === 'Test Product',
@@ -357,12 +357,12 @@ describe('HybridIpaasHeader Component', () => {
 
     it('should handle aiCallbackEvent', async () => {
       const el = await fixture<HybridIpaasHeader>(
-        html`<hybrid-ipaas-header
+        html`<clabs-global-header-hybrid-ipaas
           productName="Test Product"
           productKey="test-productKey"
           basePath="/base"
           assistMeKey="assist-key"
-          aiCallbackEvent="ai-callback-event"></hybrid-ipaas-header>`
+          aiCallbackEvent="ai-callback-event"></clabs-global-header-hybrid-ipaas>`
       );
       await waitUntil(
         () => el.headerOptions.capabilityName?.label === 'Test Product',
@@ -394,12 +394,12 @@ describe('HybridIpaasHeader Component', () => {
       placeholder: 'Test Placeholder',
     };
     const el = await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header
+      html`<clabs-global-header-hybrid-ipaas
         productName="Test Product"
         productKey="test-productKey"
         basePath="/base"
         assistMeKey="assist-key"
-        .searchConfigs="${searchConfigs}"></hybrid-ipaas-header>`
+        .searchConfigs="${searchConfigs}"></clabs-global-header-hybrid-ipaas>`
     );
     await waitUntil(
       () => el.headerOptions.capabilityName?.label === 'Test Product',
@@ -441,12 +441,12 @@ describe('HybridIpaasHeader Component', () => {
       },
     ];
     const el = await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header
+      html`<clabs-global-header-hybrid-ipaas
         productName="Test Product"
         productKey="test-productKey"
         basePath="/base"
         assistMeKey="assist-key"
-        .capabilityProfileFooterLinks="${capabilityProfileFooterLinks}"></hybrid-ipaas-header>`
+        .capabilityProfileFooterLinks="${capabilityProfileFooterLinks}"></clabs-global-header-hybrid-ipaas>`
     );
     await waitUntil(
       () => el.headerOptions.capabilityName?.label === 'Test Product',
@@ -496,12 +496,12 @@ describe('HybridIpaasHeader Component', () => {
     ];
 
     const el = await fixture<HybridIpaasHeader>(
-      html`<hybrid-ipaas-header
+      html`<clabs-global-header-hybrid-ipaas
         productName="Test Product"
         productKey="test-productKey"
         basePath="/base"
         assistMeKey="assist-key"
-        .capabilityGlobalActions="${globalActionConfigs}"></hybrid-ipaas-header>`
+        .capabilityGlobalActions="${globalActionConfigs}"></clabs-global-header-hybrid-ipaas>`
     );
     await waitUntil(
       () => el.headerOptions.capabilityName?.label === 'Test Product',

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutHeader/LogoutHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutHeader/LogoutHeader.ts
@@ -10,10 +10,11 @@
 
 import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import { AUTOMATION_HEADER_BASE_CLASS } from '../../constant';
 import styles from './_index.scss?inline' assert { type: 'css' };
 
+const { stablePrefix: clabsPrefix } = settings;
 const blockClass = `${AUTOMATION_HEADER_BASE_CLASS}__logout-header`;
 
 const eightBar = html`
@@ -32,7 +33,7 @@ const eightBar = html`
 /**
  * Component to show a company name or logo
  */
-@customElement('apaas-logout-header')
+@customElement(`${clabsPrefix}-global-header-logout-banner`)
 export class LogoutHeader extends LitElement {
   static styles = css`
     ${unsafeCSS([styles])}

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutHeader/__stories__/LogoutHeader.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutHeader/__stories__/LogoutHeader.stories.ts
@@ -27,7 +27,7 @@ type Story = StoryObj<typeof LogoutHeader>;
 export const Basic: Story = {
   render: () => html`
     <div role="main">
-      <apaas-logout-header brandCompany="Company name"></apaas-logout-header>
+      <clabs-global-header-logout-banner brandCompany="Company name"></clabs-global-header-logout-banner>
     </div>
   `,
 };
@@ -35,7 +35,7 @@ export const Basic: Story = {
 export const Corporate: Story = {
   render: () => html`
     <div role="main">
-      <apaas-logout-header brandCompany="IBM"></apaas-logout-header>
+      <clabs-global-header-logout-banner brandCompany="IBM"></clabs-global-header-logout-banner>
     </div>
   `,
 };

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutHeader/__tests__/LogoutHeader.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutHeader/__tests__/LogoutHeader.test.ts
@@ -13,7 +13,7 @@ import '../LogoutHeader';
 describe('LogoutHeader Component', () => {
   it('renders component', async () => {
     const el = await fixture<HTMLElement>(
-      html` <apaas-logout-header></apaas-logout-header>`
+      html`<clabs-global-header-logout-banner></clabs-global-header-logout-banner>`
     );
     expect(el.shadowRoot).not.to.be.null;
 
@@ -22,8 +22,8 @@ describe('LogoutHeader Component', () => {
 
   it('renders component with props', async () => {
     const el = await fixture<HTMLElement>(
-      html` <apaas-logout-header
-        brandCompany="mockCompany"></apaas-logout-header>`
+      html`<clabs-global-header-logout-banner
+        brandCompany="mockCompany"></clabs-global-header-logout-banner>`
     );
     expect(el.shadowRoot).not.to.be.null;
 
@@ -33,7 +33,7 @@ describe('LogoutHeader Component', () => {
 
   it('renders component with IBM logo', async () => {
     const el = await fixture<HTMLElement>(
-      html` <apaas-logout-header brandCompany="IBM"></apaas-logout-header>`
+      html`<clabs-global-header-logout-banner brandCompany="IBM"></clabs-global-header-logout-banner>`
     );
     expect(el.shadowRoot).not.to.be.null;
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutTile/LogoutTile.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutTile/LogoutTile.ts
@@ -12,17 +12,19 @@ import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import '@carbon/web-components/es-custom/components/tile/index.js';
 import '@carbon/web-components/es-custom/components/button/index.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import { renderCarbonIcon } from '../../globals/utils';
 
 import { AUTOMATION_HEADER_BASE_CLASS } from '../../constant';
 import styles from './_index.scss?inline' assert { type: 'css' };
 
+const { stablePrefix: clabsPrefix } = settings;
 const blockClass = `${AUTOMATION_HEADER_BASE_CLASS}__logout-tile`;
 
 /**
  * Logged out dialog
  */
-@customElement('apaas-logout-tile')
+@customElement(`${clabsPrefix}-global-header-logout-tile`)
 export class LogoutTile extends LitElement {
   static styles = css`
     ${unsafeCSS([styles])}

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutTile/__stories__/LogoutTile.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutTile/__stories__/LogoutTile.stories.ts
@@ -32,7 +32,7 @@ const brand = {
 export const Basic: Story = {
   render: () => html`
     <div role="main">
-        <apaas-logout-tile brandCompany="${brand.company}" brandProduct="${brand.product}" loginHref="http://www.ibm.com" logoutText="You are being logged out" buttonLabel="Log in"></apaas-logout-tile>
+        <clabs-global-header-logout-tile brandCompany="${brand.company}" brandProduct="${brand.product}" loginHref="http://www.ibm.com" logoutText="You are being logged out" buttonLabel="Log in"></clabs-global-header-logout-tile>
       </cds-custom-header>
     </div>
   `,

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutTile/__tests__/LogoutTile.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/LogoutTile/__tests__/LogoutTile.test.ts
@@ -13,7 +13,7 @@ import '../LogoutTile';
 describe('LogoutTile Component', () => {
   it('renders component', async () => {
     const el = await fixture<HTMLElement>(
-      html` <apaas-logout-tile></apaas-logout-tile>`
+      html`<clabs-global-header-logout-tile></clabs-global-header-logout-tile>`
     );
     expect(el.shadowRoot).not.to.be.null;
 
@@ -22,10 +22,10 @@ describe('LogoutTile Component', () => {
 
   it('renders component with props', async () => {
     const el = await fixture<HTMLElement>(
-      html` <apaas-logout-tile
+      html`<clabs-global-header-logout-tile
         brandCompany="mockCompany"
         brandProduct="mockProduct"
-        logoutText="mockLogoutText"></apaas-logout-tile>`
+        logoutText="mockLogoutText"></clabs-global-header-logout-tile>`
     );
     expect(el.shadowRoot).not.to.be.null;
 
@@ -36,9 +36,9 @@ describe('LogoutTile Component', () => {
 
   it('renders component with button', async () => {
     const el = await fixture<HTMLElement>(
-      html` <apaas-logout-tile
+      html`<clabs-global-header-logout-tile
         buttonLabel="mockButton"
-        loginHref="/"></apaas-logout-tile>`
+        loginHref="/"></clabs-global-header-logout-tile>`
     );
     expect(el.shadowRoot).not.to.be.null;
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/TrialContent/__stories__/TrialContent.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/TrialContent/__stories__/TrialContent.stories.ts
@@ -29,7 +29,7 @@ const meta: Meta = {
 export default meta;
 
 const renderTrialTooltip = (args) =>
-  html` <apaas-common-header .headerProps="${args}"></common-header> `;
+  html` <clabs-global-header-apaas .headerProps="${args}"></common-header> `;
 
 export const Default = renderTrialTooltip.bind({});
 Default.args = {

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/styles/_carbon.scss
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/styles/_carbon.scss
@@ -16,7 +16,7 @@
 @use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/theme';
 
-apaas-common-header,
+clabs-global-header-apaas,
 clabs-global-header-hybrid-ipaas {
   @include theme.theme(themes.$g100);
 }

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/styles/_carbon.scss
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/styles/_carbon.scss
@@ -17,6 +17,6 @@
 @use '@carbon/styles/scss/theme';
 
 apaas-common-header,
-hybrid-ipaas-header {
+clabs-global-header-hybrid-ipaas {
   @include theme.theme(themes.$g100);
 }


### PR DESCRIPTION

**Changed**

Renamed our top-level custom elements to use the "clabs" prefix:

apaas-common-header -> clabs-global-header-apaas
hybrid-ipaas-header -> clabs-global-header-hybrid-ipaas
apaas-logout-header -> clabs-global-header-logout-banner
apaas-logout-tile -> clabs-global-header-logout-tile
