### PR TITLE
chore: allow release workflow to be triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        description:
+          'Run as dry run'
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -38,8 +45,13 @@ jobs:
       - name: Set NPM token
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
+      - name: Set dry run env variable
+        run: |
+          if [ "${{ github.event.inputs.dry-run }}" == "false"  ]; then
+            echo "PUBLISH=--yes" >> $GITHUB_ENV
+          fi
       - name: Publish minor release of packages
         run: |
-          yarn lerna publish minor --dist-tag latest --yes --message 'chore: release'
+          yarn lerna publish minor --dist-tag latest ${{ env.PUBLISH }} --message 'chore: release'
         env:
           GH_TOKEN: ${{ secrets.MERGE_ACTION }}


### PR DESCRIPTION
Add option for release workflow to be triggered manually and also allow for dry-run
