### PR TITLE
feat: storybook demo updated with fluid dropdown

### DIFF
--- a/packages/react/src/components/MDXComponents/components/storybook-demo/_storybook-demo.scss
+++ b/packages/react/src/components/MDXComponents/components/storybook-demo/_storybook-demo.scss
@@ -13,13 +13,23 @@
 @use '../utils' as *;
 
 .#{with-prefix('demo-dropdowns')} {
-  // override carbon, label inset-inline-start padding
-  .cds--label {
+  // override carbon, label inset-inline-start padding for regular dropdown only
+  .cds--dropdown .cds--label {
     padding-inline-start: spacing.$spacing-05;
   }
 
+  // regular dropdown border
   .cds--dropdown {
     border-block-end: 1px solid theme.$layer-selected-01;
+  }
+
+  // fluid dropdown - reset padding to align label properly
+  .cds--list-box__wrapper--fluid {
+    border-block-end: 1px solid theme.$layer-selected-01;
+
+    .cds--label {
+      padding-inline-start: 0;
+    }
   }
 }
 

--- a/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.stories.jsx
+++ b/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.stories.jsx
@@ -11,51 +11,81 @@ import { StorybookDemo } from './storybook-demo';
 export default {
   title: 'Components/MDX Components/StorybookDemo',
   component: StorybookDemo,
+  argTypes: {
+    fluid: {
+      control: 'boolean',
+      description: 'Use FluidDropdown instead of regular Dropdown',
+    },
+    themeSelector: {
+      control: 'boolean',
+      description: 'Display theme selector dropdown',
+    },
+    wide: {
+      control: 'boolean',
+      description: 'Span 12 columns width',
+    },
+    tall: {
+      control: 'boolean',
+      description: 'Increase demo height',
+    },
+  },
 };
+
+const variants = [
+  {
+    label: 'Button',
+    variant: 'components-button--default',
+  },
+  {
+    label: 'Secondary',
+    variant: 'components-button--secondary',
+  },
+  {
+    label: 'Tertiary',
+    variant: 'components-button--tertiary',
+  },
+  {
+    label: 'Ghost',
+    variant: 'components-button--ghost',
+  },
+  {
+    label: 'Danger',
+    variant: 'components-button--danger',
+  },
+  {
+    label: 'Icon button',
+    variant: 'components-button--icon-button',
+  },
+  {
+    label: 'Set of buttons',
+    variant: 'components-button--set-of-buttons',
+  },
+  {
+    label: 'Skeleton',
+    variant: 'components-button--skeleton',
+  },
+];
 
 const Template = (args) => (
   <StorybookDemo
     {...args}
-    themeSelector={true}
-    wide
-    tall
     url="https://react.carbondesignsystem.com"
-    variants={[
-      {
-        label: 'Button',
-        variant: 'components-button--default',
-      },
-      {
-        label: 'Secondary',
-        variant: 'components-button--secondary',
-      },
-      {
-        label: 'Tertiary',
-        variant: 'components-button--tertiary',
-      },
-      {
-        label: 'Ghost',
-        variant: 'components-button--ghost',
-      },
-      {
-        label: 'Danger',
-        variant: 'components-button--danger',
-      },
-      {
-        label: 'Icon button',
-        variant: 'components-button--icon-button',
-      },
-      {
-        label: 'Set of buttons',
-        variant: 'components-button--set-of-buttons',
-      },
-      {
-        label: 'Skeleton',
-        variant: 'components-button--skeleton',
-      },
-    ]}
+    variants={variants}
   />
 );
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  themeSelector: true,
+  wide: false,
+  tall: false,
+  fluid: false,
+};
+
+export const WithFluidDropdown = Template.bind({});
+WithFluidDropdown.args = {
+  themeSelector: true,
+  wide: true,
+  tall: true,
+  fluid: true,
+};

--- a/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.tsx
+++ b/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.tsx
@@ -108,6 +108,7 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
               titleText="Theme selector"
               label="theme"
               items={themeItems}
+              itemToString={(item) => item?.label || ''}
               onChange={onThemeChange}
               initialSelectedItem={themeItems[0]}
               className={border}
@@ -121,6 +122,7 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
               titleText="Variant selector"
               label="variant"
               items={variants}
+              itemToString={(item) => item?.label || ''}
               initialSelectedItem={variants[0]}
               onChange={onVariantChange}
             />

--- a/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.tsx
+++ b/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Column, Dropdown, Grid, Link } from '@carbon/react';
+import { Column, Dropdown, FluidDropdown, Grid, Link } from '@carbon/react';
 import { clsx } from 'clsx';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
@@ -18,6 +18,7 @@ interface StorybookDemoProps {
   tall?: boolean | null;
   themeSelector?: boolean | null;
   wide?: boolean | null;
+  fluid?: boolean | null;
   url: string;
   variants?: Array<{
     label: string;
@@ -37,6 +38,7 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
   tall,
   themeSelector,
   wide,
+  fluid,
   url,
   variants,
 }) => {
@@ -88,17 +90,20 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
   const iframeUrl =
     url + '/iframe.html?id=' + variant + '&globals=theme:' + theme;
 
-  // Only add border when theme and variant selectors are being displayed
+  // Only add border separator when BOTH theme and variant selectors are displayed
   const border = clsx({
-    [withPrefix('theme-selector')]: multipleVariants,
+    [withPrefix('theme-selector')]: themeSelector && multipleVariants,
   });
+
+  // Use FluidDropdown when fluid prop is true, otherwise use regular Dropdown
+  const DropdownComponent = fluid ? FluidDropdown : Dropdown;
 
   return (
     <>
       <Grid condensed className={withPrefix('demo-dropdowns')}>
         {themeSelector && (
           <Column sm={2} md={4}>
-            <Dropdown
+            <DropdownComponent
               id="theme-selector"
               titleText="Theme selector"
               label="theme"
@@ -111,7 +116,7 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
         )}
         {multipleVariants && (
           <Column sm={2} md={4}>
-            <Dropdown
+            <DropdownComponent
               id="variant-selector"
               titleText="Variant selector"
               label="variant"
@@ -152,6 +157,10 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
 };
 
 StorybookDemo.propTypes = {
+  /**
+   * Use FluidDropdown instead of regular Dropdown for selectors
+   */
+  fluid: PropTypes.bool,
   /**
    * Storybook demo height
    */


### PR DESCRIPTION
Closes #1205 

Add FluidDropdown support to StorybookDemo component

#### Changelog

**New**

- Added `fluid` prop to StorybookDemo component to support FluidDropdown variant
- FluidDropdown can now be used as an alternative to regular Dropdown for theme and variant selectors

**Changed**

- Updated SCSS to properly handle label alignment for both regular Dropdown and FluidDropdown
- Fixed border separator logic to only display when both theme selector and variant selector are present
- Updated Storybook stories with argTypes for better control documentation
- Set `themeSelector` default to `false` to match original behavior

**Removed**

- Nothing.

#### Testing / Reviewing

- [ ] Open Storybook and navigate to `Components/MDX Components/StorybookDemo`
- [ ] Verify the Default story shows only the variant selector (no theme selector)
- [ ] Toggle the `fluid` control to `true` and verify FluidDropdown renders correctly
- [ ] Verify FluidDropdown label alignment is correct (no extra left padding)
- [ ] Toggle `themeSelector` to `true` and verify both dropdowns appear
- [ ] Verify the border separator only appears between dropdowns when both are visible
- [ ] Test the WithFluidDropdown story and verify it uses FluidDropdown styling
- [ ] Verify backward compatibility: existing usage without `fluid` prop still works with regular Dropdown
