### PR TITLE
chore(animated-header): add autotrack overrides tiles

### DIFF
--- a/packages/react/src/components/AnimatedHeader/components/Tiles/AIPromptTile/AIPromptTile.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/AIPromptTile/AIPromptTile.tsx
@@ -21,6 +21,8 @@ import {
   type AITileBodyProps,
   type AITileLabelVariant,
 } from '../AITile/AITileBody';
+import { AutotrackDataAttributes } from '../../types';
+import { extractAutotrackAttributes } from '../../utils';
 
 export type AIPromptTileProps = {
   variant: 'aiPrompt';
@@ -39,7 +41,7 @@ export type AIPromptTileProps = {
   open?: boolean;
   isLoading?: boolean;
   isDisabled?: boolean;
-};
+} & AutotrackDataAttributes;
 
 export const AIPromptTile: React.FC<AIPromptTileProps> = ({
   tileId,
@@ -57,6 +59,7 @@ export const AIPromptTile: React.FC<AIPromptTileProps> = ({
   open,
   isLoading,
   isDisabled,
+  ...rest
 }: AIPromptTileProps) => {
   const prefix = usePrefix();
   const blockClass = `${prefix}--animated-header__ai-prompt-tile`;
@@ -81,6 +84,9 @@ export const AIPromptTile: React.FC<AIPromptTileProps> = ({
     }
   };
 
+  // Extract data attributes from rest props
+  const dataAttributes = extractAutotrackAttributes(rest);
+
   return (
     <div
       id={`${blockClass}`}
@@ -90,7 +96,8 @@ export const AIPromptTile: React.FC<AIPromptTileProps> = ({
       aria-label={ariaLabel ?? title ?? 'AI Tile'}
       role="listitem"
       title={isDisabled ? disabledTaskLabel ?? '' : ''}
-      key={tileId}>
+      key={tileId}
+      {...dataAttributes}>
       {isLoading ? (
         <SkeletonPlaceholder className={`${blockClass}--loading-skeleton`} />
       ) : (

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/AITile/AITile.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/AITile/AITile.tsx
@@ -14,6 +14,8 @@ import {
   AITileBodyProps,
   AITileLabelVariant,
 } from '../AITile/AITileBody';
+import { AutotrackDataAttributes } from '../../types';
+import { extractAutotrackAttributes } from '../../utils';
 
 export type AITileProps = {
   variant: 'ai';
@@ -33,7 +35,7 @@ export type AITileProps = {
   open?: boolean;
   isLoading?: boolean;
   isDisabled?: boolean;
-};
+} & AutotrackDataAttributes;
 
 export const AITile: React.FC<AITileProps> = ({
   tileId,
@@ -52,6 +54,7 @@ export const AITile: React.FC<AITileProps> = ({
   open,
   isLoading,
   isDisabled,
+  ...rest
 }: AITileProps & AITileBodyProps) => {
   const prefix = usePrefix();
   const blockClass = `${prefix}--animated-header__ai-tile`;
@@ -71,6 +74,9 @@ export const AITile: React.FC<AITileProps> = ({
     />
   );
 
+  // Extract data attributes from rest props
+  const dataAttributes = extractAutotrackAttributes(rest);
+
   // Non-interactive tile
   if (!href && !aiTileClickHandler) {
     return (
@@ -79,7 +85,8 @@ export const AITile: React.FC<AITileProps> = ({
         key={tileId}
         aria-label={ariaLabel ?? title ?? 'AI Tile'}
         title={isDisabled ? disabledTaskLabel ?? '' : ''}
-        tabIndex={-1}>
+        tabIndex={-1}
+        {...dataAttributes}>
         {body}
       </div>
     );
@@ -97,7 +104,8 @@ export const AITile: React.FC<AITileProps> = ({
       key={tileId}
       href={href ?? undefined}
       disabled={isDisabled || isLoading}
-      title={isDisabled ? disabledTaskLabel ?? '' : ''}>
+      title={isDisabled ? disabledTaskLabel ?? '' : ''}
+      {...dataAttributes}>
       {body}
     </Link>
   );

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/GlassTile/GlassTile.tsx
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/GlassTile/GlassTile.tsx
@@ -11,6 +11,8 @@ import React, { ElementType } from 'react';
 import { Link } from '@carbon/react';
 import { usePrefix } from '@carbon-labs/utilities/usePrefix';
 import { GlassTileBody, GlassTileBodyProps } from './GlassTileBody';
+import { AutotrackDataAttributes } from '../../types';
+import { extractAutotrackAttributes } from '../../utils';
 
 export type GlassTileProps = {
   variant?: 'glass';
@@ -29,7 +31,7 @@ export type GlassTileProps = {
   open?: boolean;
   isLoading?: boolean;
   isDisabled?: boolean;
-};
+} & AutotrackDataAttributes;
 
 export const GlassTile: React.FC<GlassTileProps> = ({
   tileId,
@@ -47,6 +49,7 @@ export const GlassTile: React.FC<GlassTileProps> = ({
   open,
   isLoading,
   isDisabled,
+  ...rest
 }: GlassTileProps & GlassTileBodyProps) => {
   const prefix = usePrefix();
   const blockClass = `${prefix}--animated-header__glass-tile`;
@@ -65,6 +68,9 @@ export const GlassTile: React.FC<GlassTileProps> = ({
     />
   );
 
+  // Extract data attributes from rest props
+  const dataAttributes = extractAutotrackAttributes(rest);
+
   // Non-interactive tile
   if (!href && !glassTileClickHandler) {
     return (
@@ -73,7 +79,8 @@ export const GlassTile: React.FC<GlassTileProps> = ({
         key={tileId}
         aria-label={ariaLabel ?? title ?? 'Glass Tile'}
         title={isDisabled ? disabledTaskLabel ?? '' : ''}
-        tabIndex={-1}>
+        tabIndex={-1}
+        {...dataAttributes}>
         {body}
       </div>
     );
@@ -91,7 +98,8 @@ export const GlassTile: React.FC<GlassTileProps> = ({
       key={tileId}
       href={href ?? undefined}
       disabled={isDisabled || isLoading}
-      title={isDisabled ? disabledTaskLabel ?? '' : ''}>
+      title={isDisabled ? disabledTaskLabel ?? '' : ''}
+      {...dataAttributes}>
       {body}
     </Link>
   );

--- a/packages/react/src/components/AnimatedHeader/components/Tiles/index.ts
+++ b/packages/react/src/components/AnimatedHeader/components/Tiles/index.ts
@@ -12,3 +12,5 @@ import { BaseTile } from './BaseTile/BaseTile';
 import { GlassTile } from './GlassTile/GlassTile';
 
 export { AITile, AIPromptTile, BaseTile, GlassTile };
+export type { AutotrackDataAttributes } from '../types';
+export { extractAutotrackAttributes } from '../utils';

--- a/packages/react/src/components/AnimatedHeader/components/types.ts
+++ b/packages/react/src/components/AnimatedHeader/components/types.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Supported data attributes for IBM Carbon autotrack instrumentation.
+ * These attributes enable automatic tracking and analytics for user interactions.
+ * 
+ * @see https://pages.github.ibm.com/carbon/ibm-products/developing/instrumentation/autotrack/#supported-data-attributes
+ */
+export type AutotrackDataAttributes = {
+  'data-autotrack-accountgroup'?: string;
+  'data-autotrack-accountgroupname'?: string;
+  'data-autotrack-accountgroupowner'?: string;
+  'data-autotrack-accountgroupstate'?: string;
+  'data-autotrack-accountguid'?: string;
+  'data-autotrack-accountid'?: string;
+  'data-autotrack-accountidcountrycode'?: string;
+  'data-autotrack-accountidcustnum_rdcctrynum'?: string;
+  'data-autotrack-accountidibmcustomernumber'?: string;
+  'data-autotrack-accountidsapcustnum'?: string;
+  'data-autotrack-accountidsapsiteid'?: string;
+  'data-autotrack-accountidtype'?: string;
+  'data-autotrack-accountlevel'?: string;
+  'data-autotrack-accountname'?: string;
+  'data-autotrack-accountowner'?: string;
+  'data-autotrack-accountplan'?: string;
+  'data-autotrack-accountstatus'?: string;
+  'data-autotrack-action'?: string;
+  'data-autotrack-actiontype'?: string;
+  'data-autotrack-agentid'?: string;
+  'data-autotrack-agentname'?: string;
+  'data-autotrack-agenttype'?: string;
+  'data-autotrack-altuserid'?: string;
+  'data-autotrack-anonymousid'?: string;
+  'data-autotrack-category'?: string;
+  'data-autotrack-channel'?: string;
+  'data-autotrack-channelname'?: string;
+  'data-autotrack-chargeagreementnumber'?: string;
+  'data-autotrack-cloudenvironment'?: string;
+  'data-autotrack-code'?: string;
+  'data-autotrack-color'?: string;
+  'data-autotrack-commonmilestonename'?: string;
+  'data-autotrack-commonmilestonetriggeruserid'?: string;
+  'data-autotrack-context_device_id'?: string;
+  'data-autotrack-context_page_path'?: string;
+  'data-autotrack-context_page_referrer'?: string;
+  'data-autotrack-context_page_title'?: string;
+  'data-autotrack-context_page_url'?: string;
+  'data-autotrack-cta'?: string;
+  'data-autotrack-customerid'?: string;
+  'data-autotrack-data'?: string;
+  'data-autotrack-datacenter'?: string;
+  'data-autotrack-distributorid'?: string;
+  'data-autotrack-elementid'?: string;
+  'data-autotrack-enterpriseaccount'?: string;
+  'data-autotrack-enterpriseaccountdomain'?: string;
+  'data-autotrack-enterpriseaccountflag'?: string;
+  'data-autotrack-enterpriseaccountname'?: string;
+  'data-autotrack-enterpriseaccountstate'?: string;
+  'data-autotrack-enterpriseowner'?: string;
+  'data-autotrack-environment'?: string;
+  'data-autotrack-environmenttype'?: string;
+  'data-autotrack-eventid'?: string;
+  'data-autotrack-field'?: string;
+  'data-autotrack-frequency'?: string;
+  'data-autotrack-hyperscalerchannel'?: string;
+  'data-autotrack-hyperscalerformat'?: string;
+  'data-autotrack-hyperscalerproductid'?: string;
+  'data-autotrack-hyperscalerprovider'?: string;
+  'data-autotrack-hyperscalertier'?: string;
+  'data-autotrack-instancebssfirstbillabledate'?: string;
+  'data-autotrack-instanceguid'?: string;
+  'data-autotrack-instanceid'?: string;
+  'data-autotrack-instancemetricspaidmilestoneintermediateusagecount'?: string;
+  'data-autotrack-instancemetricspaidmilestoneintermediateusagelastts'?: string;
+  'data-autotrack-instancename'?: string;
+  'data-autotrack-isibmer'?: string;
+  'data-autotrack-kubernetesdistribution'?: string;
+  'data-autotrack-kubernetesdistributionversion'?: string;
+  'data-autotrack-kubernetesid'?: string;
+  'data-autotrack-kubernetesnamespace'?: string;
+  'data-autotrack-kubernetesresourceapi'?: string;
+  'data-autotrack-kubernetesresourcename'?: string;
+  'data-autotrack-kubernetesversion'?: string;
+  'data-autotrack-label'?: string;
+  'data-autotrack-locale'?: string;
+  'data-autotrack-location'?: string;
+  'data-autotrack-marketplace'?: string;
+  'data-autotrack-message'?: string;
+  'data-autotrack-milestonename'?: string;
+  'data-autotrack-name'?: string;
+  'data-autotrack-namespace'?: string;
+  'data-autotrack-object'?: string;
+  'data-autotrack-objecttype'?: string;
+  'data-autotrack-observetype'?: string;
+  'data-autotrack-offeringid'?: string;
+  'data-autotrack-openshiftclusterid'?: string;
+  'data-autotrack-openshiftinfrastructurename'?: string;
+  'data-autotrack-openshiftplatform'?: string;
+  'data-autotrack-openshiftversion'?: string;
+  'data-autotrack-operationalid'?: string;
+  'data-autotrack-orgguid'?: string;
+  'data-autotrack-orgname'?: string;
+  'data-autotrack-originalmessageid'?: string;
+  'data-autotrack-pagename'?: string;
+  'data-autotrack-pagepathurl'?: string;
+  'data-autotrack-pagesubject'?: string;
+  'data-autotrack-pagetitle'?: string;
+  'data-autotrack-pageurl'?: string;
+  'data-autotrack-parentpagecategory'?: string;
+  'data-autotrack-parentpagename'?: string;
+  'data-autotrack-partids'?: string;
+  'data-autotrack-partname'?: string;
+  'data-autotrack-partnumber'?: string;
+  'data-autotrack-path'?: string;
+  'data-autotrack-payload'?: string;
+  'data-autotrack-platformtitle'?: string;
+  'data-autotrack-previousproductversion'?: string;
+  'data-autotrack-productcode'?: string;
+  'data-autotrack-productcodetype'?: string;
+  'data-autotrack-productid'?: string;
+  'data-autotrack-productplan'?: string;
+  'data-autotrack-productplanname'?: string;
+  'data-autotrack-productplantier'?: string;
+  'data-autotrack-productplantype'?: string;
+  'data-autotrack-productstatus'?: string;
+  'data-autotrack-producttitle'?: string;
+  'data-autotrack-productversion'?: string;
+  'data-autotrack-quantity'?: string;
+  'data-autotrack-region'?: string;
+  'data-autotrack-resellerid'?: string;
+  'data-autotrack-resultvalue'?: string;
+  'data-autotrack-roles'?: string;
+  'data-autotrack-sabasubscriptionid'?: string;
+  'data-autotrack-saletype'?: string;
+  'data-autotrack-sapsiteid'?: string;
+  'data-autotrack-segmentsourceslug'?: string;
+  'data-autotrack-serviceagreementnumber'?: string;
+  'data-autotrack-sessionid'?: string;
+  'data-autotrack-size'?: string;
+  'data-autotrack-source'?: string;
+  'data-autotrack-subproducttitle'?: string;
+  'data-autotrack-subscriptionid'?: string;
+  'data-autotrack-successflag'?: string;
+  'data-autotrack-tenantid'?: string;
+  'data-autotrack-tenantname'?: string;
+  'data-autotrack-text'?: string;
+  'data-autotrack-type'?: string;
+  'data-autotrack-uielement'?: string;
+  'data-autotrack-unit'?: string;
+  'data-autotrack-unitdescription'?: string;
+  'data-autotrack-url'?: string;
+  'data-autotrack-urlsubdomain'?: string;
+  'data-autotrack-usersessionid'?: string;
+  'data-autotrack-ut10'?: string;
+  'data-autotrack-ut15'?: string;
+  'data-autotrack-ut17'?: string;
+  'data-autotrack-ut20'?: string;
+  'data-autotrack-ut30'?: string;
+  'data-autotrack-ut30_description'?: string;
+  'data-autotrack-ut35'?: string;
+  'data-autotrack-ut40'?: string;
+  'data-autotrack-utlvlcd'?: string;
+  'data-autotrack-variation'?: string;
+  'data-autotrack-version'?: string;
+};
+
+// Made with Bob

--- a/packages/react/src/components/AnimatedHeader/components/types.ts
+++ b/packages/react/src/components/AnimatedHeader/components/types.ts
@@ -10,7 +10,7 @@
 /**
  * Supported data attributes for IBM Carbon autotrack instrumentation.
  * These attributes enable automatic tracking and analytics for user interactions.
- * 
+ *
  * @see https://pages.github.ibm.com/carbon/ibm-products/developing/instrumentation/autotrack/#supported-data-attributes
  */
 export type AutotrackDataAttributes = {

--- a/packages/react/src/components/AnimatedHeader/components/utils.ts
+++ b/packages/react/src/components/AnimatedHeader/components/utils.ts
@@ -13,7 +13,7 @@
  *
  * @param {Record<string, any>} props - Props object that may contain data-autotrack-* attributes
  * @returns {Record<string, string | undefined>} Object containing only data-autotrack-* attributes
- * 
+ *
  * @example
  * ```typescript
  * const props = { title: 'My Tile', 'data-autotrack-action': 'click', ...rest };

--- a/packages/react/src/components/AnimatedHeader/components/utils.ts
+++ b/packages/react/src/components/AnimatedHeader/components/utils.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Extracts data-autotrack-* attributes from props object.
+ * This utility filters out only the autotrack data attributes for spreading onto DOM elements.
+ *
+ * @param {Record<string, any>} props - Props object that may contain data-autotrack-* attributes
+ * @returns {Record<string, string | undefined>} Object containing only data-autotrack-* attributes
+ * 
+ * @example
+ * ```typescript
+ * const props = { title: 'My Tile', 'data-autotrack-action': 'click', ...rest };
+ * const dataAttrs = extractAutotrackAttributes(rest);
+ * // Returns: { 'data-autotrack-action': 'click' }
+ * ```
+ */
+export function extractAutotrackAttributes(
+  props: Record<string, any>
+): Record<string, string | undefined> {
+  return Object.keys(props).reduce((acc, key) => {
+    if (key.startsWith('data-autotrack-')) {
+      acc[key] = props[key];
+    }
+    return acc;
+  }, {} as Record<string, string | undefined>);
+}

--- a/packages/react/src/components/AnimatedHeader/index.ts
+++ b/packages/react/src/components/AnimatedHeader/index.ts
@@ -15,9 +15,7 @@ export * from './assets';
 
 // Export all types
 export type { AnimatedHeaderProps } from './components/AnimatedHeader/AnimatedHeader';
-export type {
-  Tile,
-} from './components/AnimatedHeader/types';
+export type { Tile } from './components/AnimatedHeader/types';
 export type { AITileProps } from './components/Tiles/AITile/AITile';
 export type { AIPromptTileProps } from './components/Tiles/AIPromptTile/AIPromptTile';
 export type { GlassTileProps } from './components/Tiles/GlassTile/GlassTile';

--- a/packages/react/src/components/AnimatedHeader/index.ts
+++ b/packages/react/src/components/AnimatedHeader/index.ts
@@ -12,6 +12,20 @@ import HeaderAction from './components/HeaderAction/HeaderAction';
 import HeaderTitle from './components/HeaderTitle/HeaderTitle';
 import { BaseTile } from './components/Tiles/index';
 export * from './assets';
+
+// Export all types
+export type { AnimatedHeaderProps } from './components/AnimatedHeader/AnimatedHeader';
+export type {
+  Tile,
+} from './components/AnimatedHeader/types';
+export type { AITileProps } from './components/Tiles/AITile/AITile';
+export type { AIPromptTileProps } from './components/Tiles/AIPromptTile/AIPromptTile';
+export type { GlassTileProps } from './components/Tiles/GlassTile/GlassTile';
+export type {
+  BaseTileProps,
+  TileVariant,
+} from './components/Tiles/BaseTile/BaseTile';
+export type { AutotrackDataAttributes } from './components/types';
 export type {
   Workspace,
   WorkspaceSelectorConfig,


### PR DESCRIPTION
Add support for Carbon Autotrack overrides for Tiles

#### Changelog

**New**

- Consumer can now set `carbon-autotrack-*` properties in all tile types
