### PR TITLE
fix(global-header): only show hamburger menu when there are side-nav entries

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/CommonHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/CommonHeader.ts
@@ -154,11 +154,16 @@ export class CommonHeader extends LitElement {
     return html`
       <cds-custom-header
         class="${AUTOMATION_NAMESPACE_PREFIX}__header"
-        aria-label="IBM webMethods Hybrid Integration">
-        <cds-custom-header-menu-button
-          id="${APP_SWITCHER_BUTTON_ID}"
-          button-label-active="Close menu"
-          button-label-inactive="Open menu"></cds-custom-header-menu-button>
+        aria-label="${this.headerProps?.brand?.company} ${this.headerProps
+          ?.brand?.product}">
+        ${this.headerProps && this.headerProps?.sideNav
+          ? html`
+              <cds-custom-header-menu-button
+                id="${APP_SWITCHER_BUTTON_ID}"
+                button-label-active="Close menu"
+                button-label-inactive="Open menu"></cds-custom-header-menu-button>
+            `
+          : nothing}
         <slot name="header-logo"></slot>
         <cds-custom-header-name
           class="${AUTOMATION_NAMESPACE_PREFIX}__header-name"

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/CommonHeader.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/CommonHeader/__tests__/CommonHeader.test.ts
@@ -23,10 +23,6 @@ describe('CommonHeader tests', () => {
     // Check that the default header renders
     const header = el.shadowRoot?.querySelector(`[role='banner']`);
     expect(header).to.exist;
-    expect(header).to.have.attribute(
-      'aria-label',
-      'IBM webMethods Hybrid Integration'
-    );
   });
 
   it('renders custom values in the header', async () => {
@@ -49,6 +45,14 @@ describe('CommonHeader tests', () => {
     // Check that the prop values render
     const header = el.shadowRoot?.querySelector(`[role='banner']`);
     expect(header).to.exist;
+
+    expect(header).to.have.attribute('aria-label', 'Test Company Test Product');
+
+    // no side-nav entries, so no hamburger menu
+    const hamburger = el.shadowRoot?.querySelector(
+      `#ibm-automation-cds-app-switcher-button`
+    );
+    expect(hamburger).not.to.exist;
 
     const headerName = header?.querySelector('cds-custom-header-name');
     expect(headerName).to.have.attribute('prefix', 'Test Company');
@@ -193,6 +197,11 @@ describe('CommonHeader tests', () => {
           .headerProps="${props}"></clabs-global-header-apaas>`
       );
       expect(el).not.to.be.null;
+
+      const hamburger = el.shadowRoot?.querySelector(
+        `#ibm-automation-cds-app-switcher-button`
+      );
+      expect(hamburger).to.exist;
 
       const sideNav = el.shadowRoot?.querySelector(`[role='navigation']`);
       expect(sideNav).to.exist;


### PR DESCRIPTION

**Changed**

- Only show the hamburger menu when there are side-nav entries
- Use the product name for the aria-label instead of hardcoding

#### Testing / Reviewing

The "Help Links" story covers the "no side-nav" case

