### PR TITLE
docs: add link to carbon labs docs on carbon for ibm products website

### DIFF
--- a/.storybook/welcome/Welcome.jsx
+++ b/.storybook/welcome/Welcome.jsx
@@ -27,7 +27,7 @@ export const Welcome = () => {
             Carbon Design System
           </Link>
           <Link
-            href="https://w3.ibm.com/design/carbon-for-ibm-products/labs"
+            href="https://pages.github.ibm.com/carbon/ibm-products/contributing/carbon-labs/"
             className="welcome__link"
             renderIcon={ArrowRight}>
             Carbon Labs (IBM internal)


### PR DESCRIPTION
Add a new link to the Welcome screen for Carbon labs to the IBM Products Labs page