### PR TITLE
fix(global-header): bundle react wrapper separately

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/global-header.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/global-header.ts
@@ -13,7 +13,6 @@ import globalHeader from './src/global-header.template.js';
 
 export { CommonHeader } from './src/components/CommonHeader/CommonHeader.js';
 export { HybridIpaasHeader } from './src/components/HybridIpaasHeader/HybridIpaasHeader.js';
-export { HybridIpaasHeaderReactWrapper } from './src/components/HybridIpaasHeaderReactWrapper/HybridIpaasHeaderReactWrapper.js';
 export { LogoutHeader } from './src/components/LogoutHeader/LogoutHeader.js';
 export { LogoutTile } from './src/components/LogoutTile/LogoutTile.js';
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/index.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/index.ts
@@ -8,7 +8,6 @@
  */
 
 export { CommonHeader } from './components/CommonHeader/CommonHeader';
-export { HybridIpaasHeaderReactWrapper } from './components/HybridIpaasHeaderReactWrapper/HybridIpaasHeaderReactWrapper';
 export { HybridIpaasHeader } from './components/HybridIpaasHeader/HybridIpaasHeader';
 export { LogoutHeader } from './components/LogoutHeader/LogoutHeader';
 export { LogoutTile } from './components/LogoutTile/LogoutTile';

--- a/packages/web-components/src/components/global-header/index-react.ts
+++ b/packages/web-components/src/components/global-header/index-react.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { HybridIpaasHeaderReactWrapper } from './components/global-header/src/components/HybridIpaasHeaderReactWrapper/HybridIpaasHeaderReactWrapper.js';

--- a/packages/web-components/src/components/global-header/package.json
+++ b/packages/web-components/src/components/global-header/package.json
@@ -14,9 +14,8 @@
     "directory": "packages/global-header"
   },
   "exports": {
-    ".": {
-      "default": "./es/wc-global-header.mjs"
-    },
+    ".": "./es/wc-global-header.mjs",
+    "./react": "./es/wc-global-header-react.mjs",
     "./es/*": "./es/*",
     "./lib/*": "./lib/*"
   },

--- a/packages/web-components/src/components/global-header/vite.config.js
+++ b/packages/web-components/src/components/global-header/vite.config.js
@@ -20,6 +20,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         'wc-global-header': 'index.ts',
+        'wc-global-header-react': 'index-react.ts',
         styles: 'components/global-header/src/index.scss',
       },
       external: ['react', 'react-dom'],


### PR DESCRIPTION
**Breaking change**

- Bundle React wrapper separately so that React is not required for Angular consumers
- This is a breaking change for consumers of the React wrapper, you will need to update your import from:
```
import { HybridIpaasHeaderReactWrapper } from '@carbon-labs/wc-global-header'
```
to
```
import { HybridIpaasHeaderReactWrapper } from '@carbon-labs/wc-global-header/react'
```
