### PR TITLE
fix: update React import in usePrefix

### DIFF
--- a/packages/utilities/src/usePrefix.js
+++ b/packages/utilities/src/usePrefix.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as React from 'react';
+import React from 'react';
 
 export const PrefixContext = React.createContext('clabs');
 


### PR DESCRIPTION
Closes #

Fixed React import pattern in packages/utilities/src/usePrefix.js
Changed from import * as React from 'react'; to import React from 'react';

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
