### PR TITLE
fix(uishell): added aria-hidden attribute for SharkFinIcon

### DIFF
--- a/packages/react/src/components/UIShell/components/SharkFinIcon.tsx
+++ b/packages/react/src/components/UIShell/components/SharkFinIcon.tsx
@@ -44,6 +44,7 @@ export const SharkFinIcon: React.FC<SharkFinIconProps> = ({
       width="4"
       height="4"
       viewBox="0 0 4 4"
+      aria-hidden="true"
       fill="none"
       xmlns="http://www.w3.org/2000/svg">
       <g clip-path="url(#clip0_519_52879)">


### PR DESCRIPTION
Closes #1184 

Added missing aria-hidden attribute for SharkFinIcon to fix the `1.1.1 Non-text Content` violation

#### Changelog

**New**

-  Added aria-hidden: false to the [SharkFinIcon](https://github.com/carbon-design-system/carbon-labs/blob/main/packages/react/src/components/UIShell/components/SharkFinIcon.tsx#L42)

#### Testing / Reviewing

Scan the page IBM accessibility checker so that we won't see the below violation any more

```
The SVG element has no accessible name
```