### PR TITLE
fix(global-header): Change reports_enabled to overview_enabled

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -168,7 +168,7 @@ export class HybridIpaasHeader extends LitElement {
       isEnabled: this.solisSidekickEnabled,
       scriptUrl: SOLIS_CDN_HOSTNAMES[env] + '/sidekick/solis-sidekick.es.js',
       insights_enabled: true,
-      reports_enabled: true,
+      overview_enabled: true,
       chat_enabled: false,
       tell_me_more_enabled: false,
     };


### PR DESCRIPTION
Part of [APPCONNECT-38372](https://jsw.ibm.com/browse/APPCONNECT-38372)

The property `reports_enabled` no longer exists on the sidekick object, it has been changed to `overview_enabled`.

#### Changelog

**Changed**

- Changes Solis Sidekick property from `reports_enabled` to `overview_enabled`
