### PR TITLE
React19 support

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,8 +16,8 @@
     "test:updateSnapshot": "jest -u"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.1 || ^18.2.0",
-    "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0"
+    "react": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
+    "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0"
   },
   "dependencies": {
     "@carbon/icons-react": "^11.65.0",

--- a/packages/react/src/components/DatePicker/package.json
+++ b/packages/react/src/components/DatePicker/package.json
@@ -41,8 +41,8 @@
     "classnames": "^2.3.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
+    "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0"
   },
   "devDependencies": {
     "@carbon-labs/utilities": "0.22.0"

--- a/packages/react/src/components/TagInput/package.json
+++ b/packages/react/src/components/TagInput/package.json
@@ -33,8 +33,8 @@
     "clean": "rimraf es lib scss"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
+    "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0"
   },
   "devDependencies": {
     "@carbon-labs/utilities": "0.21.0"

--- a/packages/react/src/components/ThemeSettings/package.json
+++ b/packages/react/src/components/ThemeSettings/package.json
@@ -38,8 +38,8 @@
     "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 34d6803f-45c0-46e0-be02-b4499b40336e --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
+    "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0"
   },
   "dependencies": {
     "@carbon-labs/utilities": "0.22.0",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -52,8 +52,8 @@
     "es/index.d.ts"
   ],
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
+    "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^6.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,8 +1668,8 @@ __metadata:
     "@ibm/telemetry-js": "npm:^1.10.2"
     classnames: "npm:^2.3.2"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -1744,8 +1744,8 @@ __metadata:
   dependencies:
     "@carbon-labs/utilities": "npm:0.21.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -1765,8 +1765,8 @@ __metadata:
     "@carbon-labs/utilities": "npm:0.22.0"
     "@ibm/telemetry-js": "npm:^1.10.2"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -1855,8 +1855,8 @@ __metadata:
     typescript-config-carbon: "npm:^0.9.0"
     webpack: "npm:^5.97.0"
   peerDependencies:
-    react: ^16.8.6 || ^17.0.1 || ^18.2.0
-    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -1887,8 +1887,8 @@ __metadata:
     react-dom: "npm:^18.3.1"
     rimraf: "npm:^6.0.1"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Closes #

Carbon labs now supports the same peer dependencies as @carbon/react

    "react": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
    "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",

#### Changelog

**Changed**

Updates peer dependencies for:
- packages/react
- packages/react/src/components/DatePicker
- packages/react/src/components/TagInput
- packages/react/src/components/ThemeSettings
- packages/utilities

#### Testing / Reviewing

N/A