### PR TITLE
fix(global-header): Change reports_enabled to overview_enabled everywhere

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/CommonHeader.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/CommonHeader.stories.ts
@@ -454,7 +454,7 @@ const sidekickConfig = {
   context: 'application',
   insights_enabled: true,
   chat_enabled: true,
-  reports_enabled: true,
+  overview_enabled: true,
   tell_me_more_enabled: true,
 };
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/loadSidekickScript.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/loadSidekickScript.test.ts
@@ -49,7 +49,7 @@ const propsWithSidekickConfig: HeaderProps = {
     product: 'someproduct',
     insights_enabled: true,
     chat_enabled: true,
-    reports_enabled: true,
+    overview_enabled: true,
     tell_me_more_enabled: true,
   },
   solisConfig: {

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/loadSidekickScript.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/loadSidekickScript.ts
@@ -47,7 +47,7 @@ export default function loadSidekickScript(props: HeaderProps) {
       context: props.sidekickConfig.context,
       insights_enabled: props.sidekickConfig.insights_enabled,
       chat_enabled: props.sidekickConfig.chat_enabled,
-      reports_enabled: props.sidekickConfig.reports_enabled,
+      overview_enabled: props.sidekickConfig.overview_enabled,
       tell_me_more_enabled: props.sidekickConfig.tell_me_more_enabled,
     };
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
@@ -264,7 +264,7 @@ export type SidekickConfig = {
   context?: string;
   insights_enabled?: boolean;
   chat_enabled?: boolean;
-  reports_enabled?: boolean;
+  overview_enabled?: boolean;
   tell_me_more_enabled?: boolean;
 };
 
@@ -357,7 +357,7 @@ export type SidekickInfo = {
   context?: string;
   insights_enabled?: boolean;
   chat_enabled?: boolean;
-  reports_enabled?: boolean;
+  overview_enabled?: boolean;
   tell_me_more_enabled?: boolean;
 };
 


### PR DESCRIPTION
Part of [APPCONNECT-38372](https://jsw.ibm.com/browse/APPCONNECT-38372)

Follow on from https://github.com/carbon-design-system/carbon-labs/pull/972, for Solis sidekick this PR changes `reports_enabled` to `overview_enabled` everywhere.

#### Changelog

**Changed**

- For Solis sidekick, changes `reports_enabled` to `overview_enabled` everywhere.

