### PR TITLE
chore(build): set concurrency for framework builds

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/carbon-design-system/carbon-labs",
   "scripts": {
-    "build": "yarn clean && lerna run build --scope '@carbon-labs/react-*' --scope '@carbon-labs/mdx-components' --include-dependencies",
+    "build": "yarn clean && lerna run build --scope '@carbon-labs/react-*' --scope '@carbon-labs/mdx-components' --include-dependencies --concurrency=3",
     "clean": "rimraf es lib scss storybook-static",
     "storybook": "storybook dev -p 6008",
     "generate": "node tasks/generate",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -18,7 +18,7 @@
     "./packages/*/es/": "./package/*/es/"
   },
   "scripts": {
-    "build": "lerna run build --scope '@carbon-labs/wc-*' --scope '@carbon-labs/ai-chat' --include-dependencies && cem analyze --config ./custom-elements-manifest.config.js",
+    "build": "lerna run build --scope '@carbon-labs/wc-*' --scope '@carbon-labs/ai-chat' --include-dependencies --concurrency=3 && cem analyze --config ./custom-elements-manifest.config.js",
     "clean": "rimraf es lib storybook-static",
     "storybook": "storybook dev -p 6007",
     "generate": "node tasks/generate",


### PR DESCRIPTION
Set a max concurrency for builds. Hopefully this will reduce the memory usage and prevent the runner from exiting.

#### Changelog

**Changed**

- add `--concurrency=3` to React and web component builds

#### Testing / Reviewing

The project should build and all CI/CD workflows should pass.
