### PR TITLE
fix(global-header): Export HybridIpaasHeaderReactWrapper correctly

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/global-header.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/global-header.ts
@@ -13,7 +13,7 @@ import globalHeader from './src/global-header.template.js';
 
 export { CommonHeader } from './src/components/CommonHeader/CommonHeader.js';
 export { HybridIpaasHeader } from './src/components/HybridIpaasHeader/HybridIpaasHeader.js';
-export { HybridIpaasHeaderReactWrapper } from './src/components/HybridIpaasHeaderReactWrapper/HybridIpaasHeaderReactWrapper';
+export { HybridIpaasHeaderReactWrapper } from './src/components/HybridIpaasHeaderReactWrapper/HybridIpaasHeaderReactWrapper.js';
 export { LogoutHeader } from './src/components/LogoutHeader/LogoutHeader.js';
 export { LogoutTile } from './src/components/LogoutTile/LogoutTile.js';
 

--- a/packages/web-components/src/components/global-header/vite.config.js
+++ b/packages/web-components/src/components/global-header/vite.config.js
@@ -29,4 +29,7 @@ export default defineConfig({
       scss: {},
     },
   },
+  define: {
+    'process.env.NODE_ENV': '"production"',
+  },
 });


### PR DESCRIPTION
Part of [APPCONNECT-36870](https://jsw.ibm.com/browse/APPCONNECT-36870)

Exports the HybridIpaasHeaderReactWrapper component from the correct file

#### Changelog

**Changed**

- Exports the HybridIpaasHeaderReactWrapper component from the correct file

**Removed**

- Removes the index.ts file from the global-header src
