### PR TITLE
ci(workflows): run build on a larger runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn dedupe --check
 
   build:
-    runs-on: ubuntu-latest-large
+    runs-on: ubuntu-latest-larger-disk
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js version from .nvmrc
@@ -88,7 +88,7 @@ jobs:
         run: yarn lint:license
 
   test:
-    runs-on: ubuntu-latest-large
+    runs-on: ubuntu-latest-larger-disk
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js version from .nvmrc

--- a/.github/workflows/publish-canary-cdn.yml
+++ b/.github/workflows/publish-canary-cdn.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   deploy-canary-cdn:
     if: github.repository == 'carbon-design-system/carbon-labs'
-    runs-on: ubuntu-latest-large
+    runs-on: ubuntu-latest-larger-disk
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -14,7 +14,7 @@ jobs:
   deploy-cdn:
     if: |
       github.repository == 'carbon-design-system/carbon-labs'
-    runs-on: ubuntu-latest-large
+    runs-on: ubuntu-latest-larger-disk
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   release:
     # Only run if the PR was merged (not just closed)
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest-large
+    runs-on: ubuntu-latest-larger-disk
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/storybook-publish.yml
+++ b/.github/workflows/storybook-publish.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy:
     if: github.repository == 'carbon-design-system/carbon-labs'
-    runs-on: ubuntu-latest-large
+    runs-on: ubuntu-latest-larger-disk
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js version from .nvmrc


### PR DESCRIPTION
No issue

Builds have been failing because they are running out of disk space. This PR upgrades the runner to `ubuntu-latest-larger-disk` similarly to what was done in https://github.com/carbon-design-system/carbon/pull/20864

```
Image source: GitHub-owned
Platform: Linux x64
Size: 4-cores · 16 GB RAM · 150 GB SSD
```

#### Changelog

**Changed**

- Changed runner for all workflows that have `yarn build` to run on `ubuntu-latest-larger-disk`


#### Testing / Reviewing

- Ensure no workflows were missed, pull down and search `.github/workflows` for `yarn build`.
- They should all run on `ubuntu-latest-larger-disk`
