### PR TITLE
feat(animated-header): Tooltips are now optional

### DIFF
--- a/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.mdx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.mdx
@@ -43,6 +43,9 @@ import AnimatedHeader from '../components/AnimatedHeader/AnimatedHeader';
     - [Icon Button](#icon-button)
     - [Ghost Button](#ghost-button)
     - [Carousel (coming soon)](#carousel-coming-soon)
+  - [Tooltips](#tooltips)
+    - [Title Tooltip](#title-tooltip)
+    - [Description Tooltip](#description-tooltip)
   - [Accessibility](#accessibility)
     - [Tile ARIA Labels](#tile-aria-labels)
     - [Tasks Dropdown ARIA Label](#tasks-dropdown-aria-label)
@@ -84,11 +87,12 @@ very subtle to not distract users from performing their tasks.
 
 ### Anatomy
 
-**Title:** Welcomes the user (Welcome, username)
+**Title:** Welcomes the user (Welcome, username). Optionally displays a tooltip
+on hover.
 
 **Content:** Short sentence in max. 3 lines related to product context; Action
 button (optional). It is recommended to display content on cards to achieve
-highest contrast to the background.
+highest contrast to the background. Optionally displays a tooltip on hover.
 
 **Visual / brand image:** Line-style illustration (Lottie or static)
 
@@ -434,6 +438,47 @@ export const headerActionCarouselConfig = {
 
 ---
 
+### Tooltips
+
+The AnimatedHeader supports optional tooltips for both the title and description
+text. These tooltips display the full text on hover, which is useful when text
+might be truncated or when you want to provide additional context.
+
+#### Title Tooltip
+
+Enable the title tooltip using the `showTitleTooltip` prop. When enabled,
+hovering over the title (e.g., "Welcome, Drew") will display a tooltip with the
+full text.
+
+```jsx
+<AnimatedHeader
+  userName="Drew"
+  welcomeText="Welcome"
+  showTitleTooltip={true}
+  // ... other props
+/>
+```
+
+#### Description Tooltip
+
+Enable the description tooltip using the `showDescriptionTooltip` prop. When
+enabled, hovering over the description text will display a tooltip with the full
+description.
+
+```jsx
+<AnimatedHeader
+  description="Train, deploy, validate, and govern AI models responsibly."
+  showDescriptionTooltip={true}
+  // ... other props
+/>
+```
+
+> **Note:** Both tooltip props default to `false`. Enable them only when needed,
+> such as when text truncation is a concern or when additional context would
+> benefit users.
+
+---
+
 ### Accessibility
 
 To ensure a fully accessible experience, provide `aria-label`s directly in your
@@ -614,6 +659,8 @@ Example of Animated Header with all prop types enabled.
   tasksControllerConfig={tasksControllerConfigDropdown as TasksControllerConfig}
   contentSwitcherConfig={contentSwitcherConfig}
   headerActionConfig={headerActionGhostConfig}
+  showTitleTooltip={false}
+  showDescriptionTooltip={false}
   isLoading={false}
   tileClickHandler={handleTileClicks}
 />

--- a/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
+++ b/packages/react/src/components/AnimatedHeader/__stories__/AnimatedHeader.stories.tsx
@@ -254,6 +254,18 @@ const sharedArgTypes = {
     control: { type: 'boolean' },
     table: { category: 'Content Switcher' },
   },
+  showTitleTooltip: {
+    description:
+      'Show tooltip on hover for the header title (userName and welcomeText). Useful when text might be truncated.',
+    control: { type: 'boolean' },
+    table: { category: 'Tooltips' },
+  },
+  showDescriptionTooltip: {
+    description:
+      'Show tooltip on hover for the description text. Useful when text might be truncated or when additional context is needed.',
+    control: { type: 'boolean' },
+    table: { category: 'Tooltips' },
+  },
 };
 
 /* ------------------------------ Shared Args ------------------------------ */
@@ -282,6 +294,8 @@ const sharedArgs = {
   headerActionConfig: 1,
   contentSwitcherConfig: 0,
   contentSwitcherLowContrast: false,
+  showTitleTooltip: false,
+  showDescriptionTooltip: false,
 };
 
 /* ------------------------------ Stories ------------------------------ */

--- a/packages/react/src/components/AnimatedHeader/__tests__/__snapshots__/AnimatedHeader-test.tsx.snap
+++ b/packages/react/src/components/AnimatedHeader/__tests__/__snapshots__/AnimatedHeader-test.tsx.snap
@@ -21,47 +21,23 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
         <div
           class="clabs--animated-header__title-and-actions"
         >
-          <span
-            class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--bottom cds--tooltip"
+          <h1
+            aria-label="Welcome, Drew"
+            class="clabs--animated-header__title"
+            data-expanded="true"
           >
-            <div
-              class="cds--tooltip-trigger__wrapper"
-            >
-              <h1
-                aria-label="Welcome, Drew"
-                aria-labelledby="tooltip-:r0:"
-                class="clabs--animated-header__title"
-                data-expanded="true"
-              >
-                <span
-                  class="clabs--animated-header__title-first"
-                >
-                  Welcome
-                  , 
-                </span>
-                <span
-                  class="clabs--animated-header__title-second"
-                >
-                  Drew
-                </span>
-              </h1>
-            </div>
             <span
-              aria-hidden="true"
-              class="cds--popover"
-              id="tooltip-:r0:"
-              role="tooltip"
+              class="clabs--animated-header__title-first"
             >
-              <span
-                class="cds--popover-content cds--tooltip-content"
-              >
-                Welcome, Drew
-              </span>
-              <span
-                class="cds--popover-caret"
-              />
+              Welcome
+              , 
             </span>
-          </span>
+            <span
+              class="clabs--animated-header__title-second"
+            >
+              Drew
+            </span>
+          </h1>
         </div>
       </div>
       <div
@@ -83,8 +59,8 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
           >
             <label
               class="cds--label cds--visually-hidden"
-              for="downshift-:r3:-toggle-button"
-              id="downshift-:r3:-label"
+              for="downshift-:r1:-toggle-button"
+              id="downshift-:r1:-label"
             >
               Label
             </label>
@@ -94,12 +70,12 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
             >
               <button
                 aria-activedescendant=""
-                aria-controls="downshift-:r3:-menu"
+                aria-controls="downshift-:r1:-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Select a task group"
                 class="cds--list-box__field"
-                id="downshift-:r3:-toggle-button"
+                id="downshift-:r1:-toggle-button"
                 role="combobox"
                 tabindex="0"
                 title="AI Prompt Tile w/ two glass tiles"
@@ -135,9 +111,9 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
                 </div>
               </button>
               <ul
-                aria-labelledby="downshift-:r3:-label"
+                aria-labelledby="downshift-:r1:-label"
                 class="cds--list-box__menu"
-                id="downshift-:r3:-menu"
+                id="downshift-:r1:-menu"
                 role="listbox"
               />
             </div>
@@ -156,8 +132,8 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
           >
             <label
               class="cds--label cds--visually-hidden"
-              for="downshift-:r5:-toggle-button"
-              id="downshift-:r5:-label"
+              for="downshift-:r3:-toggle-button"
+              id="downshift-:r3:-label"
             >
               Label
             </label>
@@ -167,12 +143,12 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
             >
               <button
                 aria-activedescendant=""
-                aria-controls="downshift-:r5:-menu"
+                aria-controls="downshift-:r3:-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Select a workspace"
                 class="cds--list-box__field"
-                id="downshift-:r5:-toggle-button"
+                id="downshift-:r3:-toggle-button"
                 role="combobox"
                 tabindex="0"
                 title="Select workspace"
@@ -208,9 +184,9 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
                 </div>
               </button>
               <ul
-                aria-labelledby="downshift-:r5:-label"
+                aria-labelledby="downshift-:r3:-label"
                 class="cds--list-box__menu"
-                id="downshift-:r5:-menu"
+                id="downshift-:r3:-menu"
                 role="listbox"
               />
             </div>
@@ -275,13 +251,13 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
                 </svg>
                 <div
                   class="cds--ai-label"
-                  id="AILabel-:r6:"
+                  id="AILabel-:r4:"
                 >
                   <span
                     class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--auto-align cds--autoalign cds--popover--bottom cds--toggletip cds--autoalign"
                   >
                     <button
-                      aria-controls="id-:r7:"
+                      aria-controls="id-:r5:"
                       aria-expanded="false"
                       aria-label="AI Show information"
                       class="cds--toggletip-button cds--ai-label__button cds--ai-label__button--xs cds--ai-label__button--default"
@@ -348,7 +324,7 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
                     class="cds--tooltip-trigger__wrapper"
                   >
                     <button
-                      aria-labelledby="tooltip-:ra:"
+                      aria-labelledby="tooltip-:r8:"
                       class="clabs--animated-header__ai-prompt-tile--icon-button  cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--disabled cds--btn--icon-only"
                       disabled=""
                       type="button"
@@ -372,7 +348,7 @@ exports[`AnimatedHeader renders as expected - Component API should match snapsho
                   <span
                     aria-hidden="true"
                     class="cds--popover"
-                    id="tooltip-:ra:"
+                    id="tooltip-:r8:"
                     role="tooltip"
                   >
                     <span

--- a/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/AnimatedHeader.tsx
@@ -8,7 +8,7 @@
  */
 import React, { lazy, Suspense, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Column, Button } from '@carbon/react';
+import { Grid, Column, Button, Tooltip } from '@carbon/react';
 import { ChevronUp, ChevronDown } from '@carbon/icons-react';
 import { usePrefix } from '@carbon-labs/utilities/usePrefix';
 import { BaseTile } from '../Tiles/index';
@@ -50,6 +50,8 @@ export type AnimatedHeaderProps = {
   expandButtonLabel?: string;
   collapseButtonLabel?: string;
   tileClickHandler?: (tile: Tile) => void;
+  showTitleTooltip?: boolean;
+  showDescriptionTooltip?: boolean;
 } & TasksControllerProps &
   WorkspaceSelectorProps &
   HeaderActionProps;
@@ -74,6 +76,8 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
   expandButtonLabel = 'Expand',
   collapseButtonLabel = 'Collapse',
   tileClickHandler,
+  showTitleTooltip = false,
+  showDescriptionTooltip = false,
 }: AnimatedHeaderProps) => {
   const prefix = usePrefix();
   const blockClass = `${prefix}--animated-header`;
@@ -111,6 +115,7 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
               welcomeText={welcomeText}
               headerExpanded={isOpen}
               ariaLabels={ariaLabels}
+              showTooltip={showTitleTooltip}
             />
 
             {/* When using the ContentSwitcher, render it here (top row) */}
@@ -134,13 +139,24 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
             id={`${blockClass}-content`}
             className={`${blockClass}__left-area-container`}
             data-expanded={isOpen}>
-            {description && (
-              <h2
-                className={`${blockClass}__description`}
-                aria-label={ariaLabels?.description ?? `Header description`}>
-                {description}
-              </h2>
-            )}
+            {description &&
+              (showDescriptionTooltip ? (
+                <Tooltip align="bottom" label={description}>
+                  <h2
+                    className={`${blockClass}__description`}
+                    aria-label={
+                      ariaLabels?.description ?? `Header description`
+                    }>
+                    {description}
+                  </h2>
+                </Tooltip>
+              ) : (
+                <h2
+                  className={`${blockClass}__description`}
+                  aria-label={ariaLabels?.description ?? `Header description`}>
+                  {description}
+                </h2>
+              ))}
             {tasksControllerConfig && (
               <TasksController
                 tasksControllerConfig={tasksControllerConfig}
@@ -345,6 +361,16 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
    * Provide function to be called when switching selected tile group
    */
   setSelectedTileGroup: PropTypes.func,
+
+  /**
+   * Show tooltip on description text
+   */
+  showDescriptionTooltip: PropTypes.bool,
+
+  /**
+   * Show tooltip on header title (userName and welcomeText)
+   */
+  showTitleTooltip: PropTypes.bool,
 
   /**
    * Configuration for Carbon button / dropdown in header.

--- a/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/types.ts
+++ b/packages/react/src/components/AnimatedHeader/components/AnimatedHeader/types.ts
@@ -24,3 +24,7 @@ export interface AriaLabels {
   expandButton?: string;
   tilesContainer?: string;
 }
+
+export interface HeaderTitleConfig {
+  showTooltip?: boolean;
+}

--- a/packages/react/src/components/AnimatedHeader/components/HeaderTitle/HeaderTitle.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/HeaderTitle/HeaderTitle.tsx
@@ -26,6 +26,7 @@ export type HeaderTitleProps = {
   welcomeText?: string;
   headerExpanded?: boolean;
   ariaLabels?: AriaLabels;
+  showTooltip?: boolean;
 };
 
 const HeaderTitle: React.FC<HeaderTitleProps> = ({
@@ -33,6 +34,7 @@ const HeaderTitle: React.FC<HeaderTitleProps> = ({
   welcomeText,
   headerExpanded,
   ariaLabels,
+  showTooltip = false,
 }: HeaderTitleProps) => {
   const prefix = usePrefix();
   const blockClass = `${prefix}--animated-header__title`;
@@ -43,25 +45,31 @@ const HeaderTitle: React.FC<HeaderTitleProps> = ({
       : 'en';
   const isNameFirst = NAME_FIRST_LANGS.includes(currentLang.slice(0, 2));
 
-  return (
+  const titleContent = (
+    <h1
+      className={blockClass}
+      data-expanded={headerExpanded}
+      aria-label={ariaLabels?.welcome ?? `${welcomeText}, ${userName}`}>
+      {isNameFirst ? (
+        <>
+          <span className={`${blockClass}-first`}>{userName}, </span>
+          <span className={`${blockClass}-second`}>{welcomeText}</span>
+        </>
+      ) : (
+        <>
+          <span className={`${blockClass}-first`}>{welcomeText}, </span>
+          <span className={`${blockClass}-second`}>{userName}</span>
+        </>
+      )}
+    </h1>
+  );
+
+  return showTooltip ? (
     <Tooltip align="bottom" label={`${welcomeText}, ${userName}`}>
-      <h1
-        className={blockClass}
-        data-expanded={headerExpanded}
-        aria-label={ariaLabels?.welcome ?? `${welcomeText}, ${userName}`}>
-        {isNameFirst ? (
-          <>
-            <span className={`${blockClass}-first`}>{userName}, </span>
-            <span className={`${blockClass}-second`}>{welcomeText}</span>
-          </>
-        ) : (
-          <>
-            <span className={`${blockClass}-first`}>{welcomeText}, </span>
-            <span className={`${blockClass}-second`}>{userName}</span>
-          </>
-        )}
-      </h1>
+      {titleContent}
     </Tooltip>
+  ) : (
+    titleContent
   );
 };
 


### PR DESCRIPTION
Closes #1016 

Defaults title and description tooltips to false with new flags

#### Changelog

**New**

- showTitleTooltip and showDescriptionTooltip flags to allow user to turn on or off tooltip

**Changed**

- N/A

**Removed**

- N/A

#### Testing / Reviewing

Testing in localhost
