### PR TITLE
feat(global-header): include help links in unauthenticated mode

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/CommonHeader.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/CommonHeader.stories.ts
@@ -194,6 +194,13 @@ const headerPropsUnauthenticated: HeaderProps = {
       arialLabel: 'Log in',
     },
   ],
+  helperLinks: [
+    {
+      link: 'https://carbondesignsystem.com/',
+      label: 'Carbon Design System',
+      target: '_blank',
+    },
+  ],
 };
 
 const hybridIPaasHeaderProps = {

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/HeaderContext.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/HeaderContext.ts
@@ -367,8 +367,8 @@ export class HeaderContext extends LitElement {
         ${this.renderSidekick()} ${this.renderProfile()} ${this.renderSolis()}
       `;
     } else {
-      return html`<clabs-global-header-unauthenticated-context
-        .noAuthHeaderLinks="${noAuthHeaderLinks}"></clabs-global-header-unauthenticated-context>`;
+      return html`${this.renderHelpMenu()}<clabs-global-header-unauthenticated-context
+          .noAuthHeaderLinks="${noAuthHeaderLinks}"></clabs-global-header-unauthenticated-context>`;
     }
   }
 }

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/__tests__/HeaderContext.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HeaderContext/__tests__/HeaderContext.test.ts
@@ -221,11 +221,27 @@ describe('HeaderContext Component', () => {
       productId: 'a22453643cdb9e22397c6eab9e9da97d',
     };
 
-    it('renders help links when prop is passed in', async () => {
+    it('renders help links when prop is passed in (authenticated)', async () => {
       const el = await fixture(
         html`<clabs-global-header-context
           .props="${{
             ...headerProps,
+            helperLinks,
+          }}"></clabs-global-header-context>`
+      );
+
+      const helpMenu = el.shadowRoot?.querySelector('[menu-label="Help"]');
+      expect(helpMenu).not.to.be.null;
+
+      const helpLinks = helpMenu?.querySelectorAll('[role="listitem"]');
+      expect(helpLinks?.length).to.equal(3);
+    });
+
+    it('renders help links when prop is passed in (unauthenticated)', async () => {
+      const el = await fixture(
+        html`<clabs-global-header-context
+          .props="${{
+            ...unauthenticatedProps,
             helperLinks,
           }}"></clabs-global-header-context>`
       );


### PR DESCRIPTION
We should show help links to everyone, regardless of authentication

#### Changelog

**New**

- If "helperLinks" have been specified in header props, show them in unauthenticated mode (in addition to authenticated mode)