### PR TITLE
feat(tools): add carbon-labs-init

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "workspaces": [
     "packages/*",
-    "packages/*/**"
+    "packages/*/**",
+    "tools/*"
   ],
   "scripts": {
     "build": "yarn clean && lerna run build --scope '@carbon-labs/utilities' && lerna run build --scope '@carbon-labs/primitives' && lerna run build --scope '@carbon-labs/vscode-snippets' && lerna run build --scope '@carbon-labs/react' && lerna run build --scope '@carbon-labs/web-components'",
@@ -23,6 +24,7 @@
     "doctoc": "doctoc --title '## Table of Contents' docs",
     "format": "prettier --cache --write '**/*.{js,md,scss,ts,tsx}' '!**/*.snap.js' '!**/{build,es,lib,.storybook,ts,umd,storybook-static}/**'",
     "format:diff": "prettier --list-different '**/*.{js,md,scss,ts,tsx}' '!**/*.snap.js' '!**/{build,es,lib,.storybook,ts,umd,storybook-static}/**'",
+    "carbon-labs-init": "yarn workspace @carbon-labs/carbon-labs-init carbon-labs-init",
     "lint": "eslint packages --ext .js,.ts",
     "lint:license": "tools/check-license.cjs -a",
     "lint:license:staged": "tools/check-license.cjs -w",
@@ -60,6 +62,7 @@
     "eslint": "^8.57.0",
     "eslint-config-carbon": "^3.11.0",
     "fs-extra": "^11.2.0",
+    "glob": "^11.0.0",
     "globby": "^14.0.0",
     "husky": "^9.0.0",
     "lerna": "^9.0.0",

--- a/tools/carbon-labs-init/README.md
+++ b/tools/carbon-labs-init/README.md
@@ -1,0 +1,124 @@
+# @carbon-labs/carbon-labs-init
+
+> **Status: v0** — the API may change before v1.
+
+Collapse the Carbon Labs contribution ceremony into a single command. Go from idea to a live Storybook preview branch in under 5 minutes.
+
+## What it does
+
+```bash
+yarn carbon-labs-init new <component-name>
+```
+
+One command that:
+
+1. Checks your `gh` CLI auth
+2. Finds (or creates) your fork of `carbon-design-system/carbon-labs`
+3. Clones or updates the fork locally
+4. Ensures `upstream` points to the canonical repo
+5. Runs `yarn install && yarn build`
+6. Runs `yarn generate <name>` in the right package
+7. Re-links the workspace
+8. Injects owners and a problem-statement scaffold into the generated MDX
+9. Tags the Storybook story as `squad / incubating` (groups it in the sidebar)
+10. Creates a `feat/<component-name>` branch and makes an initial Conventional Commit
+11. Opens the component folder in your editor
+12. Spawns Storybook in the background
+13. Prints the draft PR URL
+
+## Prerequisites
+
+- Node 20+
+- [GitHub CLI (`gh`)](https://cli.github.com) — authenticated via `gh auth login`
+- `yarn` available in your shell
+
+## Running from Carbon Labs
+
+```bash
+# From the root of your carbon-labs fork:
+yarn carbon-labs-init new my-component
+
+# Or run the binary directly from the tool workspace:
+cd tools/carbon-labs-init
+yarn carbon-labs-init new my-component
+```
+
+## Usage
+
+```
+carbon-labs-init new <component-name> [options]
+
+Options:
+  --type <type>       Component type: "react" or "web-component"  [default: react]
+  --owners <handles>  Comma-separated GitHub handles, e.g. @user1,@user2
+  --path <path>       Local clone path                            [default: ~/carbon-labs]
+  --no-storybook      Skip spawning Storybook
+  --no-editor         Skip opening your editor
+  --dry-run           Print every step without making changes
+  -h, --help          Display help
+```
+
+### Examples
+
+```bash
+# React component (default)
+carbon-labs-init new DataTableFilter
+
+# Web Component
+carbon-labs-init new data-table-filter --type web-component
+
+# With explicit owners
+carbon-labs-init new MyWidget --owners @ajcase,@kenny-handle
+
+# Preview what would happen without touching anything
+carbon-labs-init new MyWidget --dry-run
+
+# Custom local path
+carbon-labs-init new MyWidget --path ~/projects/carbon-labs
+```
+
+## Config file
+
+Create `.carbon-labs-init.json` at the root of your carbon-labs fork to set team-wide defaults:
+
+```json
+{
+  "squad": "carbon-core",
+  "defaultOwners": ["@ajcase", "@kenny-handle", "@scott-handle", "@olivia-handle"],
+  "defaultType": "react",
+  "editorCommand": "code"
+}
+```
+
+CLI flags always override config values. Config values override built-in defaults.
+
+| Field | Default | Description |
+|---|---|---|
+| `squad` | `"carbon-squad"` | Squad identifier (informational) |
+| `defaultOwners` | `[]` | Owners pre-filled in MDX maintainer block |
+| `defaultType` | `"react"` | Component type when `--type` is omitted |
+| `editorCommand` | `"code"` | Editor binary for `--editor` step |
+
+## Development
+
+```bash
+cd tools/carbon-labs-init
+yarn install
+yarn test           # vitest run
+yarn test:watch     # vitest watch mode
+```
+
+## Roadmap
+
+| Milestone | Status | Description |
+|---|---|---|
+| 1 — CLI MVP | ✅ Done | fork/clone/generate/branch flow |
+| 2 — Squad namespace | Dropped | Replaced by Storybook `tags` (see step 9 above) |
+| 3 — MDX auto-fill | ✅ Done | Maintainer block + problem-statement scaffold |
+| 4 — Issue template + Action | Planned | Zero-click path for designers and PMs |
+| 5 — `yarn graduate` | Stretch | Promote component to Labs proper and open upstream PR |
+
+## Notes
+
+- **Does not replace `yarn generate`** — wraps it. If the upstream generator changes, carbon-labs-init inherits the change automatically.
+- The `storybook-publish` workflow in carbon-labs only runs on pushes to `main` (GitHub Pages). There is no per-PR preview — a draft PR link is the best we can provide until the component merges.

--- a/tools/carbon-labs-init/bin/carbon-labs-init.js
+++ b/tools/carbon-labs-init/bin/carbon-labs-init.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../src/index.js';

--- a/tools/carbon-labs-init/package.json
+++ b/tools/carbon-labs-init/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@carbon-labs/carbon-labs-init",
+  "version": "0.1.0",
+  "description": "Carbon Labs squad incubation tooling — collapse the Labs contribution ceremony into a single command",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "bin": "./bin/carbon-labs-init.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "scripts": {
+    "carbon-labs-init": "node ./bin/carbon-labs-init.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "build": "echo 'No build step — pure ESM source'"
+  },
+  "dependencies": {
+    "@octokit/rest": "^20.1.1",
+    "chalk": "^5.4.1",
+    "commander": "^12.1.0",
+    "execa": "^9.5.2",
+    "ora": "^8.1.1",
+    "prompts": "^2.4.2",
+    "simple-git": "^3.27.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.0.0"
+  }
+}

--- a/tools/carbon-labs-init/scripts/inject-mdx.js
+++ b/tools/carbon-labs-init/scripts/inject-mdx.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * CLI shim used by the GitHub Action to inject MDX metadata.
+ *
+ * Usage:
+ *   node tools/carbon-labs-init/scripts/inject-mdx.js \
+ *     <componentDir> <componentName> <owners> [storybookGroup] [problemStatement]
+ *
+ * Arguments:
+ *   componentDir       Absolute path to the component folder
+ *   componentName      Cased component name (e.g. MyButton)
+ *   owners             Comma-separated @handle list (pass "" to omit)
+ *   storybookGroup     Storybook sidebar group (default: "Components")
+ *   problemStatement   Optional — real text from the issue form
+ */
+import { injectMdxMetadata } from '../src/lib/mdx.js';
+import { parseOwners } from '../src/lib/owners.js';
+
+const [, , componentDir, componentName, ownersArg, storybookGroupArg, ...rest] = process.argv;
+
+if (!componentDir || !componentName) {
+  console.error('Usage: inject-mdx.js <componentDir> <componentName> [owners] [storybookGroup] [problemStatement]');
+  process.exit(1);
+}
+
+const owners = parseOwners(ownersArg ?? '');
+const storybookGroup = storybookGroupArg || 'Components';
+const problemStatement = rest.join(' ').trim() || undefined;
+
+await injectMdxMetadata({ componentDir, componentName, owners, storybookGroup, problemStatement });
+console.log(`MDX metadata injected for ${componentName}`);

--- a/tools/carbon-labs-init/src/commands/new.js
+++ b/tools/carbon-labs-init/src/commands/new.js
@@ -1,0 +1,284 @@
+import { homedir } from 'os';
+import { resolve, join } from 'path';
+import { execa } from 'execa';
+import { log, runStep } from '../lib/logger.js';
+import { injectMdxMetadata } from '../lib/mdx.js';
+import { validateComponentName, applyNameCasing } from '../lib/names.js';
+import { loadConfig, mergeOptions } from '../lib/config.js';
+import {
+  checkGitHubAuth,
+  getOctokit,
+  getGitHubUser,
+  getOrCreateFork,
+  buildPrUrl,
+  UPSTREAM_URL,
+} from '../lib/github.js';
+import {
+  cloneOrUpdate,
+  ensureUpstream,
+  createBranch,
+  makeScaffoldCommit,
+  readNvmrc,
+} from '../lib/git.js';
+
+const PACKAGE_DIR = {
+  react: 'packages/react',
+  'web-component': 'packages/web-components',
+};
+
+// Scoped build order extracted from the root yarn build script.
+// We skip @carbon-labs/web-components when targeting react to avoid
+// pre-existing upstream TS errors that don't affect the React package.
+const BUILD_SCOPES = {
+  react: [
+    '@carbon-labs/utilities',
+    '@carbon-labs/primitives',
+    '@carbon-labs/vscode-snippets',
+    '@carbon-labs/react',
+  ],
+  'web-component': [
+    '@carbon-labs/utilities',
+    '@carbon-labs/primitives',
+    '@carbon-labs/vscode-snippets',
+    '@carbon-labs/react',
+    '@carbon-labs/web-components',
+  ],
+};
+
+async function scopedBuild(localPath, componentType, { clean = false } = {}) {
+  if (clean) {
+    await execa('yarn', ['lerna', 'run', 'clean'], { cwd: localPath, stdio: 'inherit' });
+  }
+  const scopes = BUILD_SCOPES[componentType] ?? BUILD_SCOPES.react;
+  for (const scope of scopes) {
+    await execa('yarn', ['lerna', 'run', 'build', '--scope', scope], {
+      cwd: localPath,
+      stdio: 'inherit',
+    });
+  }
+}
+
+export async function newCommand(componentName, options) {
+  const isDryRun = Boolean(options.dryRun);
+  if (isDryRun) {
+    log.warn('Dry-run mode — no changes will be made to disk or GitHub.\n');
+  }
+
+  // ── 0. Resolve local path ─────────────────────────────────────────────────
+  const rawPath = options.path ?? '~/carbon-labs';
+  const localPath = resolve(rawPath.replace(/^~/, homedir()));
+  log.info(`Local repo path: ${localPath}`);
+
+  // ── 1. Validate component name ────────────────────────────────────────────
+  try {
+    validateComponentName(componentName);
+  } catch (err) {
+    log.error(err.message);
+    process.exit(1);
+  }
+
+  // ── 2. GitHub auth ────────────────────────────────────────────────────────
+  await runStep('Checking GitHub auth (gh CLI)', checkGitHubAuth, { dryRun: isDryRun });
+
+  let octokit;
+  let username;
+
+  if (!isDryRun) {
+    octokit = await getOctokit();
+    username = await getGitHubUser(octokit);
+    log.info(`Authenticated as @${username}`);
+  } else {
+    username = '<your-github-username>';
+  }
+
+  // ── 3. Get or create fork ─────────────────────────────────────────────────
+  let forkCloneUrl;
+
+  await runStep(
+    `Checking for fork of carbon-design-system/carbon-labs under @${username}`,
+    async () => {
+      const fork = await getOrCreateFork(octokit, username);
+      forkCloneUrl = fork.cloneUrl;
+      if (fork.existed) {
+        log.info(`Using existing fork: ${fork.cloneUrl}`);
+      } else {
+        log.info(`Fork created: ${fork.cloneUrl}`);
+      }
+    },
+    { dryRun: isDryRun }
+  );
+
+  if (isDryRun) {
+    forkCloneUrl = `https://github.com/${username}/carbon-labs.git`;
+  }
+
+  // ── 4. Clone or update local fork ────────────────────────────────────────
+  let git;
+
+  await runStep(
+    `Clone / update local fork at ${localPath}`,
+    async () => {
+      git = await cloneOrUpdate(forkCloneUrl, localPath);
+    },
+    { dryRun: isDryRun }
+  );
+
+  // ── 5. Ensure upstream remote ─────────────────────────────────────────────
+  await runStep(
+    `Ensuring upstream remote → ${UPSTREAM_URL}`,
+    () => ensureUpstream(git),
+    { dryRun: isDryRun }
+  );
+
+  // ── 6. Check .nvmrc ───────────────────────────────────────────────────────
+  if (!isDryRun) {
+    const nvmrcVersion = await readNvmrc(localPath);
+    if (nvmrcVersion) {
+      log.info(`.nvmrc specifies Node ${nvmrcVersion}`);
+      const currentMajor = parseInt(process.version.slice(1));
+      const requiredMajor = parseInt(nvmrcVersion);
+      if (currentMajor !== requiredMajor) {
+        try {
+          // nvm is a shell function — must be sourced
+          await execa('bash', ['-c', '. ~/.nvm/nvm.sh && nvm use'], {
+            cwd: localPath,
+            stdio: 'pipe',
+          });
+          log.success(`Switched to Node ${nvmrcVersion} via nvm`);
+        } catch {
+          log.warn(
+            `Node ${nvmrcVersion} required (current: ${process.version}). ` +
+              `The Labs generator may fail on other versions.\n  ` +
+              `Fix: brew install node@${requiredMajor} && brew link node@${requiredMajor} --force --overwrite`
+          );
+        }
+      }
+    }
+  }
+
+  // ── 7–8. Validate type, install, scoped build ────────────────────────────
+  const componentType = options.type ?? 'react';
+  if (!PACKAGE_DIR[componentType]) {
+    log.error(`Unknown component type "${componentType}". Use "react" or "web-component".`);
+    process.exit(1);
+  }
+
+  await runStep(
+    'yarn install',
+    () => execa('yarn', ['install'], { cwd: localPath, stdio: 'inherit' }),
+    { dryRun: isDryRun }
+  );
+
+  await runStep(
+    `Building ${componentType} package chain`,
+    () => scopedBuild(localPath, componentType),
+    { dryRun: isDryRun }
+  );
+
+  const packageDir = join(localPath, PACKAGE_DIR[componentType]);
+  const casedName = applyNameCasing(componentName, componentType);
+  log.info(`Component: ${casedName}  (type: ${componentType})`);
+
+  // ── 9. yarn generate ──────────────────────────────────────────────────────
+  await runStep(
+    `yarn generate ${casedName} in ${PACKAGE_DIR[componentType]}`,
+    () => execa('yarn', ['generate', casedName], { cwd: packageDir, stdio: 'inherit' }),
+    { dryRun: isDryRun }
+  );
+
+  // ── 10. Re-link workspace (install + scoped build, no clean) ─────────────
+  await runStep(
+    'Re-linking workspace',
+    async () => {
+      await execa('yarn', ['install'], { cwd: localPath, stdio: 'inherit' });
+      await scopedBuild(localPath, componentType);
+    },
+    { dryRun: isDryRun }
+  );
+
+  // ── 11. Create feature branch ─────────────────────────────────────────────
+  // Load config now that the repo is present
+  const repoConfig = isDryRun ? {} : await loadConfig(localPath).catch(() => ({}));
+  const merged = mergeOptions(options, repoConfig);
+
+  const branchName = `feat/${componentName.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
+
+  await runStep(
+    `Creating branch ${branchName}`,
+    () => createBranch(git, branchName),
+    { dryRun: isDryRun }
+  );
+
+  // ── 11b. MDX auto-fill ────────────────────────────────────────────────────
+  const componentPath = join(packageDir, 'src', 'components', casedName);
+
+  await runStep(
+    `Injecting maintainer block and problem-statement scaffold into MDX`,
+    () =>
+      injectMdxMetadata({
+        componentDir: componentPath,
+        componentName: casedName,
+        owners: merged.owners ?? [],
+        storybookGroup: merged.storybookGroup,
+      }),
+    { dryRun: isDryRun }
+  );
+
+  // ── 12. Initial scaffolding commit ────────────────────────────────────────
+  await runStep(
+    `git commit: feat(${casedName}): scaffold component`,
+    () => makeScaffoldCommit(git, casedName),
+    { dryRun: isDryRun }
+  );
+
+  // ── 13. Open editor ───────────────────────────────────────────────────────
+  const editorCmd = merged.editorCommand ?? 'code';
+
+  if (options.editor !== false) {
+    await runStep(
+      `Opening ${componentPath} in ${editorCmd}`,
+      () => execa(editorCmd, [componentPath], { stdio: 'ignore', detached: true }),
+      { dryRun: isDryRun }
+    );
+  }
+
+  // ── 14. Spawn Storybook (detached, non-blocking) ──────────────────────────
+  if (options.storybook !== false && !isDryRun) {
+    try {
+      const storybookProc = execa('yarn', ['storybook'], {
+        cwd: packageDir,
+        stdio: 'ignore',
+        detached: true,
+      });
+      storybookProc.unref();
+      log.info('Storybook starting in background…');
+    } catch {
+      log.warn('Failed to start Storybook automatically. Run `yarn storybook` manually.');
+    }
+  } else if (isDryRun) {
+    log.info('[dry-run] Would spawn: yarn storybook');
+  }
+
+  // ── 15. Print PR URL ──────────────────────────────────────────────────────
+  const prUrl = buildPrUrl(username, branchName);
+
+  log.blank();
+  log.success('Scaffold complete!');
+  log.blank();
+  console.log('  Component folder : ' + componentPath);
+  console.log('  Branch           : ' + branchName);
+  if (merged.owners?.length) {
+    console.log('  Owners           : ' + merged.owners.join(', '));
+  }
+  console.log('  Draft PR URL     : ' + prUrl);
+  log.blank();
+  console.log(
+    '  Next steps:\n' +
+      '    1. Fill in the problem-statement in __stories__/' + casedName + '.mdx\n' +
+      '       (look for the TODO block — owners are already pre-filled).\n' +
+      '    2. Iterate on your component.\n' +
+      '    3. Push: git push -u origin ' + branchName + '\n' +
+      '    4. Open the draft PR at the URL above.'
+  );
+  log.blank();
+}

--- a/tools/carbon-labs-init/src/index.js
+++ b/tools/carbon-labs-init/src/index.js
@@ -1,0 +1,45 @@
+import { program } from 'commander';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { readFileSync } from 'fs';
+import { newCommand } from './commands/new.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(join(__dirname, '..', 'package.json'), 'utf8')
+);
+
+program
+  .name('carbon-labs-init')
+  .version(pkg.version)
+  .description(
+    'Carbon Labs squad incubation tooling.\n' +
+      'Collapse the Labs contribution ceremony into a single command.'
+  );
+
+program
+  .command('new <component-name>')
+  .description('Scaffold a new squad-draft component in your carbon-labs fork')
+  .option(
+    '--type <type>',
+    'Component type: "react" or "web-component" (default: react or config.defaultType)'
+  )
+  .option(
+    '--owners <handles>',
+    'Comma-separated GitHub handles to list as maintainers, e.g. @user1,@user2'
+  )
+  .option(
+    '--group <name>',
+    'Storybook sidebar group for the component (default: "Components" or config.storybookGroup)'
+  )
+  .option('--path <path>', 'Local path to clone the fork into', '~/carbon-labs')
+  .option('--no-storybook', 'Skip spawning Storybook after scaffolding')
+  .option('--no-editor', 'Skip opening your editor after scaffolding')
+  .option('--dry-run', 'Print every step that would be taken without making changes')
+  .action(newCommand);
+
+program.parseAsync(process.argv).catch((err) => {
+  console.error('\nFatal:', err.message);
+  process.exit(1);
+});

--- a/tools/carbon-labs-init/src/lib/config.js
+++ b/tools/carbon-labs-init/src/lib/config.js
@@ -1,0 +1,60 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { parseOwners } from './owners.js';
+
+const CONFIG_FILE = '.carbon-labs-init.json';
+
+export const DEFAULTS = {
+  squad: 'carbon-squad',
+  defaultOwners: [],
+  defaultType: 'react',
+  editorCommand: 'code',
+  storybookGroup: 'Components',
+};
+
+/**
+ * Reads .carbon-labs-init.json from repoRoot. Returns merged defaults if file is absent.
+ * Throws on malformed JSON.
+ */
+export async function loadConfig(repoRoot) {
+  const configPath = join(repoRoot, CONFIG_FILE);
+  try {
+    const raw = await readFile(configPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return {
+      ...DEFAULTS,
+      ...parsed,
+      defaultOwners:
+        typeof parsed.defaultOwners === 'string'
+          ? parseOwners(parsed.defaultOwners)
+          : Array.isArray(parsed.defaultOwners)
+            ? parsed.defaultOwners
+            : [],
+    };
+  } catch (err) {
+    if (err.code === 'ENOENT') return { ...DEFAULTS };
+    throw new Error(`Failed to parse ${configPath}: ${err.message}`);
+  }
+}
+
+/**
+ * Merges CLI flags with config values. Flags always win over config.
+ * Config wins over hard-coded defaults.
+ *
+ * @param {object} flagOptions - raw commander options (undefined = not passed)
+ * @param {object} config - result of loadConfig()
+ */
+export function mergeOptions(flagOptions, config) {
+  const owners =
+    flagOptions.owners != null
+      ? parseOwners(flagOptions.owners)
+      : config.defaultOwners ?? DEFAULTS.defaultOwners;
+
+  return {
+    type: flagOptions.type ?? config.defaultType ?? DEFAULTS.defaultType,
+    owners,
+    editorCommand: config.editorCommand ?? DEFAULTS.editorCommand,
+    storybookGroup: flagOptions.group ?? config.storybookGroup ?? DEFAULTS.storybookGroup,
+    squad: config.squad ?? DEFAULTS.squad,
+  };
+}

--- a/tools/carbon-labs-init/src/lib/git.js
+++ b/tools/carbon-labs-init/src/lib/git.js
@@ -1,0 +1,99 @@
+import { simpleGit } from 'simple-git';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const UPSTREAM_REMOTE = 'upstream';
+const UPSTREAM_URL = 'https://github.com/carbon-design-system/carbon-labs.git';
+
+/**
+ * Clones the fork if localPath doesn't exist, or fetches + rebases upstream/main
+ * if it does. Returns a simple-git instance rooted at localPath.
+ */
+export async function cloneOrUpdate(cloneUrl, localPath) {
+  const dotGit = join(localPath, '.git');
+
+  if (!existsSync(dotGit)) {
+    const git = simpleGit();
+    await git.clone(cloneUrl, localPath);
+    return simpleGit(localPath);
+  }
+
+  const git = simpleGit(localPath);
+
+  const remotes = await git.getRemotes(true);
+  const originRemote = remotes.find((r) => r.name === 'origin');
+  if (!originRemote) {
+    throw new Error(
+      `"${localPath}" exists but has no "origin" remote. ` +
+        'Delete the directory or fix the repo and try again.'
+    );
+  }
+
+  await git.fetch('upstream').catch(() => {
+    // upstream may not be set yet; ensureUpstream adds it below
+  });
+
+  await git.checkout('main');
+
+  try {
+    await git.pull('upstream', 'main', { '--rebase': null });
+  } catch {
+    // If upstream isn't configured yet we'll set it in ensureUpstream
+    await git.pull('origin', 'main');
+  }
+
+  return git;
+}
+
+/**
+ * Ensures the "upstream" remote points to carbon-design-system/carbon-labs.
+ * Adds it if missing; corrects the URL if it's wrong.
+ */
+export async function ensureUpstream(git) {
+  const remotes = await git.getRemotes(true);
+  const existing = remotes.find((r) => r.name === UPSTREAM_REMOTE);
+
+  if (!existing) {
+    await git.addRemote(UPSTREAM_REMOTE, UPSTREAM_URL);
+    return;
+  }
+
+  const currentUrl = existing.refs?.fetch || '';
+  if (!currentUrl.includes('carbon-design-system/carbon-labs')) {
+    await git.remote(['set-url', UPSTREAM_REMOTE, UPSTREAM_URL]);
+  }
+}
+
+/**
+ * Creates and checks out a new branch off main. Does not throw if the branch
+ * already exists — it checks it out instead (idempotent for reruns).
+ */
+export async function createBranch(git, branchName) {
+  const summary = await git.branchLocal();
+  if (summary.all.includes(branchName)) {
+    await git.checkout(branchName);
+    return;
+  }
+  await git.checkoutLocalBranch(branchName);
+}
+
+/**
+ * Stages all changes and makes a Conventional Commits scaffolding commit.
+ */
+export async function makeScaffoldCommit(git, componentName) {
+  await git.add('.');
+  await git.commit(`feat(${componentName}): scaffold component`);
+}
+
+/**
+ * Reads .nvmrc from localPath and returns the Node version string, or null.
+ */
+export async function readNvmrc(localPath) {
+  try {
+    const { readFile } = await import('fs/promises');
+    const content = await readFile(join(localPath, '.nvmrc'), 'utf8');
+    return content.trim();
+  } catch {
+    return null;
+  }
+}

--- a/tools/carbon-labs-init/src/lib/github.js
+++ b/tools/carbon-labs-init/src/lib/github.js
@@ -1,0 +1,105 @@
+import { execa } from 'execa';
+import { Octokit } from '@octokit/rest';
+
+const UPSTREAM_OWNER = 'carbon-design-system';
+const UPSTREAM_REPO = 'carbon-labs';
+
+/**
+ * Verifies `gh` CLI is installed and the user is authenticated.
+ * Throws a descriptive error if not.
+ */
+export async function checkGitHubAuth() {
+  try {
+    await execa('gh', ['auth', 'status'], { stdio: 'pipe' });
+  } catch (err) {
+    const output = err.stderr || err.stdout || '';
+    if (output.includes('not logged in') || output.includes('not authenticated')) {
+      throw new Error(
+        'Not authenticated with GitHub. Run `gh auth login` and try again.'
+      );
+    }
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        '`gh` CLI not found. Install it from https://cli.github.com and run `gh auth login`.'
+      );
+    }
+    // gh auth status exits non-zero even when authed in some versions — ignore
+    if (!output.includes('Logged in')) {
+      throw new Error(
+        `GitHub auth check failed: ${output || err.message}. Run \`gh auth login\` and try again.`
+      );
+    }
+  }
+}
+
+/**
+ * Returns a token from `gh auth token` and a configured Octokit instance.
+ */
+export async function getOctokit() {
+  let token;
+  try {
+    const result = await execa('gh', ['auth', 'token'], { stdio: 'pipe' });
+    token = result.stdout.trim();
+  } catch (err) {
+    throw new Error(
+      `Could not retrieve GitHub token: ${err.message}. Run \`gh auth login\`.`
+    );
+  }
+
+  return new Octokit({ auth: token });
+}
+
+/**
+ * Returns the authenticated GitHub username.
+ */
+export async function getGitHubUser(octokit) {
+  const { data } = await octokit.rest.users.getAuthenticated();
+  return data.login;
+}
+
+/**
+ * Ensures the authenticated user has a fork of carbon-design-system/carbon-labs.
+ * Creates one if it doesn't exist. Returns the fork's clone URL (HTTPS).
+ *
+ * Note: GitHub's fork API is async — the fork may not be ready for a few seconds
+ * after creation, but that's fine because we clone immediately after.
+ */
+export async function getOrCreateFork(octokit, username) {
+  // Check if the fork already exists
+  try {
+    const { data } = await octokit.rest.repos.get({
+      owner: username,
+      repo: UPSTREAM_REPO,
+    });
+    if (data.fork && data.parent?.full_name === `${UPSTREAM_OWNER}/${UPSTREAM_REPO}`) {
+      return {
+        cloneUrl: data.clone_url,
+        sshUrl: data.ssh_url,
+        existed: true,
+      };
+    }
+  } catch (err) {
+    if (err.status !== 404) throw err;
+  }
+
+  // Create the fork
+  const { data } = await octokit.rest.repos.createFork({
+    owner: UPSTREAM_OWNER,
+    repo: UPSTREAM_REPO,
+  });
+
+  return {
+    cloneUrl: data.clone_url,
+    sshUrl: data.ssh_url,
+    existed: false,
+  };
+}
+
+export const UPSTREAM_URL = `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}.git`;
+
+/**
+ * Builds the compare URL for a future PR.
+ */
+export function buildPrUrl(username, branchName) {
+  return `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/compare/main...${username}:${UPSTREAM_REPO}:${branchName}`;
+}

--- a/tools/carbon-labs-init/src/lib/logger.js
+++ b/tools/carbon-labs-init/src/lib/logger.js
@@ -1,0 +1,56 @@
+import chalk from 'chalk';
+import ora from 'ora';
+
+export const log = {
+  info: (msg) => console.log(chalk.cyan('ℹ'), msg),
+  success: (msg) => console.log(chalk.green('✔'), msg),
+  warn: (msg) => console.log(chalk.yellow('⚠'), msg),
+  error: (msg) => console.error(chalk.red('✖'), msg),
+  step: (n, total, msg) => console.log(chalk.dim(`[${n}/${total}]`), msg),
+  blank: () => console.log(),
+};
+
+/**
+ * Wraps an async action with an ora spinner.
+ * In dry-run mode, prints what would happen and skips execution.
+ *
+ * @param {string} label - human-readable description of the action
+ * @param {() => Promise<any>} action - async work to perform
+ * @param {object} opts
+ * @param {boolean} [opts.dryRun=false]
+ * @returns {Promise<any>} whatever action() resolves to, or undefined in dry-run
+ */
+export async function runStep(label, action, { dryRun = false } = {}) {
+  if (dryRun) {
+    console.log(chalk.dim(`[dry-run] Would: ${label}`));
+    return undefined;
+  }
+
+  const spinner = ora(label).start();
+  try {
+    const result = await action();
+    spinner.succeed(label);
+    return result;
+  } catch (err) {
+    spinner.fail(label);
+    throw err;
+  }
+}
+
+export function printBanner(text) {
+  log.blank();
+  console.log(chalk.bold.bgBlue(` ${text} `));
+  log.blank();
+}
+
+export function printExperimentalWarning() {
+  log.blank();
+  console.log(
+    chalk.yellow('┌─────────────────────────────────────────────────────┐\n') +
+    chalk.yellow('│  ⚗  carbon-labs-init is EXPERIMENTAL — expect rough edges.  │\n') +
+    chalk.yellow('│  File issues at: github.com/carbon-design-system/    │\n') +
+    chalk.yellow('│  carbon-labs (squad tooling label)                   │\n') +
+    chalk.yellow('└─────────────────────────────────────────────────────┘')
+  );
+  log.blank();
+}

--- a/tools/carbon-labs-init/src/lib/mdx.js
+++ b/tools/carbon-labs-init/src/lib/mdx.js
@@ -1,0 +1,104 @@
+import { readFile, writeFile, access } from 'fs/promises';
+import { join } from 'path';
+
+const OWNER_PLACEHOLDER = 'FILL THIS LINE';
+const STORIES_EXTENSIONS = ['.stories.js', '.stories.jsx', '.stories.tsx'];
+
+/**
+ * Injects the maintainer block and problem-statement into the generated MDX,
+ * and tags the stories file so it groups under "Squad" in the Storybook sidebar.
+ *
+ * Safe to call on a freshly generated component directory.
+ *
+ * @param {object} opts
+ * @param {string} opts.componentDir - absolute path to the component folder
+ * @param {string} opts.componentName - cased component name (e.g. "MyButton")
+ * @param {string[]} opts.owners - normalized @handle list
+ * @param {string} [opts.problemStatement] - if provided, injected as real text;
+ *   otherwise a TODO scaffold is inserted for the author to fill in
+ * @param {string} [opts.storybookGroup] - Storybook sidebar group, e.g. "Components"
+ */
+export async function injectMdxMetadata({ componentDir, componentName, owners, problemStatement, storybookGroup = 'Components' }) {
+  await Promise.all([
+    injectMdxFile({ componentDir, componentName, owners, problemStatement }),
+    injectStoriesFile({ componentDir, componentName, storybookGroup }),
+  ]);
+}
+
+async function injectMdxFile({ componentDir, componentName, owners, problemStatement }) {
+  const mdxPath = join(componentDir, '__stories__', `${componentName}.mdx`);
+  let content = await readFile(mdxPath, 'utf8');
+
+  // ── 1. Owner placeholder ───────────────────────────────────────────────
+  if (owners.length > 0 && content.includes(OWNER_PLACEHOLDER)) {
+    content = content.replace(OWNER_PLACEHOLDER, owners.join(', '));
+  }
+
+  // ── 2. Problem-statement ──────────────────────────────────────────────
+  // Inserted immediately after the "## Overview" heading.
+  // Only inject once — idempotent if the file is processed again.
+  const SCAFFOLD_MARKER = '{/* carbon-labs-init:problem-statement */}';
+  if (!content.includes(SCAFFOLD_MARKER)) {
+    const body = problemStatement
+      ? `> **Problem statement:** ${problemStatement}\n`
+      : `{/*\n` +
+        ` * TODO: Replace this block with a concise problem statement.\n` +
+        ` *\n` +
+        ` * Answer:\n` +
+        ` *   - What gap does this component fill?\n` +
+        ` *   - What user need does it address?\n` +
+        ` *   - Which existing Carbon component is the nearest neighbor (if any)?\n` +
+        ` */}\n` +
+        `> **Problem statement:** _Describe the gap this component fills (edit or delete this line)._\n`;
+
+    const scaffold = `\n${SCAFFOLD_MARKER}\n${body}`;
+
+    content = content.replace(
+      /^(## Overview)$/m,
+      `$1\n${scaffold}`
+    );
+  }
+
+  await writeFile(mdxPath, content, 'utf8');
+}
+
+async function injectStoriesFile({ componentDir, componentName, storybookGroup }) {
+  const storiesDir = join(componentDir, '__stories__');
+
+  // Find whichever extension the generator produced
+  let storiesPath = null;
+  for (const ext of STORIES_EXTENSIONS) {
+    const candidate = join(storiesDir, `${componentName}${ext}`);
+    try {
+      await access(candidate);
+      storiesPath = candidate;
+      break;
+    } catch {
+      // try next
+    }
+  }
+
+  if (!storiesPath) return; // generator may not have produced a stories file yet
+
+  let content = await readFile(storiesPath, 'utf8');
+
+  // ── 1. Set/replace Storybook group in title ───────────────────────────
+  // Replaces whatever group the generator used (Components/) with the
+  // configured storybookGroup. Idempotent — re-running with the same
+  // group value is a no-op.
+  content = content.replace(
+    /(title:\s*['"])[^/'"]+\//,
+    `$1${storybookGroup}/`
+  );
+
+  // ── 2. Add tags if not already present ────────────────────────────────
+  // Inserts after the title line inside the default export object.
+  if (!content.includes("tags:")) {
+    content = content.replace(
+      /(title:\s*['"][^'"]+['"],?)\n/,
+      `$1\n  tags: ['squad', 'incubating'],\n`
+    );
+  }
+
+  await writeFile(storiesPath, content, 'utf8');
+}

--- a/tools/carbon-labs-init/src/lib/names.js
+++ b/tools/carbon-labs-init/src/lib/names.js
@@ -1,0 +1,58 @@
+/**
+ * Converts any casing variant to PascalCase.
+ * "my-button" | "my_button" | "myButton" -> "MyButton"
+ */
+export function toPascalCase(str) {
+  return str
+    .replace(/[-_\s]+(.)/g, (_, c) => c.toUpperCase())
+    .replace(/^(.)/, (_, c) => c.toUpperCase());
+}
+
+/**
+ * Converts any casing variant to param-case (kebab-case).
+ * "MyButton" | "my_button" | "myButton" -> "my-button"
+ */
+export function toParamCase(str) {
+  return str
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .replace(/([a-z\d])([A-Z])/g, '$1-$2')
+    .replace(/[-_\s]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase();
+}
+
+/**
+ * Throws a descriptive error if the name would produce an invalid param-case identifier.
+ */
+export function validateComponentName(name) {
+  if (!name || typeof name !== 'string') {
+    throw new Error('Component name is required.');
+  }
+
+  const param = toParamCase(name);
+
+  if (!/^[a-z][a-z0-9-]*[a-z0-9]$/.test(param) && !/^[a-z]$/.test(param)) {
+    throw new Error(
+      `Invalid component name "${name}" (resolves to "${param}"). ` +
+        'Names must start with a letter and contain only lowercase letters, numbers, and hyphens.'
+    );
+  }
+
+  if (name.trimStart().startsWith('_')) {
+    throw new Error(
+      `Component name "${name}" must not start with "_" — that prefix is reserved for internal namespaces (e.g. _squad/).`
+    );
+  }
+
+  return true;
+}
+
+/**
+ * Applies the correct casing for a component type.
+ * - react -> PascalCase
+ * - web-component -> param-case
+ */
+export function applyNameCasing(name, type) {
+  if (type === 'web-component') return toParamCase(name);
+  return toPascalCase(name);
+}

--- a/tools/carbon-labs-init/src/lib/owners.js
+++ b/tools/carbon-labs-init/src/lib/owners.js
@@ -1,0 +1,27 @@
+/**
+ * Parses a comma-separated string of GitHub handles into a normalized array.
+ * Adds "@" prefix if missing. Deduplicated.
+ */
+export function parseOwners(str) {
+  if (!str) return [];
+  const seen = new Set();
+  return str
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((handle) => (handle.startsWith('@') ? handle : `@${handle}`))
+    .filter((handle) => {
+      if (seen.has(handle)) return false;
+      seen.add(handle);
+      return true;
+    });
+}
+
+/**
+ * Returns the first non-empty owner list in priority order: flag > config > [].
+ */
+export function mergeOwners(flagOwners, configOwners) {
+  if (flagOwners && flagOwners.length > 0) return flagOwners;
+  if (configOwners && configOwners.length > 0) return configOwners;
+  return [];
+}

--- a/tools/carbon-labs-init/test/config.test.js
+++ b/tools/carbon-labs-init/test/config.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mergeOptions, DEFAULTS } from '../src/lib/config.js';
+
+// loadConfig is tested with a real filesystem in a temp dir;
+// mergeOptions covers the merge logic in isolation.
+
+describe('mergeOptions — type priority', () => {
+  it('uses flag type when provided', () => {
+    const result = mergeOptions({ type: 'web-component' }, { defaultType: 'react' });
+    expect(result.type).toBe('web-component');
+  });
+
+  it('falls back to config defaultType when flag is absent', () => {
+    const result = mergeOptions({}, { defaultType: 'web-component' });
+    expect(result.type).toBe('web-component');
+  });
+
+  it('falls back to hardcoded default when neither flag nor config set type', () => {
+    const result = mergeOptions({}, {});
+    expect(result.type).toBe(DEFAULTS.defaultType);
+  });
+});
+
+describe('mergeOptions — owner priority', () => {
+  it('uses flag owners when --owners is passed', () => {
+    const result = mergeOptions(
+      { owners: '@flag-user' },
+      { defaultOwners: ['@config-user'] }
+    );
+    expect(result.owners).toEqual(['@flag-user']);
+  });
+
+  it('falls back to config defaultOwners when flag is absent', () => {
+    const result = mergeOptions(
+      { owners: undefined },
+      { defaultOwners: ['@config-user'] }
+    );
+    expect(result.owners).toEqual(['@config-user']);
+  });
+
+  it('returns empty array when no owners provided anywhere', () => {
+    const result = mergeOptions({}, {});
+    expect(result.owners).toEqual([]);
+  });
+
+  it('parses comma-separated flag owners string', () => {
+    const result = mergeOptions(
+      { owners: '@alice,@bob' },
+      { defaultOwners: [] }
+    );
+    expect(result.owners).toEqual(['@alice', '@bob']);
+  });
+});
+
+describe('mergeOptions — editor command', () => {
+  it('uses config editorCommand when set', () => {
+    const result = mergeOptions({}, { editorCommand: 'vim' });
+    expect(result.editorCommand).toBe('vim');
+  });
+
+  it('falls back to default editorCommand', () => {
+    const result = mergeOptions({}, {});
+    expect(result.editorCommand).toBe(DEFAULTS.editorCommand);
+  });
+});
+
+describe('mergeOptions — storybookGroup', () => {
+  it('uses --group flag over config', () => {
+    const result = mergeOptions({ group: 'Labs' }, { storybookGroup: 'Squad' });
+    expect(result.storybookGroup).toBe('Labs');
+  });
+
+  it('falls back to config storybookGroup', () => {
+    const result = mergeOptions({}, { storybookGroup: 'Squad' });
+    expect(result.storybookGroup).toBe('Squad');
+  });
+
+  it('defaults to Components', () => {
+    const result = mergeOptions({}, {});
+    expect(result.storybookGroup).toBe('Components');
+  });
+});
+
+// ── loadConfig filesystem tests ────────────────────────────────────────────
+
+import { loadConfig } from '../src/lib/config.js';
+import { writeFile, mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('loadConfig', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'carbon-labs-init-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns defaults when no .carbon-labs-init.json present', async () => {
+    const config = await loadConfig(tmpDir);
+    expect(config).toMatchObject(DEFAULTS);
+  });
+
+  it('merges file values over defaults', async () => {
+    await writeFile(
+      join(tmpDir, '.carbon-labs-init.json'),
+      JSON.stringify({ squad: 'my-squad', defaultType: 'web-component' })
+    );
+    const config = await loadConfig(tmpDir);
+    expect(config.squad).toBe('my-squad');
+    expect(config.defaultType).toBe('web-component');
+    expect(config.editorCommand).toBe(DEFAULTS.editorCommand);
+  });
+
+  it('parses string defaultOwners', async () => {
+    await writeFile(
+      join(tmpDir, '.carbon-labs-init.json'),
+      JSON.stringify({ defaultOwners: '@alice,@bob' })
+    );
+    const config = await loadConfig(tmpDir);
+    expect(config.defaultOwners).toEqual(['@alice', '@bob']);
+  });
+
+  it('preserves array defaultOwners', async () => {
+    await writeFile(
+      join(tmpDir, '.carbon-labs-init.json'),
+      JSON.stringify({ defaultOwners: ['@alice', '@bob'] })
+    );
+    const config = await loadConfig(tmpDir);
+    expect(config.defaultOwners).toEqual(['@alice', '@bob']);
+  });
+
+  it('throws on malformed JSON', async () => {
+    await writeFile(join(tmpDir, '.carbon-labs-init.json'), 'not json {{{');
+    await expect(loadConfig(tmpDir)).rejects.toThrow(/Failed to parse/);
+  });
+});

--- a/tools/carbon-labs-init/test/mdx.test.js
+++ b/tools/carbon-labs-init/test/mdx.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { injectMdxMetadata } from '../src/lib/mdx.js';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const SAMPLE_MDX = `import { ArgTypes, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as ExampleButtonStories from './ExampleButton.stories';
+
+<Meta isTemplate />
+
+# ExampleButton
+
+- **Initiative owner(s):** FILL THIS LINE
+- **Status:** Draft
+- **Target library:** TBD
+- **Support channel:** \`#carbon-labs\`
+
+## Overview
+
+This is an example button component.
+`;
+
+const SAMPLE_STORIES = `import ExampleButtonDocs from './ExampleButton.mdx';
+import { ExampleButton } from '../ExampleButton.js';
+
+export default {
+  title: 'Components/ExampleButton',
+  component: ExampleButton,
+  docs: { page: ExampleButtonDocs },
+};
+
+export const Default = () => <ExampleButton />;
+`;
+
+async function makeComponentDir(tmpDir, name) {
+  const componentDir = join(tmpDir, name);
+  const storiesDir = join(componentDir, '__stories__');
+  await mkdir(storiesDir, { recursive: true });
+  await writeFile(join(storiesDir, `${name}.mdx`), SAMPLE_MDX);
+  await writeFile(join(storiesDir, `${name}.stories.js`), SAMPLE_STORIES);
+  return componentDir;
+}
+
+describe('injectMdxMetadata', () => {
+  let tmpDir;
+  let componentDir;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'carbon-labs-init-mdx-test-'));
+    componentDir = await makeComponentDir(tmpDir, 'ExampleButton');
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── MDX owner injection ────────────────────────────────────────────────
+
+  it('replaces FILL THIS LINE with owner handles', async () => {
+    await injectMdxMetadata({
+      componentDir,
+      componentName: 'ExampleButton',
+      owners: ['@ajcase', '@bob'],
+    });
+    const content = await readFile(
+      join(componentDir, '__stories__', 'ExampleButton.mdx'),
+      'utf8'
+    );
+    expect(content).toContain('@ajcase, @bob');
+    expect(content).not.toContain('FILL THIS LINE');
+  });
+
+  it('leaves owner line untouched when owners array is empty', async () => {
+    await injectMdxMetadata({
+      componentDir,
+      componentName: 'ExampleButton',
+      owners: [],
+    });
+    const content = await readFile(
+      join(componentDir, '__stories__', 'ExampleButton.mdx'),
+      'utf8'
+    );
+    expect(content).toContain('FILL THIS LINE');
+  });
+
+  // ── MDX problem-statement scaffold ────────────────────────────────────
+
+  it('injects a problem-statement scaffold after ## Overview', async () => {
+    await injectMdxMetadata({
+      componentDir,
+      componentName: 'ExampleButton',
+      owners: ['@ajcase'],
+    });
+    const content = await readFile(
+      join(componentDir, '__stories__', 'ExampleButton.mdx'),
+      'utf8'
+    );
+    expect(content).toContain('carbon-labs-init:problem-statement');
+    expect(content).toContain('Problem statement:');
+    // Scaffold must appear after ## Overview
+    const overviewIdx = content.indexOf('## Overview');
+    const scaffoldIdx = content.indexOf('carbon-labs-init:problem-statement');
+    expect(scaffoldIdx).toBeGreaterThan(overviewIdx);
+  });
+
+  it('is idempotent — does not duplicate the scaffold on second call', async () => {
+    await injectMdxMetadata({ componentDir, componentName: 'ExampleButton', owners: ['@ajcase'] });
+    await injectMdxMetadata({ componentDir, componentName: 'ExampleButton', owners: ['@ajcase'] });
+    const content = await readFile(
+      join(componentDir, '__stories__', 'ExampleButton.mdx'),
+      'utf8'
+    );
+    const count = (content.match(/carbon-labs-init:problem-statement/g) || []).length;
+    expect(count).toBe(1);
+  });
+
+  // ── Stories file tagging ───────────────────────────────────────────────
+
+  it('defaults the Storybook title group to Components/', async () => {
+    await injectMdxMetadata({
+      componentDir,
+      componentName: 'ExampleButton',
+      owners: ['@ajcase'],
+    });
+    const content = await readFile(
+      join(componentDir, '__stories__', 'ExampleButton.stories.js'),
+      'utf8'
+    );
+    expect(content).toContain("title: 'Components/ExampleButton'");
+  });
+
+  it('uses a custom storybookGroup when provided', async () => {
+    await injectMdxMetadata({
+      componentDir,
+      componentName: 'ExampleButton',
+      owners: ['@ajcase'],
+      storybookGroup: 'Squad',
+    });
+    const content = await readFile(
+      join(componentDir, '__stories__', 'ExampleButton.stories.js'),
+      'utf8'
+    );
+    expect(content).toContain("title: 'Squad/ExampleButton'");
+    expect(content).not.toContain("title: 'Components/ExampleButton'");
+  });
+
+  it('is idempotent when re-run with the same group', async () => {
+    await injectMdxMetadata({ componentDir, componentName: 'ExampleButton', owners: ['@ajcase'], storybookGroup: 'Labs' });
+    await injectMdxMetadata({ componentDir, componentName: 'ExampleButton', owners: ['@ajcase'], storybookGroup: 'Labs' });
+    const content = await readFile(
+      join(componentDir, '__stories__', 'ExampleButton.stories.js'),
+      'utf8'
+    );
+    const count = (content.match(/title:/g) || []).length;
+    expect(count).toBe(1);
+    expect(content).toContain("title: 'Labs/ExampleButton'");
+  });
+
+  it("adds tags: ['squad', 'incubating'] to the stories default export", async () => {
+    await injectMdxMetadata({
+      componentDir,
+      componentName: 'ExampleButton',
+      owners: ['@ajcase'],
+    });
+    const content = await readFile(
+      join(componentDir, '__stories__', 'ExampleButton.stories.js'),
+      'utf8'
+    );
+    expect(content).toContain("tags: ['squad', 'incubating']");
+  });
+
+  it('does not duplicate tags on second call', async () => {
+    await injectMdxMetadata({ componentDir, componentName: 'ExampleButton', owners: ['@ajcase'] });
+    await injectMdxMetadata({ componentDir, componentName: 'ExampleButton', owners: ['@ajcase'] });
+    const content = await readFile(
+      join(componentDir, '__stories__', 'ExampleButton.stories.js'),
+      'utf8'
+    );
+    const count = (content.match(/tags:/g) || []).length;
+    expect(count).toBe(1);
+  });
+
+  it('handles missing stories file gracefully (no throw)', async () => {
+    const emptyDir = join(tmpDir, 'Empty');
+    await mkdir(join(emptyDir, '__stories__'), { recursive: true });
+    await writeFile(join(emptyDir, '__stories__', 'Empty.mdx'), SAMPLE_MDX);
+    // No stories file written — should not throw
+    await expect(
+      injectMdxMetadata({ componentDir: emptyDir, componentName: 'Empty', owners: [] })
+    ).resolves.not.toThrow();
+  });
+});

--- a/tools/carbon-labs-init/test/names.test.js
+++ b/tools/carbon-labs-init/test/names.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toPascalCase,
+  toParamCase,
+  validateComponentName,
+  applyNameCasing,
+} from '../src/lib/names.js';
+
+describe('toPascalCase', () => {
+  it('converts kebab-case', () => expect(toPascalCase('my-button')).toBe('MyButton'));
+  it('converts snake_case', () => expect(toPascalCase('my_button')).toBe('MyButton'));
+  it('converts camelCase', () => expect(toPascalCase('myButton')).toBe('MyButton'));
+  it('preserves PascalCase', () => expect(toPascalCase('MyButton')).toBe('MyButton'));
+  it('handles single word', () => expect(toPascalCase('button')).toBe('Button'));
+  it('handles multi-word kebab', () => expect(toPascalCase('data-table-toolbar')).toBe('DataTableToolbar'));
+  it('handles mixed separators', () => expect(toPascalCase('data_table-toolbar')).toBe('DataTableToolbar'));
+});
+
+describe('toParamCase', () => {
+  it('converts PascalCase', () => expect(toParamCase('MyButton')).toBe('my-button'));
+  it('converts camelCase', () => expect(toParamCase('myButton')).toBe('my-button'));
+  it('preserves kebab-case', () => expect(toParamCase('my-button')).toBe('my-button'));
+  it('converts snake_case', () => expect(toParamCase('my_button')).toBe('my-button'));
+  it('handles consecutive caps (acronyms)', () =>
+    expect(toParamCase('CDNButton')).toBe('cdn-button'));
+  it('handles mixed separators', () =>
+    expect(toParamCase('data_Table-toolbar')).toBe('data-table-toolbar'));
+  it('strips leading/trailing hyphens', () =>
+    expect(toParamCase('-my-button-')).toBe('my-button'));
+});
+
+describe('validateComponentName', () => {
+  it('accepts valid kebab-case names', () => expect(() => validateComponentName('my-button')).not.toThrow());
+  it('accepts valid PascalCase names', () => expect(() => validateComponentName('MyButton')).not.toThrow());
+  it('accepts single-word names', () => expect(() => validateComponentName('button')).not.toThrow());
+  it('rejects empty string', () => expect(() => validateComponentName('')).toThrow());
+  it('rejects null', () => expect(() => validateComponentName(null)).toThrow());
+  it('rejects names starting with underscore', () =>
+    expect(() => validateComponentName('_squad-button')).toThrow(/_squad/));
+  it('rejects names with special characters', () =>
+    expect(() => validateComponentName('my@button')).toThrow());
+  it('rejects names starting with a number', () =>
+    expect(() => validateComponentName('1button')).toThrow());
+});
+
+describe('applyNameCasing', () => {
+  it('returns PascalCase for react', () => expect(applyNameCasing('my-button', 'react')).toBe('MyButton'));
+  it('returns param-case for web-component', () =>
+    expect(applyNameCasing('MyButton', 'web-component')).toBe('my-button'));
+  it('defaults to PascalCase for unknown type', () =>
+    expect(applyNameCasing('my-button', 'react')).toBe('MyButton'));
+});

--- a/tools/carbon-labs-init/test/owners.test.js
+++ b/tools/carbon-labs-init/test/owners.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { parseOwners, mergeOwners } from '../src/lib/owners.js';
+
+describe('parseOwners', () => {
+  it('parses comma-separated handles', () =>
+    expect(parseOwners('@alice,@bob')).toEqual(['@alice', '@bob']));
+
+  it('adds @ prefix if missing', () =>
+    expect(parseOwners('alice,bob')).toEqual(['@alice', '@bob']));
+
+  it('normalises mixed @ usage', () =>
+    expect(parseOwners('@alice,bob')).toEqual(['@alice', '@bob']));
+
+  it('trims surrounding whitespace', () =>
+    expect(parseOwners('  @alice , @bob  ')).toEqual(['@alice', '@bob']));
+
+  it('handles empty string', () => expect(parseOwners('')).toEqual([]));
+  it('handles null', () => expect(parseOwners(null)).toEqual([]));
+  it('handles undefined', () => expect(parseOwners(undefined)).toEqual([]));
+
+  it('deduplicates handles', () =>
+    expect(parseOwners('@alice,@alice,@bob')).toEqual(['@alice', '@bob']));
+
+  it('drops empty entries from trailing comma', () =>
+    expect(parseOwners('@alice,')).toEqual(['@alice']));
+
+  it('handles a single handle without comma', () =>
+    expect(parseOwners('@alice')).toEqual(['@alice']));
+});
+
+describe('mergeOwners', () => {
+  it('prefers flagOwners over configOwners', () =>
+    expect(mergeOwners(['@flag'], ['@config'])).toEqual(['@flag']));
+
+  it('falls back to configOwners when flagOwners is empty', () =>
+    expect(mergeOwners([], ['@config'])).toEqual(['@config']));
+
+  it('falls back to configOwners when flagOwners is null', () =>
+    expect(mergeOwners(null, ['@config'])).toEqual(['@config']));
+
+  it('returns [] when both are empty', () =>
+    expect(mergeOwners([], [])).toEqual([]));
+
+  it('returns [] when both are null/undefined', () =>
+    expect(mergeOwners(null, null)).toEqual([]));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,6 +1610,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@carbon-labs/carbon-labs-init@workspace:tools/carbon-labs-init":
+  version: 0.0.0-use.local
+  resolution: "@carbon-labs/carbon-labs-init@workspace:tools/carbon-labs-init"
+  dependencies:
+    "@octokit/rest": "npm:^20.1.1"
+    chalk: "npm:^5.4.1"
+    commander: "npm:^12.1.0"
+    execa: "npm:^9.5.2"
+    ora: "npm:^8.1.1"
+    prompts: "npm:^2.4.2"
+    simple-git: "npm:^3.27.0"
+    vitest: "npm:^3.0.0"
+  bin:
+    carbon-labs-init: ./bin/carbon-labs-init.js
+  languageName: unknown
+  linkType: soft
+
 "@carbon-labs/mdx-components@workspace:packages/react/src/components/MDXComponents":
   version: 0.0.0-use.local
   resolution: "@carbon-labs/mdx-components@workspace:packages/react/src/components/MDXComponents"
@@ -2907,6 +2924,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/aix-ppc64@npm:0.27.7"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/android-arm64@npm:0.18.20"
@@ -2924,6 +2948,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-arm64@npm:0.25.12"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm64@npm:0.27.7"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -2949,6 +2980,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm@npm:0.27.7"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/android-x64@npm:0.18.20"
@@ -2966,6 +3004,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-x64@npm:0.25.12"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-x64@npm:0.27.7"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -2991,6 +3036,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-arm64@npm:0.27.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/darwin-x64@npm:0.18.20"
@@ -3008,6 +3060,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/darwin-x64@npm:0.25.12"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-x64@npm:0.27.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -3033,6 +3092,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.7"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/freebsd-x64@npm:0.18.20"
@@ -3050,6 +3116,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/freebsd-x64@npm:0.25.12"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-x64@npm:0.27.7"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -3075,6 +3148,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm64@npm:0.27.7"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-arm@npm:0.18.20"
@@ -3092,6 +3172,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-arm@npm:0.25.12"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm@npm:0.27.7"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -3117,6 +3204,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ia32@npm:0.27.7"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-loong64@npm:0.18.20"
@@ -3134,6 +3228,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-loong64@npm:0.25.12"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-loong64@npm:0.27.7"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -3159,6 +3260,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-mips64el@npm:0.27.7"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-ppc64@npm:0.18.20"
@@ -3176,6 +3284,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-ppc64@npm:0.25.12"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ppc64@npm:0.27.7"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -3201,6 +3316,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-riscv64@npm:0.27.7"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-s390x@npm:0.18.20"
@@ -3218,6 +3340,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-s390x@npm:0.25.12"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-s390x@npm:0.27.7"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -3243,9 +3372,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-x64@npm:0.27.7"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -3271,9 +3414,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-x64@npm:0.27.7"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -3299,9 +3456,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-x64@npm:0.27.7"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openharmony-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -3327,6 +3498,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/sunos-x64@npm:0.27.7"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/win32-arm64@npm:0.18.20"
@@ -3344,6 +3522,13 @@ __metadata:
 "@esbuild/win32-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-arm64@npm:0.27.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -3369,6 +3554,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-ia32@npm:0.27.7"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/win32-x64@npm:0.18.20"
@@ -3386,6 +3578,13 @@ __metadata:
 "@esbuild/win32-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/win32-x64@npm:0.25.12"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-x64@npm:0.27.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4359,6 +4558,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kwsites/file-exists@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/file-exists@npm:1.1.1"
+  dependencies:
+    debug: "npm:^4.1.1"
+  checksum: 10c0/39e693239a72ccd8408bb618a0200e4a8d61682057ca7ae2c87668d7e69196e8d7e2c9cde73db6b23b3b0230169a15e5f1bfe086539f4be43e767b2db68e8ee4
+  languageName: node
+  linkType: hard
+
+"@kwsites/promise-deferred@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/promise-deferred@npm:1.1.1"
+  checksum: 10c0/ef1ad3f1f50991e3bed352b175986d8b4bc684521698514a2ed63c1d1fc9848843da4f2bc2df961c9b148c94e1c34bf33f0da8a90ba2234e452481f2cc9937b1
+  languageName: node
+  linkType: hard
+
 "@lerna/create@npm:9.0.3":
   version: 9.0.3
   resolution: "@lerna/create@npm:9.0.3"
@@ -5074,7 +5289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/rest@npm:20.1.2":
+"@octokit/rest@npm:20.1.2, @octokit/rest@npm:^20.1.1":
   version: 20.1.2
   resolution: "@octokit/rest@npm:20.1.2"
   dependencies:
@@ -6578,9 +6793,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-android-arm-eabi@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-android-arm64@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-android-arm64@npm:4.57.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-android-arm64@npm:4.60.2"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -6592,9 +6821,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-darwin-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-darwin-x64@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-darwin-x64@npm:4.57.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-darwin-x64@npm:4.60.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -6606,9 +6849,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-freebsd-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-freebsd-x64@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-freebsd-x64@npm:4.57.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6620,9 +6877,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-arm-musleabihf@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.57.0"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.2"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
@@ -6634,9 +6905,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-arm64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-arm64-musl@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-linux-arm64-musl@npm:4.57.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -6648,9 +6933,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-loong64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-loong64-musl@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-linux-loong64-musl@npm:4.57.0"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.2"
   conditions: os=linux & cpu=loong64 & libc=musl
   languageName: node
   linkType: hard
@@ -6662,9 +6961,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-ppc64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-ppc64-musl@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.57.0"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.2"
   conditions: os=linux & cpu=ppc64 & libc=musl
   languageName: node
   linkType: hard
@@ -6676,9 +6989,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-riscv64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-riscv64-musl@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.57.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.2"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
@@ -6690,9 +7017,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-s390x-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-x64-gnu@npm:4.57.0, @rollup/rollup-linux-x64-gnu@npm:^4.24.4":
   version: 4.57.0
   resolution: "@rollup/rollup-linux-x64-gnu@npm:4.57.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -6704,9 +7045,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-x64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-openbsd-x64@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-openbsd-x64@npm:4.57.0"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.2"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6718,9 +7073,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-openharmony-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-win32-arm64-msvc@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.57.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -6732,9 +7101,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-win32-ia32-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-win32-x64-gnu@npm:4.57.0":
   version: 4.57.0
   resolution: "@rollup/rollup-win32-x64-gnu@npm:4.57.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6746,10 +7129,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-win32-x64-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rtsao/scc@npm:^1.1.0":
   version: 1.1.0
   resolution: "@rtsao/scc@npm:1.1.0"
   checksum: 10c0/b5bcfb0d87f7d1c1c7c0f7693f53b07866ed9fec4c34a97a8c948fb9a7c0082e416ce4d3b60beb4f5e167cbe04cdeefbf6771320f3ede059b9ce91188c409a5b
+  languageName: node
+  linkType: hard
+
+"@sec-ant/readable-stream@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@sec-ant/readable-stream@npm:0.4.1"
+  checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
   languageName: node
   linkType: hard
 
@@ -6937,6 +7334,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@simple-git/args-pathspec@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@simple-git/args-pathspec@npm:1.0.3"
+  checksum: 10c0/91bfc99daa956df28e4efd683cd799f60c6d169fce6adf71a9efa80a6b5938fed4b03e55fa929cfd51aed64f3ada5c1e4edad45a3872dbd94d11924b3258b5bc
+  languageName: node
+  linkType: hard
+
+"@simple-git/argv-parser@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@simple-git/argv-parser@npm:1.1.1"
+  dependencies:
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+  checksum: 10c0/2c21166f1bb7c4373e7b4e52bd0c7f333e58ea0ff5ac0b6c2d305835f4a2bcad1ef4bcce3cff63312ac55655ea7be3aba4c7c0c41e3ebcb8bee343f65bb92f5e
+  languageName: node
+  linkType: hard
+
 "@simple-libs/child-process-utils@npm:^1.0.0":
   version: 1.0.2
   resolution: "@simple-libs/child-process-utils@npm:1.0.2"
@@ -6978,6 +7391,13 @@ __metadata:
   version: 2.3.0
   resolution: "@sindresorhus/merge-streams@npm:2.3.0"
   checksum: 10c0/69ee906f3125fb2c6bb6ec5cdd84e8827d93b49b3892bce8b62267116cc7e197b5cccf20c160a1d32c26014ecd14470a72a5e3ee37a58f1d6dadc0db1ccf3894
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/merge-streams@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@sindresorhus/merge-streams@npm:4.0.0"
+  checksum: 10c0/482ee543629aa1933b332f811a1ae805a213681ecdd98c042b1c1b89387df63e7812248bb4df3910b02b3cc5589d3d73e4393f30e197c9dde18046ccd471fc6b
   languageName: node
   linkType: hard
 
@@ -9161,12 +9581,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:3.2.4":
+"@vitest/pretty-format@npm:3.2.4, @vitest/pretty-format@npm:^3.2.4":
   version: 3.2.4
   resolution: "@vitest/pretty-format@npm:3.2.4"
   dependencies:
     tinyrainbow: "npm:^2.0.0"
   checksum: 10c0/5ad7d4278e067390d7d633e307fee8103958806a419ca380aec0e33fae71b44a64415f7a9b4bc11635d3c13d4a9186111c581d3cef9c65cc317e68f077456887
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/runner@npm:3.2.4"
+  dependencies:
+    "@vitest/utils": "npm:3.2.4"
+    pathe: "npm:^2.0.3"
+    strip-literal: "npm:^3.0.0"
+  checksum: 10c0/e8be51666c72b3668ae3ea348b0196656a4a5adb836cb5e270720885d9517421815b0d6c98bfdf1795ed02b994b7bfb2b21566ee356a40021f5bf4f6ed4e418a
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/snapshot@npm:3.2.4"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.2.4"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/f8301a3d7d1559fd3d59ed51176dd52e1ed5c2d23aa6d8d6aa18787ef46e295056bc726a021698d8454c16ed825ecba163362f42fa90258bb4a98cfd2c9424fc
   languageName: node
   linkType: hard
 
@@ -11698,6 +12140,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^19.0.1":
   version: 19.0.1
   resolution: "cacache@npm:19.0.1"
@@ -11933,6 +12382,7 @@ __metadata:
     eslint: "npm:^8.57.0"
     eslint-config-carbon: "npm:^3.11.0"
     fs-extra: "npm:^11.2.0"
+    glob: "npm:^11.0.0"
     globby: "npm:^14.0.0"
     husky: "npm:^9.0.0"
     lerna: "npm:^9.0.0"
@@ -12047,7 +12497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.1.2, chalk@npm:^5.4.1":
+"chalk@npm:^5.1.2, chalk@npm:^5.3.0, chalk@npm:^5.4.1":
   version: 5.6.2
   resolution: "chalk@npm:5.6.2"
   checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
@@ -12419,7 +12869,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.5.0":
+"cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.9.2":
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
@@ -15469,7 +15919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.0.0, es-module-lexer@npm:^1.5.0, es-module-lexer@npm:^1.6.0":
+"es-module-lexer@npm:^1.0.0, es-module-lexer@npm:^1.5.0, es-module-lexer@npm:^1.6.0, es-module-lexer@npm:^1.7.0":
   version: 1.7.0
   resolution: "es-module-lexer@npm:1.7.0"
   checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
@@ -15790,6 +16240,95 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/fa08508adf683c3f399e8a014a6382a6b65542213431e26206c0720e536b31c09b50798747c2a105a4bbba1d9767b8d3615a74c2f7bf1ddf6d836cd11eb672de
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.27.0":
+  version: 0.27.7
+  resolution: "esbuild@npm:0.27.7"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.27.7"
+    "@esbuild/android-arm": "npm:0.27.7"
+    "@esbuild/android-arm64": "npm:0.27.7"
+    "@esbuild/android-x64": "npm:0.27.7"
+    "@esbuild/darwin-arm64": "npm:0.27.7"
+    "@esbuild/darwin-x64": "npm:0.27.7"
+    "@esbuild/freebsd-arm64": "npm:0.27.7"
+    "@esbuild/freebsd-x64": "npm:0.27.7"
+    "@esbuild/linux-arm": "npm:0.27.7"
+    "@esbuild/linux-arm64": "npm:0.27.7"
+    "@esbuild/linux-ia32": "npm:0.27.7"
+    "@esbuild/linux-loong64": "npm:0.27.7"
+    "@esbuild/linux-mips64el": "npm:0.27.7"
+    "@esbuild/linux-ppc64": "npm:0.27.7"
+    "@esbuild/linux-riscv64": "npm:0.27.7"
+    "@esbuild/linux-s390x": "npm:0.27.7"
+    "@esbuild/linux-x64": "npm:0.27.7"
+    "@esbuild/netbsd-arm64": "npm:0.27.7"
+    "@esbuild/netbsd-x64": "npm:0.27.7"
+    "@esbuild/openbsd-arm64": "npm:0.27.7"
+    "@esbuild/openbsd-x64": "npm:0.27.7"
+    "@esbuild/openharmony-arm64": "npm:0.27.7"
+    "@esbuild/sunos-x64": "npm:0.27.7"
+    "@esbuild/win32-arm64": "npm:0.27.7"
+    "@esbuild/win32-ia32": "npm:0.27.7"
+    "@esbuild/win32-x64": "npm:0.27.7"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/ccd51f0555708bc9ff4ec9dc3ac92d3daacd45ecaac949ca8645984c5c323bf8cefe98c2df307418685e0b4ce37f9a3bdbfe8e3651fe632a0059a436195a17d4
   languageName: node
   linkType: hard
 
@@ -16467,6 +17006,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:^9.5.2":
+  version: 9.6.1
+  resolution: "execa@npm:9.6.1"
+  dependencies:
+    "@sindresorhus/merge-streams": "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.6"
+    figures: "npm:^6.1.0"
+    get-stream: "npm:^9.0.0"
+    human-signals: "npm:^8.0.1"
+    is-plain-obj: "npm:^4.1.0"
+    is-stream: "npm:^4.0.1"
+    npm-run-path: "npm:^6.0.0"
+    pretty-ms: "npm:^9.2.0"
+    signal-exit: "npm:^4.1.0"
+    strip-final-newline: "npm:^4.0.0"
+    yoctocolors: "npm:^2.1.1"
+  checksum: 10c0/636b36585306a3c8bc3a9d7b25d2d915fb06d8c9b9b02a804280d62562de3b34535affc1b7702b039320e0953daa6545a073f3c4b63fe974c1fe11336c56b467
+  languageName: node
+  linkType: hard
+
 "exeunt@npm:1.1.0":
   version: 1.1.0
   resolution: "exeunt@npm:1.1.0"
@@ -16518,6 +17077,13 @@ __metadata:
   version: 2.0.3
   resolution: "expand-template@npm:2.0.3"
   checksum: 10c0/1c9e7afe9acadf9d373301d27f6a47b34e89b3391b1ef38b7471d381812537ef2457e620ae7f819d2642ce9c43b189b3583813ec395e2938319abe356a9b2f51
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.2.1":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -16785,6 +17351,15 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^1.0.5"
   checksum: 10c0/9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
+  languageName: node
+  linkType: hard
+
+"figures@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "figures@npm:6.1.0"
+  dependencies:
+    is-unicode-supported: "npm:^2.0.0"
+  checksum: 10c0/9159df4264d62ef447a3931537de92f5012210cf5135c35c010df50a2169377581378149abfe1eb238bd6acbba1c0d547b1f18e0af6eee49e30363cedaffcfe4
   languageName: node
   linkType: hard
 
@@ -17536,6 +18111,16 @@ __metadata:
   version: 8.0.1
   resolution: "get-stream@npm:8.0.1"
   checksum: 10c0/5c2181e98202b9dae0bb4a849979291043e5892eb40312b47f0c22b9414fc9b28a3b6063d2375705eb24abc41ecf97894d9a51f64ff021511b504477b27b4290
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "get-stream@npm:9.0.1"
+  dependencies:
+    "@sec-ant/readable-stream": "npm:^0.4.1"
+    is-stream: "npm:^4.0.1"
+  checksum: 10c0/d70e73857f2eea1826ac570c3a912757dcfbe8a718a033fa0c23e12ac8e7d633195b01710e0559af574cbb5af101009b42df7b6f6b29ceec8dbdf7291931b948
   languageName: node
   linkType: hard
 
@@ -18486,6 +19071,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"human-signals@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "human-signals@npm:8.0.1"
+  checksum: 10c0/195ac607108c56253757717242e17cd2e21b29f06c5d2dad362e86c672bf2d096e8a3bbb2601841c376c2301c4ae7cff129e87f740aa4ebff1390c163114c7c4
+  languageName: node
+  linkType: hard
+
 "husky@npm:^9.0.0":
   version: 9.1.7
   resolution: "husky@npm:9.1.7"
@@ -19250,6 +19842,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-interactive@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-interactive@npm:2.0.0"
+  checksum: 10c0/801c8f6064f85199dc6bf99b5dd98db3282e930c3bc197b32f2c5b89313bb578a07d1b8a01365c4348c2927229234f3681eb861b9c2c92bee72ff397390fa600
+  languageName: node
+  linkType: hard
+
 "is-ip@npm:^3.1.0":
   version: 3.1.0
   resolution: "is-ip@npm:3.1.0"
@@ -19482,6 +20081,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-stream@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "is-stream@npm:4.0.1"
+  checksum: 10c0/2706c7f19b851327ba374687bc4a3940805e14ca496dc672b9629e744d143b1ad9c6f1b162dece81c7bfbc0f83b32b61ccc19ad2e05aad2dd7af347408f60c7f
+  languageName: node
+  linkType: hard
+
 "is-string@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-string@npm:1.1.1"
@@ -19525,6 +20131,20 @@ __metadata:
   version: 0.1.0
   resolution: "is-unicode-supported@npm:0.1.0"
   checksum: 10c0/00cbe3455c3756be68d2542c416cab888aebd5012781d6819749fefb15162ff23e38501fe681b3d751c73e8ff561ac09a5293eba6f58fdf0178462ce6dcb3453
+  languageName: node
+  linkType: hard
+
+"is-unicode-supported@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "is-unicode-supported@npm:1.3.0"
+  checksum: 10c0/b8674ea95d869f6faabddc6a484767207058b91aea0250803cbf1221345cb0c56f466d4ecea375dc77f6633d248d33c47bd296fb8f4cdba0b4edba8917e83d8a
+  languageName: node
+  linkType: hard
+
+"is-unicode-supported@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "is-unicode-supported@npm:2.1.0"
+  checksum: 10c0/a0f53e9a7c1fdbcf2d2ef6e40d4736fdffff1c9f8944c75e15425118ff3610172c87bf7bc6c34d3903b04be59790bb2212ddbe21ee65b5a97030fc50370545a5
   languageName: node
   linkType: hard
 
@@ -20372,6 +20992,13 @@ __metadata:
   version: 3.0.2
   resolution: "js-tokens@npm:3.0.2"
   checksum: 10c0/e3c3ee4d12643d90197628eb022a2884a15f08ea7dcac1ce97fdeee43031fbfc7ede674f2cdbbb582dcd4c94388b22e52d56c6cbeb2ac7d1b57c2f33c405e2ba
+  languageName: node
+  linkType: hard
+
+"js-tokens@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "js-tokens@npm:9.0.1"
+  checksum: 10c0/68dcab8f233dde211a6b5fd98079783cbcd04b53617c1250e3553ee16ab3e6134f5e65478e41d82f6d351a052a63d71024553933808570f04dbf828d7921e80e
   languageName: node
   linkType: hard
 
@@ -21516,6 +22143,16 @@ __metadata:
     chalk: "npm:^4.1.0"
     is-unicode-supported: "npm:^0.1.0"
   checksum: 10c0/67f445a9ffa76db1989d0fa98586e5bc2fd5247260dafb8ad93d9f0ccd5896d53fb830b0e54dade5ad838b9de2006c826831a3c528913093af20dff8bd24aca6
+  languageName: node
+  linkType: hard
+
+"log-symbols@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "log-symbols@npm:6.0.0"
+  dependencies:
+    chalk: "npm:^5.3.0"
+    is-unicode-supported: "npm:^1.3.0"
+  checksum: 10c0/36636cacedba8f067d2deb4aad44e91a89d9efb3ead27e1846e7b82c9a10ea2e3a7bd6ce28a7ca616bebc60954ff25c67b0f92d20a6a746bb3cc52c3701891f6
   languageName: node
   linkType: hard
 
@@ -24178,6 +24815,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "npm-run-path@npm:6.0.0"
+  dependencies:
+    path-key: "npm:^4.0.0"
+    unicorn-magic: "npm:^0.3.0"
+  checksum: 10c0/b223c8a0dcd608abf95363ea5c3c0ccc3cd877daf0102eaf1b0f2390d6858d8337fbb7c443af2403b067a7d2c116d10691ecd22ab3c5273c44da1ff8d07753bd
+  languageName: node
+  linkType: hard
+
 "nth-check@npm:^2.0.1":
   version: 2.1.1
   resolution: "nth-check@npm:2.1.1"
@@ -24587,6 +25234,23 @@ __metadata:
     strip-ansi: "npm:^6.0.0"
     wcwidth: "npm:^1.0.1"
   checksum: 10c0/10ff14aace236d0e2f044193362b22edce4784add08b779eccc8f8ef97195cae1248db8ec1ec5f5ff076f91acbe573f5f42a98c19b78dba8c54eefff983cae85
+  languageName: node
+  linkType: hard
+
+"ora@npm:^8.1.1":
+  version: 8.2.0
+  resolution: "ora@npm:8.2.0"
+  dependencies:
+    chalk: "npm:^5.3.0"
+    cli-cursor: "npm:^5.0.0"
+    cli-spinners: "npm:^2.9.2"
+    is-interactive: "npm:^2.0.0"
+    is-unicode-supported: "npm:^2.0.0"
+    log-symbols: "npm:^6.0.0"
+    stdin-discarder: "npm:^0.2.2"
+    string-width: "npm:^7.2.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10c0/7d9291255db22e293ea164f520b6042a3e906576ab06c9cf408bf9ef5664ba0a9f3bd258baa4ada058cfcc2163ef9b6696d51237a866682ce33295349ba02c3a
   languageName: node
   linkType: hard
 
@@ -25092,6 +25756,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-ms@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "parse-ms@npm:4.0.0"
+  checksum: 10c0/a7900f4f1ebac24cbf5e9708c16fb2fd482517fad353aecd7aefb8c2ba2f85ce017913ccb8925d231770404780df46244ea6fec598b3bde6490882358b4d2d16
+  languageName: node
+  linkType: hard
+
 "parse-path@npm:^7.0.0":
   version: 7.1.0
   resolution: "parse-path@npm:7.1.0"
@@ -25353,6 +26024,13 @@ __metadata:
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
   checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 
@@ -26449,6 +27127,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-ms@npm:^9.2.0":
+  version: 9.3.0
+  resolution: "pretty-ms@npm:9.3.0"
+  dependencies:
+    parse-ms: "npm:^4.0.0"
+  checksum: 10c0/555ea39a1de48a30601938aedb76d682871d33b6dee015281c37108921514b11e1792928b1648c2e5589acc73c8ef0fb5e585fb4c718e340a28b86799e90fb34
+  languageName: node
+  linkType: hard
+
 "private@npm:^0.1.8":
   version: 0.1.8
   resolution: "private@npm:0.1.8"
@@ -26564,7 +27251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prompts@npm:^2.0.1":
+"prompts@npm:^2.0.1, prompts@npm:^2.4.2":
   version: 2.4.2
   resolution: "prompts@npm:2.4.2"
   dependencies:
@@ -28102,6 +28789,96 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^4.43.0":
+  version: 4.60.2
+  resolution: "rollup@npm:4.60.2"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.60.2"
+    "@rollup/rollup-android-arm64": "npm:4.60.2"
+    "@rollup/rollup-darwin-arm64": "npm:4.60.2"
+    "@rollup/rollup-darwin-x64": "npm:4.60.2"
+    "@rollup/rollup-freebsd-arm64": "npm:4.60.2"
+    "@rollup/rollup-freebsd-x64": "npm:4.60.2"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.2"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.2"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-x64-musl": "npm:4.60.2"
+    "@rollup/rollup-openbsd-x64": "npm:4.60.2"
+    "@rollup/rollup-openharmony-arm64": "npm:4.60.2"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.2"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.2"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.60.2"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.60.2"
+    "@types/estree": "npm:1.0.8"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10c0/f67d6156fc5b895f33b929a4762392906d00fa5550f0a1f5e66519ab1c05d835aec5f201b4e748c29d1c87f024d3d9c4b0a2d1285668456db661d82b961d379c
+  languageName: node
+  linkType: hard
+
 "roughjs@npm:^4.6.6":
   version: 4.6.6
   resolution: "roughjs@npm:4.6.6"
@@ -28732,6 +29509,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:3.0.7, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -28782,6 +29566,19 @@ __metadata:
     once: "npm:^1.3.1"
     simple-concat: "npm:^1.0.0"
   checksum: 10c0/b0649a581dbca741babb960423248899203165769747142033479a7dc5e77d7b0fced0253c731cd57cf21e31e4d77c9157c3069f4448d558ebc96cf9e1eebcf0
+  languageName: node
+  linkType: hard
+
+"simple-git@npm:^3.27.0":
+  version: 3.36.0
+  resolution: "simple-git@npm:3.36.0"
+  dependencies:
+    "@kwsites/file-exists": "npm:^1.1.1"
+    "@kwsites/promise-deferred": "npm:^1.1.1"
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+    "@simple-git/argv-parser": "npm:^1.1.0"
+    debug: "npm:^4.4.0"
+  checksum: 10c0/4c22e57107535168f354e5abbbf6e618a7b39d76491ca225c70588520fbe86891f3b9a5c4f8a3fc0137e669aad2f0e11f6c6e677bfec07169cd18f29bf23cb77
   languageName: node
   linkType: hard
 
@@ -29196,6 +29993,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
 "stackframe@npm:^1.3.4":
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
@@ -29253,6 +30057,20 @@ __metadata:
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.9.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
+  languageName: node
+  linkType: hard
+
+"stdin-discarder@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "stdin-discarder@npm:0.2.2"
+  checksum: 10c0/c78375e82e956d7a64be6e63c809c7f058f5303efcaf62ea48350af072bacdb99c06cba39209b45a071c1acbd49116af30df1df9abb448df78a6005b72f10537
   languageName: node
   linkType: hard
 
@@ -29423,7 +30241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^7.0.0":
+"string-width@npm:^7.0.0, string-width@npm:^7.2.0":
   version: 7.2.0
   resolution: "string-width@npm:7.2.0"
   dependencies:
@@ -29608,6 +30426,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-final-newline@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "strip-final-newline@npm:4.0.0"
+  checksum: 10c0/b0cf2b62d597a1b0e3ebc42b88767f0a0d45601f89fd379a928a1812c8779440c81abba708082c946445af1d6b62d5f16e2a7cf4f30d9d6587b89425fae801ff
+  languageName: node
+  linkType: hard
+
 "strip-indent@npm:^3.0.0":
   version: 3.0.0
   resolution: "strip-indent@npm:3.0.0"
@@ -29635,6 +30460,15 @@ __metadata:
   version: 2.0.1
   resolution: "strip-json-comments@npm:2.0.1"
   checksum: 10c0/b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
+  languageName: node
+  linkType: hard
+
+"strip-literal@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "strip-literal@npm:3.1.0"
+  dependencies:
+    js-tokens: "npm:^9.0.1"
+  checksum: 10c0/50918f669915d9ad0fe4b7599902b735f853f2201c97791ead00104a654259c0c61bc2bc8fa3db05109339b61f4cf09e47b94ecc874ffbd0e013965223893af8
   languageName: node
   linkType: hard
 
@@ -30355,10 +31189,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
 "tinycolor2@npm:^1.6.0":
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
   checksum: 10c0/9aa79a36ba2c2a87cb221453465cabacd04b9e35f9694373e846fdc78b1c768110f81e581ea41440106c0f24d9a023891d0887e8075885e790ac40eb0e74a5c1
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
   languageName: node
   linkType: hard
 
@@ -30386,6 +31234,23 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.14":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "tinypool@npm:1.1.1"
+  checksum: 10c0/bf26727d01443061b04fa863f571016950888ea994ba0cd8cba3a1c51e2458d84574341ab8dbc3664f1c3ab20885c8cf9ff1cc4b18201f04c2cde7d317fff69b
   languageName: node
   linkType: hard
 
@@ -32175,6 +33040,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:3.2.4":
+  version: 3.2.4
+  resolution: "vite-node@npm:3.2.4"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.4.1"
+    es-module-lexer: "npm:^1.7.0"
+    pathe: "npm:^2.0.3"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 10c0/6ceca67c002f8ef6397d58b9539f80f2b5d79e103a18367288b3f00a8ab55affa3d711d86d9112fce5a7fa658a212a087a005a045eb8f4758947dd99af2a6c6b
+  languageName: node
+  linkType: hard
+
 "vite-plugin-lit-css@npm:^2.1.0":
   version: 2.2.2
   resolution: "vite-plugin-lit-css@npm:2.2.2"
@@ -32182,6 +33062,61 @@ __metadata:
     lit: ^2.0.0 || ^3.0.0
     vite: ^5.2.10 || ^6.0.0 || ^7.0.0
   checksum: 10c0/1a8e12e13992dc55a7b301ad20c266d542066cc51d671e93af25b6e986dc34678e274882f17e852241a8d47fc31ccb013f704c00cdfccef03e4bdc9012d0bc13
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0":
+  version: 7.3.2
+  resolution: "vite@npm:7.3.2"
+  dependencies:
+    esbuild: "npm:^0.27.0"
+    fdir: "npm:^6.5.0"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.3"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.43.0"
+    tinyglobby: "npm:^0.2.15"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    lightningcss: ^1.21.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/74be36907e208916f18bfec81c8eba18b869f0a170f1ece0a4dcb14874d0f0e7c022fb6c2ad896e3ee6c973fe88f53ac23b4078879ada340d8b263260868b8d4
   languageName: node
   linkType: hard
 
@@ -32225,6 +33160,62 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/468336a1409f728b464160cbf02672e72271fb688d0e605e776b74a89d27e1029509eef3a3a6c755928d8011e474dbf234824d054d07960be5f23cd176bc72de
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^3.0.0":
+  version: 3.2.4
+  resolution: "vitest@npm:3.2.4"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/expect": "npm:3.2.4"
+    "@vitest/mocker": "npm:3.2.4"
+    "@vitest/pretty-format": "npm:^3.2.4"
+    "@vitest/runner": "npm:3.2.4"
+    "@vitest/snapshot": "npm:3.2.4"
+    "@vitest/spy": "npm:3.2.4"
+    "@vitest/utils": "npm:3.2.4"
+    chai: "npm:^5.2.0"
+    debug: "npm:^4.4.1"
+    expect-type: "npm:^1.2.1"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.2"
+    std-env: "npm:^3.9.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^0.3.2"
+    tinyglobby: "npm:^0.2.14"
+    tinypool: "npm:^1.1.1"
+    tinyrainbow: "npm:^2.0.0"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node: "npm:3.2.4"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/debug": ^4.1.12
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    "@vitest/browser": 3.2.4
+    "@vitest/ui": 3.2.4
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/debug":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/5bf53ede3ae6a0e08956d72dab279ae90503f6b5a05298a6a5e6ef47d2fd1ab386aaf48fafa61ed07a0ebfe9e371772f1ccbe5c258dd765206a8218bf2eb79eb
   languageName: node
   linkType: hard
 
@@ -32689,6 +33680,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
+  languageName: node
+  linkType: hard
+
 "wide-align@npm:1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
@@ -33134,6 +34137,13 @@ __metadata:
   version: 2.1.3
   resolution: "yoctocolors-cjs@npm:2.1.3"
   checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
+  languageName: node
+  linkType: hard
+
+"yoctocolors@npm:^2.1.1":
+  version: 2.1.2
+  resolution: "yoctocolors@npm:2.1.2"
+  checksum: 10c0/b220f30f53ebc2167330c3adc86a3c7f158bcba0236f6c67e25644c3188e2571a6014ffc1321943bb619460259d3d27eb4c9cc58c2d884c1b195805883ec7066
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds `carbon-labs-init`, a repo-local CLI utility that streamlines starting a new Carbon Labs component contribution. The tool automates the fork/update flow, workspace setup, generator run, MDX scaffolding, Storybook tagging, branch creation, and initial commit so teams can get from a forked repo to a ready-to-edit component scaffold with one command.

#### Changelog

**New**

- Added `tools/carbon-labs-init`, a private Carbon Labs workspace package with the `carbon-labs-init` CLI.
- Added root `yarn carbon-labs-init` script for running the tool from the Carbon Labs repo root.
- Added support for team defaults through `.carbon-labs-init.json`.
- Added MDX metadata injection for maintainer handles and a problem-statement scaffold.
- Added Storybook story updates for contribution grouping and incubating tags.
- Added tests for name handling, owner parsing, config merging/loading, and MDX/story injection.

**Changed**

- Updated root workspaces to include `tools/*` so repo-local utilities can be managed by Yarn.
- Updated `yarn.lock` with the new tool workspace and CLI dependencies.

**Removed**

- Nothing.

#### Testing / Reviewing

- Run the tool test suite:

  ```bash
  yarn workspace @carbon-labs/carbon-labs-init test
  ```

- Confirm the root command resolves:

  ```bash
  yarn carbon-labs-init --help
  ```

- Preview the scaffold flow without creating files or touching GitHub:

  ```bash
  yarn carbon-labs-init new TestContribution --dry-run --no-editor --no-storybook
  ```

- Review `tools/carbon-labs-init/README.md` for usage, config, and contributor flow documentation.

- Confirm the CLI is repo-local and private by checking `tools/carbon-labs-init/package.json`.