### PR TITLE
chore(animated-header): add event to click handler

### DIFF
--- a/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
@@ -250,11 +250,9 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
                     disabledTaskLabel={disabledTaskLabel}
                     onClick={
                       hasAction
-                        ? () => {
+                        ? (event: React.MouseEvent<HTMLElement>) => {
                             tileClickHandler?.(tile);
-                            if (typeof (tile as any).onClick === 'function') {
-                              (tile as any).onClick();
-                            }
+                            tile.onClick?.(event);
                           }
                         : undefined
                     }

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/AIPromptTile/AIPromptTile.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/AIPromptTile/AIPromptTile.tsx
@@ -26,7 +26,7 @@ export type AIPromptTileProps = {
   productName?: string;
   promptPlaceholder?: string;
   primaryIcon?: ElementType | null;
-  onClick?: (() => void) | null;
+  onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | null;
   ariaLabel?: string;
   open?: boolean;
   isLoading?: boolean;
@@ -120,8 +120,8 @@ export const AIPromptTile: React.FC<AIPromptTileProps> = ({
               size="sm"
               disabled={!textInput}
               align="top-end"
-              onClick={() => {
-                onClick?.();
+              onClick={(event) => {
+                onClick?.(event);
                 openInNewTab(`${href}&primed_chat=${textInput}`);
               }}
               onKeyDown={handleTextInputKeyDown}>

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/AITile/AITile.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/AITile/AITile.tsx
@@ -21,7 +21,7 @@ export type AITileProps = {
   customContent?: React.ReactNode | null;
   primaryIcon?: ElementType | null;
   secondaryIcon?: ElementType | null;
-  onClick?: (() => void) | null;
+  onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | null;
   ariaLabel?: string;
   open?: boolean;
   isLoading?: boolean;
@@ -74,8 +74,8 @@ export const AITile: React.FC<AITileProps> = ({
 
   return (
     <Link
-      onClick={() => {
-        aiTileClickHandler?.();
+      onClick={(event) => {
+        aiTileClickHandler?.(event);
       }}
       className={`${prefix}--animated-header__tile ${blockClass}`}
       aria-label={ariaLabel ?? title ?? 'AI Tile'}

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/GlassTile/GlassTile.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/GlassTile/GlassTile.tsx
@@ -19,7 +19,7 @@ export type GlassTileProps = {
   customContent?: React.ReactNode | null;
   primaryIcon?: ElementType | null;
   secondaryIcon?: ElementType | null;
-  onClick?: (() => void) | null;
+  onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | null;
   ariaLabel?: string;
   open?: boolean;
   isLoading?: boolean;
@@ -76,8 +76,8 @@ export const GlassTile: React.FC<GlassTileProps> = ({
 
   return (
     <Link
-      onClick={() => {
-        glassTileClickHandler?.();
+      onClick={(event) => {
+        glassTileClickHandler?.(event);
       }}
       className={`${prefix}--animated-header__tile ${blockClass}`}
       aria-label={ariaLabel ?? title ?? 'Glass Tile'}


### PR DESCRIPTION
We should expose the consumers the click event on tile click.

#### Changelog
**Changed**

- Added event prop support to tile onClick handlers
