### PR TITLE
fix(ux-control): missing iconLoader

### DIFF
--- a/packages/web-components/src/components/ux-control/components/ux-control/src/ux-control.template.ts
+++ b/packages/web-components/src/components/ux-control/components/ux-control/src/ux-control.template.ts
@@ -410,7 +410,7 @@ export function uxControlTemplate(customElementClass) {
                     class="${clabsPrefix}--add-context-variable-tag"
                     @click=${toggleAddContextVariable}
                     type="gray">
-                    ${Add16({ slot: 'icon' })} Add context variable
+                    ${iconLoader(Add16, { slot: 'icon' })} Add context variable
                   </cds-tag>`
                 : html`
                     <div class="${clabsPrefix}--enter-new">


### PR DESCRIPTION
Closes #n/a

when updating the core packages from #840  I missed the icon loader wrapper around this icon. Thank you bob 😉 
#### Changelog

**New**

- add iconLoader


