### PR TITLE
chore(global-header): Re-enable codecept test

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__codecept__/HybridIpaasHeader.spec.js
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__codecept__/HybridIpaasHeader.spec.js
@@ -159,7 +159,7 @@ Scenario('Trial information renders', async ({ I }) => {
   I.see('Contact sales');
 });
 
-Scenario.skip('Solis components render', async ({ I }) => {
+Scenario('Solis components render', async ({ I }) => {
   I.amOnPage(localhostWithSolis);
   I.waitForElement('clabs-global-header-apaas', 30);
 


### PR DESCRIPTION
#### Changelog

**Changed**

- Re-enables the Solis codecept test for the global-header web component as that test is passing again.
