### PR TITLE
fix: fixed the theme selector going behind the background

### DIFF
--- a/packages/react/src/components/MDXComponents/components/storybook-demo/_storybook-demo.scss
+++ b/packages/react/src/components/MDXComponents/components/storybook-demo/_storybook-demo.scss
@@ -34,14 +34,18 @@
 }
 
 .#{with-prefix('theme-selector')} {
-  position: absolute;
-  display: block;
-  background-color: theme.$layer-selected;
-  block-size: convert.rem(40px);
-  content: '';
-  inline-size: 1px;
-  inset-block-start: 0;
-  inset-inline-end: -1px;
+  position: relative;
+
+  &::after {
+    position: absolute;
+    display: block;
+    background-color: theme.$layer-selected;
+    block-size: 100%;
+    content: '';
+    inline-size: 1px;
+    inset-block-start: 0;
+    inset-inline-end: -1px;
+  }
 }
 
 .#{with-prefix('storybook-demo')} {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-experience-platform/issues/1185

Fixed theme selector z-index bug and divider height issue in Storybook demo component.

#### Changelog

**New**

- Nothing.

**Changed**

- Fixed theme selector dropdown disappearing behind background when switching variants
- Fixed divider line between theme selector and variant selector to span full dropdown height

**Removed**

- Nothing.

#### Testing / Reviewing

1. Open the Storybook demo component story
2. Enable both `themeSelector` and multiple variants
3. Toggle between default and fluid dropdown variants
4. Verify the theme selector dropdown remains visible and doesn't go behind the background
5. Verify the vertical divider line between theme selector and variant selector spans the full height of the dropdowns
6. Test in both regular and fluid dropdown modes

**Technical Details:**
- Restored proper `::after` pseudo-element approach for the divider (styles were incorrectly applied directly to the element)
- Changed divider height from fixed `40px` to `100%` to match dropdown height
