### PR TITLE
fix: spacing in uishell header name

### DIFF
--- a/packages/react/src/components/UIShell/components/styles/_header.scss
+++ b/packages/react/src/components/UIShell/components/styles/_header.scss
@@ -83,6 +83,10 @@ $prefix: 'cds' !default;
   @include custom-property.declaration('link-focus-text-color', $focus);
 }
 
+.#{$prefix}--header .#{$prefix}--header__name {
+  padding-inline-end: $spacing-05;
+}
+
 //----------------------------------------------------------------------------
 // Menu button inside Header
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1119 

updates the header name style `padding-inline-end: $spacing-05;`

#### Changelog

**Changed**

- updates the header name style `padding-inline-end: $spacing-05;`

#### Testing / Reviewing

visually through storybook
https://deploy-preview-1149--carbon-labs-react.netlify.app/?path=/story/components-uishell--demo
