### PR TITLE
feat(global-header): header-logo slot

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/CommonHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/CommonHeader.ts
@@ -159,6 +159,7 @@ export class CommonHeader extends LitElement {
           id="${APP_SWITCHER_BUTTON_ID}"
           button-label-active="Close menu"
           button-label-inactive="Open menu"></cds-custom-header-menu-button>
+        <slot name="header-logo"></slot>
         <cds-custom-header-name
           class="${AUTOMATION_NAMESPACE_PREFIX}__header-name"
           prefix="${this.headerProps?.brand?.company ?? 'IBM'}">

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/CommonHeader.stories.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__stories__/CommonHeader.stories.ts
@@ -69,7 +69,7 @@ const headerProps: HeaderProps = {
     },
   ],
   sideNav: {
-    isCollapsible: false,
+    isCollapsible: true,
     buttonLabel: 'Open menu',
     sidebarLabel: 'Side navigation',
     links: [
@@ -409,46 +409,51 @@ type Story = StoryObj<typeof CommonHeader>;
 
 export const Basic: Story = {
   render: () => html`
-		<div role="main">
-			<clabs-global-header-apaas .headerProps="${headerProps}"></common-header>
-		</div>
-	`,
+    <div role="main">
+      <clabs-global-header-apaas
+        .headerProps="${headerProps}"></clabs-global-header-apaas>
+    </div>
+  `,
 };
 
 export const UnauthenticatedContext: Story = {
   render: () => html`
-		<div role="main">
-			<clabs-global-header-apaas .headerProps="${headerPropsUnauthenticated}"></common-header>
-		</div>
-	`,
+    <div role="main">
+      <clabs-global-header-apaas
+        .headerProps="${headerPropsUnauthenticated}"></clabs-global-header-apaas>
+    </div>
+  `,
 };
 
 export const IbmMockProduct: Story = {
   name: 'IBM Mock Product',
   render: () => html`
-		<div role="main">
-			<clabs-global-header-apaas .headerProps="${hybridIPaasHeaderProps}"></common-header>
-		</div>
-	`,
+    <div role="main">
+      <clabs-global-header-apaas
+        .headerProps="${hybridIPaasHeaderProps}"></clabs-global-header-apaas>
+    </div>
+  `,
 };
 
 export const HelpLinks: Story = {
   render: () => html`
-		<div role="main">
-			<clabs-global-header-apaas .headerProps="${headerPropsWithHelpLinks}"></common-header>
-		</div>
-	`,
+    <div role="main">
+      <clabs-global-header-apaas
+        .headerProps="${headerPropsWithHelpLinks}"></clabs-global-header-apaas>
+    </div>
+  `,
 };
 
 export const ChatBot: Story = {
   render: () => html`
-		<div role="main">
-			<clabs-global-header-apaas .headerProps="${{
-        ...headerProps,
-        chatBotConfigs,
-      }}"></common-header>
-		</div>
-	`,
+    <div role="main">
+      <clabs-global-header-apaas
+        .headerProps="${{
+          ...headerProps,
+          chatBotConfigs,
+        }}"></clabs-global-header-apaas>
+    </div>
+  `,
 };
 
 const sidekickConfig = {
@@ -477,45 +482,73 @@ const solisConfig = {
 
 export const WithSolis: Story = {
   render: () => html`
-		<div role="main">
-			<clabs-global-header-apaas .headerProps="${{
-        ...headerProps,
-        sidekickConfig: sidekickConfig,
-        solisConfig: solisConfig,
-      }}"></common-header>
-		</div>
-	`,
+    <div role="main">
+      <clabs-global-header-apaas
+        .headerProps="${{
+          ...headerProps,
+          sidekickConfig: sidekickConfig,
+          solisConfig: solisConfig,
+        }}"></clabs-global-header-apaas>
+    </div>
+  `,
 };
 
 export const Notifications: Story = {
   render: () => html`
-		<div role="main">
-			<clabs-global-header-apaas .headerProps="${{
-        ...headerProps,
-        notificationConfigs,
-      }}"></common-header>
-		</div>
-	`,
+    <div role="main">
+      <clabs-global-header-apaas
+        .headerProps="${{
+          ...headerProps,
+          notificationConfigs,
+        }}"></clabs-global-header-apaas>
+    </div>
+  `,
 };
 
 export const NotificationsNew: Story = {
   render: () => html`
-		<div role="main">
-			<clabs-global-header-apaas hasNewNotifications .headerProps="${{
-        ...headerProps,
-        notificationConfigs,
-      }}"></common-header>
-		</div>
-	`,
+    <div role="main">
+      <clabs-global-header-apaas
+        hasNewNotifications
+        .headerProps="${{
+          ...headerProps,
+          notificationConfigs,
+        }}"></clabs-global-header-apaas>
+    </div>
+  `,
 };
 
 export const Search: Story = {
   render: () => html`
-		<div role="main">
-			<clabs-global-header-apaas .headerProps="${{
-        ...headerProps,
-        searchConfigs,
-      }}"></common-header>
-		</div>
-	`,
+    <div role="main">
+      <clabs-global-header-apaas
+        .headerProps="${{
+          ...headerProps,
+          searchConfigs,
+        }}"></clabs-global-header-apaas>
+    </div>
+  `,
+};
+
+export const Logo: Story = {
+  render: () => html`
+    <div role="main">
+      <clabs-global-header-apaas .headerProps="${headerProps}">
+        <div slot="header-logo">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 32 32"
+            width="32"
+            height="32">
+            <path
+              fill="cyan"
+              d="M13.5,30.8149a1.0011,1.0011,0,0,1-.4927-.13l-8.5-4.815A1,1,0,0,1,4,25V15a1,1,0,0,1,.5073-.87l8.5-4.815a1.0013,1.0013,0,0,1,.9854,0l8.5,4.815A1,1,0,0,1,23,15V25a1,1,0,0,1-.5073.87l-8.5,4.815A1.0011,1.0011,0,0,1,13.5,30.8149ZM6,24.417l7.5,4.2485L21,24.417V15.583l-7.5-4.2485L6,15.583Z" />
+            <path
+              fill="lightcyan"
+              d="M28,17H26V7.583L18.5,3.3345,10.4927,7.87,9.5073,6.13l8.5-4.815a1.0013,1.0013,0,0,1,.9854,0l8.5,4.815A1,1,0,0,1,28,7Z" />
+          </svg>
+        </div>
+      </clabs-global-header-apaas>
+    </div>
+  `,
 };

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/CommonHeader.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/CommonHeader.test.ts
@@ -485,4 +485,16 @@ describe('CommonHeader tests', () => {
       expect(sideNav).to.have.attribute('aria-label', 'Side navigation');
     });
   });
+
+  describe('Logo support', () => {
+    it('renders content in the header-logo slot', async () => {
+      const el = await fixture<CommonHeader>(
+        html`<clabs-global-header-apaas
+          ><div slot="header-logo">LOGO</div></clabs-global-header-apaas
+        >`
+      );
+      expect(el).not.to.be.null;
+      expect(el).lightDom.to.equal('<div slot="header-logo">LOGO</div>');
+    });
+  });
 });


### PR DESCRIPTION

**New**

- Add a slot called "header-logo" which can be used to add a custom logo to the header
