### PR TITLE
chore(deps): move @carbon-labs/utilities to dep from devDep in react resizer

### DIFF
--- a/packages/react/src/components/Resizer/package.json
+++ b/packages/react/src/components/Resizer/package.json
@@ -37,10 +37,8 @@
     "postinstall": "ibmtelemetry --config=telemetry.yml",
     "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id c3e81c63-8688-4d9d-9f8f-2c0c369a780a --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./components/**/*.(tsx|js|jsx)"
   },
-  "devDependencies": {
-    "@carbon-labs/utilities": "0.24.0"
-  },
   "dependencies": {
+    "@carbon-labs/utilities": "0.24.0",
     "@ibm/telemetry-js": "^1.10.2"
   }
 }


### PR DESCRIPTION
Closes #

Moved @carbon-labs/utilities from devDependencies to dependencies because The Resizer component imports [usePrefix](vscode-webview://1k35obo7an2fcifecctq7jj1ma2ckk2j0kj1cg6q8m4i0af11l2q/packages/react/src/components/Resizer/components/Resizer.tsx:17) from @carbon-labs/utilities

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
