### PR TITLE
fix(global-header): Header sidenav active

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/SideNavItem/SideNavItem.scss
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/SideNavItem/SideNavItem.scss
@@ -16,20 +16,6 @@
 
 .ibm-automation-cds--rail-sidePanel {
   inline-size: $spacing-09 !important;
-
-  a.ibm-automation-cds--side-nav__link[aria-current='page']::before,
-  a.ibm-automation-cds--side-nav__link--current::before {
-    background-color: $background-brand !important;
-  }
-}
-
-.ibm-automation-cds--side-nav__link--current::before {
-  position: absolute;
-  background-color: $background-brand;
-  content: '';
-  inline-size: 3px;
-  inset-block: 0;
-  inset-inline-start: 0;
 }
 
 .ibm-automation-cds--side-nav__items {

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/SideNavItem/SideNavItem.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/SideNavItem/SideNavItem.ts
@@ -148,6 +148,7 @@ export class SideNavItem extends LitElement {
                 this.isActive,
             })}"
             role="link"
+            ?active="${this.isActive}"
             href="${this.link?.href}"
             @click="${(e: Event) =>
               this.handleSideNavLinkClick(e, this.link?.label)}"
@@ -163,6 +164,7 @@ export class SideNavItem extends LitElement {
                   this.isActive,
               })}"
               role="link"
+              ?active="${this.isActive}"
               href="${this.link?.href}"
               @click="${(e: Event) =>
                 this.handleSideNavLinkClick(e, this.link?.label)}"


### PR DESCRIPTION

#### Changelog

- Fixed style highlight of current/active item in side-nav by setting `active` attribute instead of custom styling.