### PR TITLE
docs(uishell): disable a11y checker for demo story

### DIFF
--- a/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/__stories__/UIShell.stories.js
@@ -742,4 +742,6 @@ export const Demo = () => {
 Demo.parameters = {
   controls: { disable: true },
   actions: { disable: true },
+  a11y: { disable: true },
+  accessibilityChecker: { disable: true },
 };


### PR DESCRIPTION
The UI Shell Demo story experiences a 3-4 second delay before becoming interactive in Storybook. This is due to the accessibility checker scanning every element on render.

This PR disables both a11y addons (`@storybook/addon-a11y` and `storybook-addon-accessibility-checker`) for the UI Shell Demo story only . Individual component stories are unaffected and can still be tested for accessibility issues.

#### Changelog

**Changed**

- Disable `@storybook/addon-a11y` and `storybook-addon-accessibility-checker` for UI Shell Demo story


#### Testing / Reviewing

Check load time for UI Shell demo story