### PR TITLE
chore(global-header): use clabs prefix for all elements

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/AuthContext/AuthContext.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/AuthContext/AuthContext.ts
@@ -23,9 +23,13 @@ import {
 import { AuthContextProps } from './AuthContext.types';
 import '../UserProfileImage/UserProfileImage';
 import { customElement, property } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
+
 import styles from './_index.scss?inline';
 
 import { renderCarbonIcon } from '../../globals/utils';
+
+const { stablePrefix: clabsPrefix } = settings;
 
 const iconSlot = 'title-icon';
 const iconSize = 16;
@@ -33,7 +37,7 @@ const iconSize = 16;
 /**
  * Show the authentication context (profile menu)
  */
-@customElement('apaas-auth-context')
+@customElement(`${clabsPrefix}-global-header-auth-context`)
 export class AuthContext extends LitElement {
   static styles = css`
     ${unsafeCSS([styles])}
@@ -238,13 +242,13 @@ export class AuthContext extends LitElement {
         class="${NAMESPACE}__popover--focus">
         <div
           class="${NAMESPACE}__popover__header ${AUTOMATION_HEADER_BASE_CLASS}__popover__section">
-          <apaas-user-profile-image
+          <clabs-global-header-user-profile-image
             .size="xlg"
             .image="${profile?.imageUrl}"
             .backgroundColor="light-cyan"
             .initials="${profile?.displayName}">
             .className="${NAMESPACE}__popover__profile-icon"
-          </apaas-user-profile-image>
+          </clabs-global-header-user-profile-image>
           <div class="${AUTOMATION_HEADER_BASE_CLASS}__name_section">
             <span
               id="${POPOVER_LABEL_ID}"

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/AuthContext/__tests__/AuthContext.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/AuthContext/__tests__/AuthContext.test.ts
@@ -61,7 +61,9 @@ const profileFooterLinks = [
 
 describe('AuthContext Component', () => {
   it('renders default with no props', async () => {
-    const el = await fixture(html`<apaas-auth-context></apaas-auth-context>`);
+    const el = await fixture(
+      html`<clabs-global-header-auth-context></clabs-global-header-auth-context>`
+    );
     expect(el).not.to.be.undefined;
 
     const tabpanel = el.shadowRoot?.querySelectorAll('[role="tabpanel"');
@@ -91,7 +93,8 @@ describe('AuthContext Component', () => {
     };
 
     const el = await fixture(
-      html`<apaas-auth-context .props="${{ ...props }}"></apaas-auth-context>`
+      html`<clabs-global-header-auth-context
+        .props="${{ ...props }}"></clabs-global-header-auth-context>`
     );
     expect(el).not.to.be.undefined;
 
@@ -107,8 +110,11 @@ describe('AuthContext Component', () => {
 
   it('renders the profile section', async () => {
     const el = await fixture(
-      html`<apaas-auth-context
-        .props="${{ enableLogs: true, profile }}"></apaas-auth-context>`
+      html`<clabs-global-header-auth-context
+        .props="${{
+          enableLogs: true,
+          profile,
+        }}"></clabs-global-header-auth-context>`
     );
     expect(el).not.to.be.undefined;
 
@@ -123,11 +129,11 @@ describe('AuthContext Component', () => {
 
   it('renders the main section', async () => {
     const el = await fixture(
-      html`<apaas-auth-context
+      html`<clabs-global-header-auth-context
         .props="${{
           enableLogs: true,
           mainSectionItems,
-        }}"></apaas-auth-context>`
+        }}"></clabs-global-header-auth-context>`
     );
     expect(el).not.to.be.undefined;
 
@@ -148,11 +154,11 @@ describe('AuthContext Component', () => {
   describe('renders the footer section', () => {
     it('basic render', async () => {
       const el = await fixture(
-        html`<apaas-auth-context
+        html`<clabs-global-header-auth-context
           .props="${{
             enableLogs: true,
             footerSectionItems,
-          }}"></apaas-auth-context>`
+          }}"></clabs-global-header-auth-context>`
       );
       expect(el).not.to.be.undefined;
 
@@ -183,11 +189,11 @@ describe('AuthContext Component', () => {
       ];
 
       const el = await fixture(
-        html`<apaas-auth-context
+        html`<clabs-global-header-auth-context
           .props="${{
             enableLogs: true,
             footerSectionItems,
-          }}"></apaas-auth-context>`
+          }}"></clabs-global-header-auth-context>`
       );
       expect(el).not.to.be.undefined;
 
@@ -208,11 +214,11 @@ describe('AuthContext Component', () => {
 
   it('renders the management console section', async () => {
     const el = await fixture(
-      html`<apaas-auth-context
+      html`<clabs-global-header-auth-context
         .props="${{
           enableLogs: true,
           managementConsole,
-        }}"></apaas-auth-context>`
+        }}"></clabs-global-header-auth-context>`
     );
     expect(el).not.to.be.undefined;
 
@@ -228,11 +234,11 @@ describe('AuthContext Component', () => {
   describe('renders the profile footer link section', () => {
     it('renders with href in profile link', async () => {
       const el = await fixture(
-        html`<apaas-auth-context
+        html`<clabs-global-header-auth-context
           .props="${{
             enableLogs: true,
             profileFooterLinks,
-          }}"></apaas-auth-context>`
+          }}"></clabs-global-header-auth-context>`
       );
       expect(el).not.to.be.undefined;
 
@@ -260,11 +266,11 @@ describe('AuthContext Component', () => {
       ];
 
       const el = await fixture<AuthContext>(
-        html`<apaas-auth-context
+        html`<clabs-global-header-auth-context
           .props="${{
             enableLogs: true,
             profileFooterLinks,
-          }}"></apaas-auth-context>`
+          }}"></clabs-global-header-auth-context>`
       );
       expect(el).not.to.be.undefined;
 
@@ -297,11 +303,11 @@ describe('AuthContext Component', () => {
       ];
 
       const el = await fixture(
-        html`<apaas-auth-context
+        html`<clabs-global-header-auth-context
           .props="${{
             enableLogs: true,
             profileFooterLinks,
-          }}"></apaas-auth-context>`
+          }}"></clabs-global-header-auth-context>`
       );
       expect(el).not.to.be.undefined;
 
@@ -322,8 +328,11 @@ describe('AuthContext Component', () => {
 
   it('renders the user management console section', async () => {
     const el = await fixture(
-      html`<apaas-auth-context
-        .props="${{ enableLogs: true, userManagement }}"></apaas-auth-context>`
+      html`<clabs-global-header-auth-context
+        .props="${{
+          enableLogs: true,
+          userManagement,
+        }}"></clabs-global-header-auth-context>`
     );
     expect(el).not.to.be.undefined;
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/CommonHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/CommonHeader.ts
@@ -109,15 +109,15 @@ export class CommonHeader extends LitElement {
         <span class="${AUTOMATION_NAMESPACE_PREFIX}__capability-name"
           >${this.headerProps?.capabilityName?.label ?? nothing}</span
         >
-        <apaas-header-context
+        <clabs-global-header-context
           class="${AUTOMATION_NAMESPACE_PREFIX}__global"
           .props="${{ ...this.headerProps }}"
           .assistMeScriptLoaded="${this.assistMeScriptLoaded}"
           ?hasNewNotifications="${this
-            .hasNewNotifications}"></apaas-header-context>
+            .hasNewNotifications}"></clabs-global-header-context>
         ${this.headerProps && this.headerProps?.sideNav
           ? html`
-              <apaas-wide-side-nav
+              <clabs-global-header-wide-side-nav
                 aria-label=${this.headerProps?.sideNav?.buttonLabel ??
                 'Side navigation'}
                 collapse-mode="${typeof this.headerProps.sideNav
@@ -147,7 +147,7 @@ export class CommonHeader extends LitElement {
                               ${group?.links?.map((link, key, { length }) => {
                                 // Loop through the links array to render the menu items
                                 return html`
-                                  <apaas-side-nav-item
+                                  <clabs-global-header-side-nav-item
                                     .link="${{ ...link }}"
                                     .isCollapsible="${this.headerProps.sideNav
                                       ?.isCollapsible}"
@@ -164,7 +164,7 @@ export class CommonHeader extends LitElement {
                                     'function'}">
                                     .isHybridIpaas="${this.headerProps
                                       .isHybridIpaas}"
-                                  </apaas-side-nav-item>
+                                  </clabs-global-header-side-nav-item>
                                   ${
                                     // do not add a divider after the final group
                                     index + 1 !== numberOfGroups &&
@@ -187,7 +187,7 @@ export class CommonHeader extends LitElement {
                         ${this.headerProps.sideNav?.links?.map((link) => {
                           // Loop through the links array to render the menu items
                           return html`
-												<apaas-side-nav-item 
+												<clabs-global-header-side-nav-item 
 												.link="${{ ...link }}"
 												.isCollapsible="${this.headerProps.sideNav?.isCollapsible}"
 												.handleNavItemClick="${this.handleNavItemClick}"
@@ -198,14 +198,14 @@ export class CommonHeader extends LitElement {
                           typeof this.headerProps?.sideNav?.onClick ===
                           'function'
                         }">	
-												</apaas-side-nav-item>
+												</clabs-global-header-side-nav-item>
                                 </cds-custom-side-nav-menu>
                               `;
                         })}
                       `
                     : nothing}
                 </cds-custom-side-nav-items>
-              </apaas-wide-side-nav>
+              </clabs-global-header-wide-side-nav>
             `
           : nothing}
         ${this.headerProps && this.headerProps.sideNavPropsV2
@@ -233,7 +233,7 @@ export class CommonHeader extends LitElement {
               ${this.headerProps.sideNavPropsV2?.links?.map((link) => {
                 // Loop through the links array to render the menu items
                 return html`
-									<apaas-side-nav-item 
+									<clabs-global-header-side-nav-item 
 									.link="${{ ...link }}"
 									.isCollapsible="${this.headerProps.sideNavPropsV2?.isCollapsible}"
 									.handleNavItemClick="${this.handleNavItemClick}"
@@ -245,7 +245,7 @@ export class CommonHeader extends LitElement {
                     'function'
                   }"
 									>
-									</apaas-side-nav-item>
+									</clabs-global-header-side-nav-item>
                 </cds-custom-side-nav-menu>
                 `;
               })}

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/WideSideNav.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/WideSideNav.ts
@@ -9,12 +9,15 @@
 
 import { css } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import CDSSideNav from '@carbon/web-components/es-custom/components/ui-shell/side-nav.js';
+
+const { stablePrefix: clabsPrefix } = settings;
 
 /**
  * Extended width version of SideNav
  */
-@customElement('apaas-wide-side-nav')
+@customElement(`${clabsPrefix}-global-header-wide-side-nav`)
 export class WideSideNav extends CDSSideNav {
   // Make wider than regular cds-side-nav to match React version
   static styles = css`

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/CommonHeader.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/CommonHeader.test.ts
@@ -199,7 +199,9 @@ describe('CommonHeader tests', () => {
       expect(sideNav).to.have.attribute('collapse-mode', 'responsive');
       expect(sideNav).to.have.attribute('aria-label', 'Open menu');
 
-      const navItems = el.shadowRoot?.querySelectorAll('apaas-side-nav-item');
+      const navItems = el.shadowRoot?.querySelectorAll(
+        'clabs-global-header-side-nav-item'
+      );
       expect(navItems?.length).to.equal(2);
     });
 
@@ -293,7 +295,9 @@ describe('CommonHeader tests', () => {
       const sideNav = el.shadowRoot?.querySelector(`[role='navigation']`);
       expect(sideNav).to.exist;
 
-      const navItems = el.shadowRoot?.querySelectorAll('apaas-side-nav-item');
+      const navItems = el.shadowRoot?.querySelectorAll(
+        'clabs-global-header-side-nav-item'
+      );
       expect(navItems?.length).to.equal(3);
     });
 
@@ -330,7 +334,7 @@ describe('CommonHeader tests', () => {
       const sideNav = el.shadowRoot?.querySelector(`[role='navigation']`);
       expect(sideNav).to.exist;
 
-      const item = sideNav?.querySelector('apaas-side-nav-item');
+      const item = sideNav?.querySelector('clabs-global-header-side-nav-item');
       expect(item).to.exist;
 
       const link = item?.shadowRoot?.querySelector(`[role='link']`);
@@ -378,7 +382,9 @@ describe('CommonHeader tests', () => {
       );
       expect(el).not.to.be.null;
 
-      const sideNavItem = el.shadowRoot?.querySelector('apaas-side-nav-item');
+      const sideNavItem = el.shadowRoot?.querySelector(
+        'clabs-global-header-side-nav-item'
+      );
 
       const link = sideNavItem?.shadowRoot?.querySelector(`[role="link"]`);
       expect(link).not.to.have.class(
@@ -445,7 +451,9 @@ describe('CommonHeader tests', () => {
       expect(sideNav).to.have.attribute('collapse-mode', 'rail');
       expect(sideNav).to.have.attribute('aria-label', 'Side navigation');
 
-      const navItems = el.shadowRoot?.querySelectorAll('apaas-side-nav-item');
+      const navItems = el.shadowRoot?.querySelectorAll(
+        'clabs-global-header-side-nav-item'
+      );
       expect(navItems?.length).to.equal(2);
     });
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/WideSideNav.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/WideSideNav.test.ts
@@ -13,7 +13,7 @@ import { WideSideNav } from '../WideSideNav';
 describe('WideSideNav tests', () => {
   it('renders with no props', async () => {
     const el = await fixture<WideSideNav>(
-      html`<apaas-wide-side-nav></apaas-wide-side-nav>`
+      html`<clabs-global-header-wide-side-nav></clabs-global-header-wide-side-nav>`
     );
     expect(el).not.to.be.null;
   });

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/HeaderContext.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/HeaderContext.ts
@@ -10,6 +10,7 @@
 
 import { LitElement, css, html, nothing, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import {
   AUTOMATION_HEADER_BASE_CLASS,
   AUTOMATION_NAMESPACE_PREFIX,
@@ -39,10 +40,12 @@ import { isValidObject, renderCarbonIcon } from '../../globals/utils';
 
 import styles from './_index.scss?inline' assert { type: 'css' };
 
+const { stablePrefix: clabsPrefix } = settings;
+
 /**
  * Header entries depending on context
  */
-@customElement('apaas-header-context')
+@customElement(`${clabsPrefix}-global-header-context`)
 export class HeaderContext extends LitElement {
   static styles = css`
     ${unsafeCSS([styles])}
@@ -127,7 +130,7 @@ export class HeaderContext extends LitElement {
     if (isValidObject(trialConfig)) {
       return html`
         <div class="${AUTOMATION_HEADER_BASE_CLASS}--popover-content-container">
-          <apaas-trial-popover
+          <clabs-global-header-trial-popover
             id="${TRIAL_POPOVER_BUTTON_ID}"
             .open="${this.isTrialOpen}"
             .trialConfig="${trialConfig}"
@@ -143,7 +146,7 @@ export class HeaderContext extends LitElement {
               >
               <p class="trial-label">${trialConfig.trialLabel}</p>
             </cds-custom-header-global-action>
-          </apaas-trial-popover>
+          </clabs-global-header-trial-popover>
         </div>
       `;
     } else {
@@ -239,7 +242,7 @@ export class HeaderContext extends LitElement {
   renderProfile() {
     return html`
       <div class="${AUTOMATION_HEADER_BASE_CLASS}--popover-content-container">
-        <apaas-profile-popover
+        <clabs-global-header-profile-popover
           ?profileOpen="${this.isProfileOpen}"
           .props="${this.props}"
           @profile-toggle="${this._toggleProfilePopup}">
@@ -251,14 +254,14 @@ export class HeaderContext extends LitElement {
             aria-label="Profile"
             tooltip-text=""
             tabindex="${this.isTrialOpen ? -1 : 0}">
-            <apaas-user-profile-image
+            <clabs-global-header-user-profile-image
               .size="lg"
               .image="${this.props.profile?.imageUrl}"
               .backgroundColor="light-cyan"
               .initials="${this.props.profile
-                ?.displayName}"></apaas-user-profile-image>
+                ?.displayName}"></clabs-global-header-user-profile-image>
           </cds-custom-header-global-action>
-        </apaas-profile-popover>
+        </clabs-global-header-profile-popover>
       </div>
     `;
   }
@@ -266,9 +269,9 @@ export class HeaderContext extends LitElement {
   renderSearch() {
     const { searchConfigs } = this.props;
     if (searchConfigs) {
-      return html`<apaas-header-search
+      return html`<clabs-global-header-search
         id="${SEARCH_BUTTON_ID}"
-        .props="${searchConfigs}"></apaas-header-search>`;
+        .props="${searchConfigs}"></clabs-global-header-search>`;
     }
   }
 
@@ -306,14 +309,14 @@ export class HeaderContext extends LitElement {
       return html`
         ${this.renderTrial()}
         ${switcherProps && switcherProps.items?.length
-          ? html` <apaas-switcher-component
+          ? html` <clabs-global-header-switcher-component
               id="${ENV_SWITCHER_BUTTON_ID}"
               .items=${switcherProps.items}
               .iconsLeft=${switcherProps.iconsLeft}
               .disabled=${switcherProps.disabled}
               .initialSelectedIndex=${switcherProps.initialSelectedIndex}
               ?isTrialOpen="${this.isTrialOpen}"
-              .onClick=${switcherProps.onClick}></apaas-switcher-component>`
+              .onClick=${switcherProps.onClick}></clabs-global-header-switcher-component>`
           : nothing}
         ${this.renderGlobalActions()}
         ${this.props.isHybridIpaas
@@ -326,8 +329,8 @@ export class HeaderContext extends LitElement {
         ${this.renderProfile()}
       `;
     } else {
-      return html`<apaas-unauthenticated-context
-        .noAuthHeaderLinks="${noAuthHeaderLinks}"></apaas-unauthenticated-context>`;
+      return html`<clabs-global-header-unauthenticated-context
+        .noAuthHeaderLinks="${noAuthHeaderLinks}"></clabs-global-header-unauthenticated-context>`;
     }
   }
 }

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/__tests__/HeaderContext.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/__tests__/HeaderContext.test.ts
@@ -128,7 +128,7 @@ describe('HeaderContext Component', () => {
 
   it('renders the header component without props', async () => {
     const el = await fixture(
-      html`<apaas-header-context></apaas-header-context>`
+      html`<clabs-global-header-context></clabs-global-header-context>`
     );
     expect(el?.shadowRoot).not.to.be.null;
   });
@@ -136,13 +136,13 @@ describe('HeaderContext Component', () => {
   describe('test isAuthenticated', () => {
     it('renders unauthenticated context when no profile is in header props', async () => {
       const el = await fixture(
-        html`<apaas-header-context
-          .props="${unauthenticatedProps}"></apaas-header-context>`
+        html`<clabs-global-header-context
+          .props="${unauthenticatedProps}"></clabs-global-header-context>`
       );
 
       // make sure that the 'unauthenticated-context' is rendered in this case.
       const unauthenticated = el.shadowRoot?.querySelector(
-        'apaas-unauthenticated-context'
+        'clabs-global-header-unauthenticated-context'
       );
       expect(unauthenticated).not.to.be.null;
 
@@ -152,29 +152,33 @@ describe('HeaderContext Component', () => {
 
     it('renders the header nav when a profile is in the header props', async () => {
       const el = await fixture(
-        html`<apaas-header-context
-          .props="${headerProps}"></apaas-header-context>`
+        html`<clabs-global-header-context
+          .props="${headerProps}"></clabs-global-header-context>`
       );
 
       // make sure that the 'unauthenticated-context' is not rendered in this case.
       const unauthenticated = el.shadowRoot?.querySelector(
-        'apaas-unauthenticated-context'
+        'clabs-global-header-unauthenticated-context'
       );
       expect(unauthenticated).to.be.null;
 
       // expect that the environment switcher has been rendered as switcherConfigs is present
-      const switcher = el.shadowRoot?.querySelector('apaas-switcher-component');
+      const switcher = el.shadowRoot?.querySelector(
+        'clabs-global-header-switcher-component'
+      );
       expect(switcher).not.to.be.null;
 
       // expect the profile popover is present as a profile object is present
-      const popover = el.shadowRoot?.querySelector('apaas-profile-popover');
+      const popover = el.shadowRoot?.querySelector(
+        'clabs-global-header-profile-popover'
+      );
       expect(popover).not.to.be.null;
     });
 
     it('profile menu can toggle', async () => {
       const el = await fixture<HeaderContext>(
-        html`<apaas-header-context
-          .props="${{ ...headerProps }}"></apaas-header-context>`
+        html`<clabs-global-header-context
+          .props="${{ ...headerProps }}"></clabs-global-header-context>`
       );
 
       const toggleProfilePopupSpy = sinon.spy(el, '_toggleProfilePopup');
@@ -219,8 +223,11 @@ describe('HeaderContext Component', () => {
 
     it('renders help links when prop is passed in', async () => {
       const el = await fixture(
-        html`<apaas-header-context
-          .props="${{ ...headerProps, helperLinks }}"></apaas-header-context>`
+        html`<clabs-global-header-context
+          .props="${{
+            ...headerProps,
+            helperLinks,
+          }}"></clabs-global-header-context>`
       );
 
       const helpMenu = el.shadowRoot?.querySelector('[menu-label="Help"]');
@@ -237,11 +244,11 @@ describe('HeaderContext Component', () => {
         'initAssistMeController'
       );
       const el = await fixture(
-        html`<apaas-header-context
+        html`<clabs-global-header-context
           .props="${{
             ...headerProps,
             assistMeConfigs,
-          }}"></apaas-header-context>`
+          }}"></clabs-global-header-context>`
       );
 
       const helpMenu = el.shadowRoot?.querySelector(
@@ -278,8 +285,11 @@ describe('HeaderContext Component', () => {
 
     it('renders the trial menu action', async () => {
       const el = await fixture(
-        html`<apaas-header-context
-          .props="${{ ...headerProps, trialConfigs }}"></apaas-header-context>`
+        html`<clabs-global-header-context
+          .props="${{
+            ...headerProps,
+            trialConfigs,
+          }}"></clabs-global-header-context>`
       );
       const trialMenuAction = el?.shadowRoot?.querySelector(
         '[type="button"], [aria-label="Trial Menu"]'
@@ -289,8 +299,11 @@ describe('HeaderContext Component', () => {
 
     it('trial menu action can toggle', async () => {
       const el = await fixture<HeaderContext>(
-        html`<apaas-header-context
-          .props="${{ ...headerProps, trialConfigs }}"></apaas-header-context>`
+        html`<clabs-global-header-context
+          .props="${{
+            ...headerProps,
+            trialConfigs,
+          }}"></clabs-global-header-context>`
       );
       expect(el.isTrialOpen).to.equal(false);
 
@@ -317,11 +330,11 @@ describe('HeaderContext Component', () => {
 
     it('check the chatbot action renders', async () => {
       const el = await fixture(
-        html`<apaas-header-context
+        html`<clabs-global-header-context
           .props="${{
             ...headerProps,
             chatBotConfigs,
-          }}"></apaas-header-context>`
+          }}"></clabs-global-header-context>`
       );
       expect(el).not.to.be.null;
 
@@ -344,11 +357,11 @@ describe('HeaderContext Component', () => {
 
     it('renders the notification menu', async () => {
       const el = await fixture(
-        html`<apaas-header-context
+        html`<clabs-global-header-context
           .props="${{
             ...headerProps,
             notificationConfigs,
-          }}"></apaas-header-context>`
+          }}"></clabs-global-header-context>`
       );
       expect(el).not.to.be.null;
 
@@ -370,11 +383,11 @@ describe('HeaderContext Component', () => {
 
     it('renders the notification menu', async () => {
       const el = await fixture(
-        html`<apaas-header-context
+        html`<clabs-global-header-context
           .props="${{
             ...headerProps,
             notificationConfigs: notificationConfigsNew,
-          }}"></apaas-header-context>`
+          }}"></clabs-global-header-context>`
       );
       expect(el).not.to.be.null;
 
@@ -392,11 +405,11 @@ describe('HeaderContext Component', () => {
 
   describe('webMethods Hybrid Integration divider', async () => {
     const el = await fixture(
-      html`<apaas-header-context
+      html`<clabs-global-header-context
         .props="${{
           ...headerProps,
           isHybridIpaas: true,
-        }}"></apaas-header-context>`
+        }}"></clabs-global-header-context>`
     );
     expect(el).not.to.be.null;
 
@@ -414,12 +427,17 @@ describe('HeaderContext Component', () => {
 
     it('renders', async () => {
       const el = await fixture(
-        html`<apaas-header-context
-          .props="${{ ...headerProps, searchConfigs }}"></apaas-header-context>`
+        html`<clabs-global-header-context
+          .props="${{
+            ...headerProps,
+            searchConfigs,
+          }}"></clabs-global-header-context>`
       );
       expect(el).not.to.be.null;
 
-      const search = el?.shadowRoot?.querySelector('apaas-header-search');
+      const search = el?.shadowRoot?.querySelector(
+        'clabs-global-header-search'
+      );
       expect(search).to.exist;
     });
   });
@@ -436,11 +454,11 @@ describe('HeaderContext Component', () => {
 
     it('renders the notification menu', async () => {
       const el = await fixture(
-        html`<apaas-header-context
+        html`<clabs-global-header-context
           .props="${{
             ...headerProps,
             globalActionConfigs,
-          }}"></apaas-header-context>`
+          }}"></clabs-global-header-context>`
       );
       expect(el).not.to.be.null;
       const globalAction = el?.shadowRoot?.querySelector(

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/_index.scss
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/_index.scss
@@ -17,7 +17,7 @@ cds-custom-header-global-action.mcsp-header-user-profile {
   inline-size: 48px;
 }
 
-cds-custom-header-global-action apaas-user-profile-image {
+cds-custom-header-global-action clabs-global-header-user-profile-image {
   inline-size: 100%;
 }
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/ProfilePopover/ProfilePopover.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/ProfilePopover/ProfilePopover.ts
@@ -10,14 +10,17 @@
 
 import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import styles from './_index.scss?inline';
 import { animate, fadeIn, fadeOut } from '@lit-labs/motion';
 import { HeaderContextProps } from '../HeaderContext/HeaderContext.types';
 
+const { stablePrefix: clabsPrefix } = settings;
+
 /**
  * Contents of the profile menu
  */
-@customElement('apaas-profile-popover')
+@customElement(`${clabsPrefix}-global-header-profile-popover`)
 export class AuthContext extends LitElement {
   static styles = css`
     ${unsafeCSS([styles])}
@@ -83,7 +86,7 @@ export class AuthContext extends LitElement {
             ? html` <div
                 class="automation-header__tooltip"
                 ${animate({ in: fadeIn, out: fadeOut })}>
-                <apaas-auth-context
+                <clabs-global-header-auth-context
                   .props="${{
                     profile,
                     mainSectionItems,
@@ -91,7 +94,7 @@ export class AuthContext extends LitElement {
                     userManagement,
                     managementConsole,
                     profileFooterLinks,
-                  }}"></apaas-auth-context>
+                  }}"></clabs-global-header-auth-context>
               </div>`
             : nothing}
         </cds-custom-popover-content>

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/ProfilePopover/__tests__/ProfilePopover.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/ProfilePopover/__tests__/ProfilePopover.test.ts
@@ -18,17 +18,19 @@ describe('ProfilePopover Component', () => {
       managementConsole: undefined,
     };
     const el = await fixture(
-      html`<apaas-profile-popover
+      html`<clabs-global-header-profile-popover
         ?profileOpen="${true}"
         .props="${props}"
-        ?activeProfileMenu="${false}"></apaas-profile-popover>`
+        ?activeProfileMenu="${false}"></clabs-global-header-profile-popover>`
     );
     const popoverContainer = el.shadowRoot?.querySelector(
       'cds-custom-popover-content'
     );
 
     expect(popoverContainer).to.exist;
-    const authContext = popoverContainer?.querySelector('apaas-auth-context');
+    const authContext = popoverContainer?.querySelector(
+      'clabs-global-header-auth-context'
+    );
     expect(authContext).to.exist;
   });
 });

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/Search/Search.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/Search/Search.ts
@@ -10,15 +10,18 @@
 
 import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import '@carbon/web-components/es-custom/components/search/index.js';
 
 import styles from './_index.scss?inline' assert { type: 'css' };
 import { SearchConfigs } from '../../types/Header.types';
 
+const { stablePrefix: clabsPrefix } = settings;
+
 /**
  * Optional search box for the header
  */
-@customElement('apaas-header-search')
+@customElement(`${clabsPrefix}-global-header-search`)
 export class Search extends LitElement {
   static styles = css`
     ${unsafeCSS([styles])}

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/Search/__tests__/Search.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/Search/__tests__/Search.test.ts
@@ -18,7 +18,7 @@ import { Search } from '../Search';
 describe('Search Component', () => {
   it('renders component', async () => {
     const el = await fixture<HTMLElement>(
-      html` <apaas-header-search></apaas-header-search>`
+      html` <clabs-global-header-search></clabs-global-header-search>`
     );
     expect(el.shadowRoot).not.to.be.null;
 
@@ -34,7 +34,7 @@ describe('Search Component', () => {
 
     const consoleLogStub = sinon.stub(console, 'log');
     const el = await fixture<Search>(
-      html` <apaas-header-search .props=""></apaas-header-search>`
+      html` <clabs-global-header-search .props=""></clabs-global-header-search>`
     );
     expect(el.shadowRoot).not.to.be.null;
 
@@ -55,7 +55,8 @@ describe('Search Component', () => {
     };
 
     const el = await fixture<Search>(
-      html` <apaas-header-search .props="${props}"></apaas-header-search>`
+      html` <clabs-global-header-search
+        .props="${props}"></clabs-global-header-search>`
     );
     expect(el.shadowRoot).not.to.be.null;
 
@@ -74,7 +75,8 @@ describe('Search Component', () => {
     };
 
     const el = await fixture<Search>(
-      html` <apaas-header-search .props="${props}"></apaas-header-search>`
+      html` <clabs-global-header-search
+        .props="${props}"></clabs-global-header-search>`
     );
     expect(el.shadowRoot).not.to.be.null;
 
@@ -96,7 +98,8 @@ describe('Search Component', () => {
       };
 
       const el = await fixture<Search>(
-        html` <apaas-header-search .props="${props}"></apaas-header-search>`
+        html` <clabs-global-header-search
+          .props="${props}"></clabs-global-header-search>`
       );
       expect(el.shadowRoot).not.to.be.null;
 
@@ -118,7 +121,8 @@ describe('Search Component', () => {
       };
 
       const el = await fixture<Search>(
-        html` <apaas-header-search .props="${props}"></apaas-header-search>`
+        html` <clabs-global-header-search
+          .props="${props}"></clabs-global-header-search>`
       );
       expect(el.shadowRoot).not.to.be.null;
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/SideNavItem/SideNavItem.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/SideNavItem/SideNavItem.ts
@@ -15,13 +15,16 @@ import { SideNavLink, SideNavMenuItems } from '../../types/Header.types';
 import cx from 'classnames';
 import { AUTOMATION_NAMESPACE_PREFIX } from '../../constant';
 import { customElement, property, state } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import { renderCarbonIcon, trackEvent } from '../../globals/utils';
 import styles from './SideNavItem.scss?inline';
+
+const { stablePrefix: clabsPrefix } = settings;
 
 /**
  * Entries for the left-hand Apps menu
  */
-@customElement('apaas-side-nav-item')
+@customElement(`${clabsPrefix}-global-header-side-nav-item`)
 export class SideNavItem extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/SideNavItem/__tests__/SideNavItem.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/SideNavItem/__tests__/SideNavItem.test.ts
@@ -65,7 +65,9 @@ const sideItemWithMenuItems: SideNavLink = {
 
 describe('SideNavItem Component', () => {
   it('renders side nav item with no props', async () => {
-    const el = await fixture(html`<apaas-side-nav-item></apaas-side-nav-item>`);
+    const el = await fixture(
+      html`<clabs-global-header-side-nav-item></clabs-global-header-side-nav-item>`
+    );
     expect(el).to.exist;
 
     const popover = el.shadowRoot?.querySelector(
@@ -77,7 +79,8 @@ describe('SideNavItem Component', () => {
   describe('default behaviour', () => {
     it('renders side nav item no menu items when not collapsable', async () => {
       const el = await fixture(
-        html`<apaas-side-nav-item .link="${sideItem}"></apaas-side-nav-item>`
+        html`<clabs-global-header-side-nav-item
+          .link="${sideItem}"></clabs-global-header-side-nav-item>`
       );
       expect(el).to.exist;
 
@@ -94,8 +97,8 @@ describe('SideNavItem Component', () => {
 
     it('renders side nav item with no icon', async () => {
       const el = await fixture(
-        html`<apaas-side-nav-item
-          .link="${sideItemNoIcon}"></apaas-side-nav-item>`
+        html`<clabs-global-header-side-nav-item
+          .link="${sideItemNoIcon}"></clabs-global-header-side-nav-item>`
       );
       expect(el).to.exist;
 
@@ -109,10 +112,10 @@ describe('SideNavItem Component', () => {
   describe('renders when isCollapsible is passed in', () => {
     it('renders side nav item when isCollapsible is true and has handleSideNavLinkClick prop', async () => {
       const el = await fixture(
-        html`<apaas-side-nav-item
+        html`<clabs-global-header-side-nav-item
           .link="${sideItemWithClickHandler}"
           .isOnClickAvailable="${true}"
-          .isCollapsible="${true}"></apaas-side-nav-item>`
+          .isCollapsible="${true}"></clabs-global-header-side-nav-item>`
       );
       expect(el).to.exist;
 
@@ -123,9 +126,9 @@ describe('SideNavItem Component', () => {
 
     it('renders side nav item when isCollapsible is true and has not handleSideNavLinkClick prop', async () => {
       const el = await fixture(
-        html`<apaas-side-nav-item
+        html`<clabs-global-header-side-nav-item
           .link="${sideItem}"
-          .isCollapsible="${true}"></apaas-side-nav-item>`
+          .isCollapsible="${true}"></clabs-global-header-side-nav-item>`
       );
       expect(el).to.exist;
 
@@ -137,12 +140,12 @@ describe('SideNavItem Component', () => {
 
   it('renders side nav item with sub menus', async () => {
     const el = await fixture(
-      html`<apaas-side-nav-item
+      html`<clabs-global-header-side-nav-item
         .menuOpen="${true}"
         .link="${sideItemWithMenuItems}"
         .isCollapsible="${true}"
         .isSideNavMenuItems="${true}"
-        .isActive="${false}"></apaas-side-nav-item>`
+        .isActive="${false}"></clabs-global-header-side-nav-item>`
     );
     expect(el).to.exist;
 
@@ -172,12 +175,12 @@ describe('SideNavItem Component', () => {
     it('handleSideNavLinkClick can be called', async () => {
       const onClickSpy = sinon.spy();
       const el = await fixture(
-        html`<apaas-side-nav-item
+        html`<clabs-global-header-side-nav-item
           .link="${sideItem}"
           .isCollapsible="${true}"
           .isSideNavMenuItems="${false}"
           .isOnClickAvailable="${true}"
-          .handleNavItemClick="${onClickSpy}"></apaas-side-nav-item>`
+          .handleNavItemClick="${onClickSpy}"></clabs-global-header-side-nav-item>`
       );
       expect(el).to.exist;
 
@@ -196,7 +199,7 @@ describe('SideNavItem Component', () => {
       const onClickSpy = sinon.spy();
 
       const el = await fixture(
-        html`<apaas-side-nav-item
+        html`<clabs-global-header-side-nav-item
           .link="${{
             ...sideItem,
             sideNavMenuItems: [
@@ -209,7 +212,7 @@ describe('SideNavItem Component', () => {
             ],
           }}"
           .isCollapsible="${true}"
-          .isSideNavMenuItems="${true}"></apaas-side-nav-item>`
+          .isSideNavMenuItems="${true}"></clabs-global-header-side-nav-item>`
       );
       expect(el).to.exist;
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/Switcher/Switcher.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/Switcher/Switcher.ts
@@ -10,6 +10,7 @@
 
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 
 /* c8 ignore next */
 import cx from 'classnames';
@@ -20,10 +21,12 @@ import { unsafeCSS } from 'lit';
 import styles from './_index.scss?inline';
 import { renderCarbonIcon, trackEvent } from '../../globals/utils';
 
+const { stablePrefix: clabsPrefix } = settings;
+
 /**
  * Environment switcher
  */
-@customElement('apaas-switcher-component')
+@customElement(`${clabsPrefix}-global-header-switcher-component`)
 export class Switcher extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/Switcher/__tests__/Switcher.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/Switcher/__tests__/Switcher.test.ts
@@ -82,11 +82,11 @@ describe('Switcher Component', () => {
   };
   it('should render items passed as a property', async () => {
     const el = await fixture<HTMLElement>(
-      html` <apaas-switcher-component
+      html` <clabs-global-header-switcher-component
         .items=${switcherConfigs.items}
         .iconsLeft=${switcherConfigs.iconsLeft}
         .disabled=${switcherConfigs.disabled}
-        .initialSelectedIndex=${switcherConfigs.initialSelectedIndex}></apaas-switcher-component>`
+        .initialSelectedIndex=${switcherConfigs.initialSelectedIndex}></clabs-global-header-switcher-component>`
     );
     const renderedItems = el.shadowRoot?.querySelectorAll(
       'cds-custom-header-menu-item'
@@ -100,8 +100,8 @@ describe('Switcher Component', () => {
       { label: 'Item 2', id: 'item2' },
     ];
     const el = await fixture<Switcher>(
-      html`<apaas-switcher-component
-        .items=${items}></apaas-switcher-component>`
+      html`<clabs-global-header-switcher-component
+        .items=${items}></clabs-global-header-switcher-component>`
     );
     const firstItem = el.shadowRoot?.querySelector(
       'cds-custom-header-menu-item'
@@ -119,8 +119,8 @@ describe('Switcher Component', () => {
       { label: 'Item 3', id: 'item3' },
     ];
     const el = await fixture<Switcher>(
-      html`<apaas-switcher-component
-        .items=${items}></apaas-switcher-component>`
+      html`<clabs-global-header-switcher-component
+        .items=${items}></clabs-global-header-switcher-component>`
     );
     await el.updateComplete;
     const secondMenuItem = el.shadowRoot?.querySelectorAll(
@@ -149,9 +149,9 @@ describe('Switcher Component', () => {
       { label: 'Item 2', id: 'item2' },
     ];
     const el = await fixture<Switcher>(
-      html`<apaas-switcher-component
+      html`<clabs-global-header-switcher-component
         .items=${items}
-        .initialSelectedIndex=${1}></apaas-switcher-component>`
+        .initialSelectedIndex=${1}></clabs-global-header-switcher-component>`
     );
     await el.updateComplete;
     const secondItem = el.shadowRoot?.querySelectorAll(
@@ -170,9 +170,9 @@ describe('Switcher Component', () => {
       { label: 'Item 2', id: 'item2' },
     ];
     const el = await fixture<Switcher>(
-      html`<apaas-switcher-component
+      html`<clabs-global-header-switcher-component
         .items=${items}
-        .disabled=${true}></apaas-switcher-component>`
+        .disabled=${true}></clabs-global-header-switcher-component>`
     );
     const headerMenu = el.shadowRoot?.querySelector('cds-custom-header-menu');
     expect(headerMenu).to.exist;
@@ -191,10 +191,10 @@ describe('Switcher Component', () => {
     ];
     const handleClick = sinon.spy();
     const el = await fixture<Switcher>(
-      html`<apaas-switcher-component
+      html`<clabs-global-header-switcher-component
         .items=${items}
         .disabled=${false}
-        .onClick=${handleClick}></apaas-switcher-component>`
+        .onClick=${handleClick}></clabs-global-header-switcher-component>`
     );
     await el.updateComplete;
     const secondItem = el.shadowRoot?.querySelectorAll(

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/TrialPopover/TrialPopover.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/TrialPopover/TrialPopover.ts
@@ -10,6 +10,7 @@
 
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import '@carbon/web-components/es-custom/components/popover/index.js';
 import { TrialContent } from '../TrialContent/TrialContent';
 import { unsafeCSS } from 'lit';
@@ -18,10 +19,12 @@ import { animate, fadeIn, fadeOut } from '@lit-labs/motion';
 import styles from './_index.scss?inline';
 import { TrialConfigs } from '../../types/Header.types';
 
+const { stablePrefix: clabsPrefix } = settings;
+
 /**
  * Content to show when clicking the Trial entry in the header
  */
-@customElement('apaas-trial-popover')
+@customElement(`${clabsPrefix}-global-header-trial-popover`)
 export class TrialPopover extends LitElement {
   @property({ type: Boolean }) open = false;
   @property({ type: Object }) trialConfig: TrialConfigs = {};

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/TrialPopover/__tests__/TrialPopover.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/TrialPopover/__tests__/TrialPopover.test.ts
@@ -15,9 +15,9 @@ describe('TrialPopover Component', () => {
   it('renders cds-popover with cds-popover-content', async () => {
     const props = { description: 'Test Description' };
     const el = await fixture(
-      html`<apaas-trial-popover
+      html`<clabs-global-header-trial-popover
         .open="true"
-        .trialConfig="${props}"></apaas-trial-popover>`
+        .trialConfig="${props}"></clabs-global-header-trial-popover>`
     );
     const popover = el.shadowRoot?.querySelector('cds-custom-popover');
 
@@ -29,9 +29,9 @@ describe('TrialPopover Component', () => {
   it('does not render the description when not provided', async () => {
     const props = {};
     const el = await fixture(
-      html` <apaas-trial-popover
+      html` <clabs-global-header-trial-popover
         .open="true"
-        .trialConfig="${props}"></apaas-trial-popover>`
+        .trialConfig="${props}"></clabs-global-header-trial-popover>`
     );
     const description = el.shadowRoot?.querySelector(
       `.${AUTOMATION_HEADER_BASE_CLASS}__tooltip-description`
@@ -49,9 +49,9 @@ describe('TrialPopover Component', () => {
       ],
     };
     const el = await fixture(html`
-      <apaas-trial-popover
+      <clabs-global-header-trial-popover
         ?open="${true}"
-        .trialConfig="${props}"></apaas-trial-popover>
+        .trialConfig="${props}"></clabs-global-header-trial-popover>
     `);
     const links = el.shadowRoot?.querySelectorAll(
       `.${AUTOMATION_HEADER_BASE_CLASS}__tooltip-link`
@@ -63,9 +63,9 @@ describe('TrialPopover Component', () => {
   it('renders the description when provided', async () => {
     const props = { description: 'Test Description' };
     const el = await fixture(
-      html`<apaas-trial-popover
+      html`<clabs-global-header-trial-popover
         ?open="${true}"
-        .trialConfig="${props}"></apaas-trial-popover>`
+        .trialConfig="${props}"></clabs-global-header-trial-popover>`
     );
     const description = el.shadowRoot?.querySelector(
       `.${AUTOMATION_HEADER_BASE_CLASS}__tooltip-description`
@@ -78,9 +78,9 @@ describe('TrialPopover Component', () => {
   it('renders the action link when actionText and actionLink are provided', async () => {
     const props = { actionText: 'Action', actionLink: '#' };
     const el = await fixture(
-      html`<apaas-trial-popover
+      html`<clabs-global-header-trial-popover
         ?open="${true}"
-        .trialConfig="${props}"></apaas-trial-popover>`
+        .trialConfig="${props}"></clabs-global-header-trial-popover>`
     );
     const actionLink = el.shadowRoot?.querySelector(
       `.${AUTOMATION_HEADER_BASE_CLASS}__trial-button`

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/UnauthenticatedContext/UnauthenticatedContext.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/UnauthenticatedContext/UnauthenticatedContext.stories.ts
@@ -41,8 +41,8 @@ export const Basic: Story = {
         <cds-custom-header-name>IBM</cds-custom-header-name>
         <cds-custom-header-nav menu-bar-label="IBM [Platform]">
         </cds-custom-header-nav>
-        <apaas-unauthenticated-context
-          .noAuthHeaderLinks="${defaultNoAuthHeaderLinks}"></apaas-unauthenticated-context>
+        <clabs-global-header-unauthenticated-context
+          .noAuthHeaderLinks="${defaultNoAuthHeaderLinks}"></clabs-global-header-unauthenticated-context>
       </cds-custom-header>
     </div>
   `,

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/UnauthenticatedContext/UnauthenticatedContext.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/UnauthenticatedContext/UnauthenticatedContext.ts
@@ -10,6 +10,7 @@
 
 import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import { NoAuthHeaderLinks } from '../../types/Header.types';
 import { renderCarbonIcon } from '../../globals/utils';
 import '@carbon/web-components/es-custom/components/ui-shell/index.js';
@@ -23,10 +24,12 @@ import {
 } from '../../constant';
 import styles from '../_index.scss?inline';
 
+const { stablePrefix: clabsPrefix } = settings;
+
 /**
  * Content to show when not logged in
  */
-@customElement('apaas-unauthenticated-context')
+@customElement(`${clabsPrefix}-global-header-unauthenticated-context`)
 export class UnauthenticatedContext extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/UnauthenticatedContext/__tests__/UnauthenticatedContext.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/UnauthenticatedContext/__tests__/UnauthenticatedContext.test.ts
@@ -13,7 +13,7 @@ import '../UnauthenticatedContext';
 describe('Unauthenticated Component', () => {
   it('renders default unauthenticated buttons', async () => {
     const el = await fixture(html`
-      <apaas-unauthenticated-context></apaas-unauthenticated-context>
+      <clabs-global-header-unauthenticated-context></clabs-global-header-unauthenticated-context>
     `);
     const buttons = el.shadowRoot?.querySelectorAll('[role="listitem"]');
 
@@ -25,7 +25,7 @@ describe('Unauthenticated Component', () => {
 
   it('renders prop unauthenticated buttons', async () => {
     const el = await fixture(html`
-      <apaas-unauthenticated-context
+      <clabs-global-header-unauthenticated-context
         .noAuthHeaderLinks="${[
           {
             text: 'Test Link',
@@ -33,7 +33,7 @@ describe('Unauthenticated Component', () => {
             carbonIcon: 'Document',
             arialLabel: 'Test Link',
           },
-        ]}"></apaas-unauthenticated-context>
+        ]}"></clabs-global-header-unauthenticated-context>
     `);
     const buttons = el.shadowRoot?.querySelectorAll('[role="listitem"]');
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/UserProfileImage/UserProfileImage.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/UserProfileImage/UserProfileImage.ts
@@ -10,6 +10,7 @@
 
 import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities/es/settings/index.js';
 import { renderCarbonIcon } from '../../globals/utils';
 
 /* c8 ignore next */
@@ -19,10 +20,12 @@ import styles from './UserProfileImage.scss?inline' assert { type: 'css' };
 import { AUTOMATION_HEADER_BASE_CLASS } from '../../constant';
 const blockClass = `${AUTOMATION_HEADER_BASE_CLASS}__user-profile-image`;
 
+const { stablePrefix: clabsPrefix } = settings;
+
 /**
  * User image for the profile menu
  */
-@customElement('apaas-user-profile-image')
+@customElement(`${clabsPrefix}-global-header-user-profile-image`)
 export class SideNavItem extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/UserProfileImage/__tests__/UserProfileImage.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/UserProfileImage/__tests__/UserProfileImage.test.ts
@@ -13,8 +13,8 @@ import '../UserProfileImage';
 describe('UserProfileImage Component', () => {
   it('renders the basic component with initial', async () => {
     const el = await fixture(
-      html`<apaas-user-profile-image
-        initials="test user"></apaas-user-profile-image>`
+      html`<clabs-global-header-user-profile-image
+        initials="test user"></clabs-global-header-user-profile-image>`
     );
     const profileImageContainer = el.shadowRoot?.querySelector(
       '.automation-global-header__user-profile-image'
@@ -26,7 +26,8 @@ describe('UserProfileImage Component', () => {
 
   it('renders the basic component with lower case initials', async () => {
     const el = await fixture(
-      html`<apaas-user-profile-image initials="ab"></apaas-user-profile-image>`
+      html`<clabs-global-header-user-profile-image
+        initials="ab"></clabs-global-header-user-profile-image>`
     );
     const profileImageContainer = el.shadowRoot?.querySelector(
       '.automation-global-header__user-profile-image'
@@ -38,9 +39,9 @@ describe('UserProfileImage Component', () => {
 
   it('renders the basic component with lower case initials', async () => {
     const el = await fixture(
-      html`<apaas-user-profile-image
+      html`<clabs-global-header-user-profile-image
         initials="test user"
-        image="test_value"></apaas-user-profile-image>`
+        image="test_value"></clabs-global-header-user-profile-image>`
     );
     const profileImageContainer = el.shadowRoot?.querySelector(
       '.automation-global-header__user-profile-image'
@@ -51,9 +52,9 @@ describe('UserProfileImage Component', () => {
 
   it('renders the basic component with carbon icon', async () => {
     const el = await fixture(
-      html`<apaas-user-profile-image
+      html`<clabs-global-header-user-profile-image
         kind="User"
-        size="20"></apaas-user-profile-image>`
+        size="20"></clabs-global-header-user-profile-image>`
     );
     const profileImageContainer = el.shadowRoot?.querySelector(
       '.automation-global-header__user-profile-image'
@@ -64,7 +65,7 @@ describe('UserProfileImage Component', () => {
 
   it('renders the profile icon if initial prop is not passed in', async () => {
     const el = await fixture(
-      html`<apaas-user-profile-image></apaas-user-profile-image>`
+      html`<clabs-global-header-user-profile-image></clabs-global-header-user-profile-image>`
     );
     const profileImageContainer = el.shadowRoot?.querySelector(
       '.automation-global-header__user-profile-image'


### PR DESCRIPTION

**Changed**

- Rename all internal components to use the "clabs" prefix