### PR TITLE
chore(storybook): pass default meta object

### DIFF
--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -56,10 +56,25 @@ const config = {
 
   staticDirs: ['../public'],
 
-  async viteFinal(config) {
+  async viteFinal(config, { configType }) {
+    const productionBuild =
+      configType === 'PRODUCTION'
+        ? {
+            rolldownOptions: {
+              output: {
+                // Vite 8 / Rolldown can split CSF and MDX into separate module instances.
+                // Storybook resolves <Meta of={Stories} /> by object identity, which breaks
+                // when the runtime import and MDX import get different copies (see #34373).
+                strictExecutionOrder: true,
+              },
+            },
+          }
+        : {};
+
     return mergeConfig(config, {
       build: {
         cssMinify: 'esbuild',
+        ...productionBuild,
       },
       css: {
         preprocessorOptions: {

--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -56,25 +56,10 @@ const config = {
 
   staticDirs: ['../public'],
 
-  async viteFinal(config, { configType }) {
-    const productionBuild =
-      configType === 'PRODUCTION'
-        ? {
-            rolldownOptions: {
-              output: {
-                // Vite 8 / Rolldown can split CSF and MDX into separate module instances.
-                // Storybook resolves <Meta of={Stories} /> by object identity, which breaks
-                // when the runtime import and MDX import get different copies (see #34373).
-                strictExecutionOrder: true,
-              },
-            },
-          }
-        : {};
-
+  async viteFinal(config) {
     return mergeConfig(config, {
       build: {
         cssMinify: 'esbuild',
-        ...productionBuild,
       },
       css: {
         preprocessorOptions: {

--- a/packages/web-components/src/components/chat/components/chartElement/__stories__/docs.mdx
+++ b/packages/web-components/src/components/chat/components/chartElement/__stories__/docs.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../../../globals/internal/storybook-cdn';
-import * as ChartElementStories from './chartElement.stories';
+import meta from './chartElement.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={ChartElementStories} />
+<Meta of={meta} />
 
 # Chart Handbook
 

--- a/packages/web-components/src/components/chat/components/chat/__stories__/chat.mdx
+++ b/packages/web-components/src/components/chat/components/chat/__stories__/chat.mdx
@@ -1,9 +1,9 @@
 import { Markdown, Meta, ArgTypes } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../../../globals/internal/storybook-cdn';
-import * as ChatStories from './chat.stories';
+import meta from './chat.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={ChatStories} />
+<Meta of={meta} />
 
 # Carbon AI Chat
 

--- a/packages/web-components/src/components/chat/components/codeElement/__stories__/docs.mdx
+++ b/packages/web-components/src/components/chat/components/codeElement/__stories__/docs.mdx
@@ -1,9 +1,9 @@
 import { Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../../../globals/internal/storybook-cdn';
-import * as CodeElementStories from './codeElement.stories';
+import meta from './codeElement.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={CodeElementStories} />
+<Meta of={meta} />
 
 # Carbon AI Chat: Code
 

--- a/packages/web-components/src/components/chat/components/diagramElement/__stories__/docs.mdx
+++ b/packages/web-components/src/components/chat/components/diagramElement/__stories__/docs.mdx
@@ -1,8 +1,8 @@
 import { Markdown, Meta} from '@storybook/addon-docs/blocks';
-import * as elementStories from './diagramElement.stories';
+import meta from './diagramElement.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={elementStories} />
+<Meta of={meta} />
 
 # Carbon AI Chat: Diagram
 

--- a/packages/web-components/src/components/chat/components/formulaElement/__stories__/docs.mdx
+++ b/packages/web-components/src/components/chat/components/formulaElement/__stories__/docs.mdx
@@ -1,8 +1,8 @@
 import { Markdown, Meta} from '@storybook/addon-docs/blocks';
-import * as elementStories from './formulaElement.stories';
+import meta from './formulaElement.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={elementStories} />
+<Meta of={meta} />
 
 # Carbon AI Chat: Formula
 

--- a/packages/web-components/src/components/chat/components/historyViewer/__stories__/docs.mdx
+++ b/packages/web-components/src/components/chat/components/historyViewer/__stories__/docs.mdx
@@ -1,8 +1,8 @@
 import { Markdown, Meta} from '@storybook/addon-docs/blocks';
-import * as elementStories from './historyViewer.stories';
+import meta from './historyViewer.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={elementStories} />
+<Meta of={meta} />
 
 # Carbon AI Chat: History viewer
 

--- a/packages/web-components/src/components/chat/components/molecularElement/__stories__/docs.mdx
+++ b/packages/web-components/src/components/chat/components/molecularElement/__stories__/docs.mdx
@@ -1,8 +1,8 @@
 import { Markdown, Meta} from '@storybook/addon-docs/blocks';
-import * as elementStories from './molecularElement.stories';
+import meta from './molecularElement.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={elementStories} />
+<Meta of={meta} />
 
 # Carbon AI Chat: Molecule
 

--- a/packages/web-components/src/components/chat/components/popupElement/__stories__/popup.mdx
+++ b/packages/web-components/src/components/chat/components/popupElement/__stories__/popup.mdx
@@ -1,9 +1,9 @@
 import { Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../../../globals/internal/storybook-cdn';
-import * as popupElementStories from './popupElement.stories';
+import meta from './popupElement.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={popupElementStories} />
+<Meta of={meta} />
 
 # Carbon AI Chat: Popup
 

--- a/packages/web-components/src/components/chat/components/tableElement/__stories__/docs.mdx
+++ b/packages/web-components/src/components/chat/components/tableElement/__stories__/docs.mdx
@@ -1,8 +1,8 @@
 import { Markdown, Meta} from '@storybook/addon-docs/blocks';
-import * as elementStories from './tableElement.stories';
+import meta from './tableElement.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={elementStories} />
+<Meta of={meta} />
 
 # Carbon AI Chat: Table
 

--- a/packages/web-components/src/components/chat/components/textElement/__stories__/docs.mdx
+++ b/packages/web-components/src/components/chat/components/textElement/__stories__/docs.mdx
@@ -1,9 +1,9 @@
 import { Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../../../globals/internal/storybook-cdn';
-import * as TextElementStories from './textElement.stories';
+import meta from './textElement.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={TextElementStories} />
+<Meta of={meta} />
 
 # Carbon AI Chat: Text
 

--- a/packages/web-components/src/components/chat/components/textElement/__stories__/text.mdx
+++ b/packages/web-components/src/components/chat/components/textElement/__stories__/text.mdx
@@ -1,9 +1,9 @@
 import { Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../../../globals/internal/storybook-cdn';
-import * as TextElementStories from './textElement.stories';
+import meta from './textElement.stories';
 import packageJson from '../../../package.json';
 
-<Meta of={TextElementStories} />
+<Meta of={meta} />
 
 # Carbon-Labs Text Handbook
 

--- a/packages/web-components/src/components/empty-state/__stories__/empty-state.mdx
+++ b/packages/web-components/src/components/empty-state/__stories__/empty-state.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as EmptyStateStories from './empty-state.stories';
+import meta from './empty-state.stories';
 import packageJson from '../package.json';
 
-<Meta of={EmptyStateStories} />
+<Meta of={meta} />
 
 # Empty State
 

--- a/packages/web-components/src/components/example-button/__stories__/example-button.mdx
+++ b/packages/web-components/src/components/example-button/__stories__/example-button.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as ExampleButtonStories from './example-button.stories';
+import meta from './example-button.stories';
 import packageJson from '../package.json';
 
-<Meta of={ExampleButtonStories} />
+<Meta of={meta} />
 
 # Example Button
 

--- a/packages/web-components/src/components/first-time-orientation/__stories__/first-time-orientation.mdx
+++ b/packages/web-components/src/components/first-time-orientation/__stories__/first-time-orientation.mdx
@@ -1,10 +1,10 @@
 
 import { ArgTypes, Canvas, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
+import meta from './first-time-orientation.stories';
 import * as FirstTimeOrientationStories from './first-time-orientation.stories';
 
-
-<Meta of={FirstTimeOrientationStories} />
+<Meta of={meta} />
 
 
 # First-time orientation pattern

--- a/packages/web-components/src/components/global-header/__stories__/global-header.mdx
+++ b/packages/web-components/src/components/global-header/__stories__/global-header.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as GlobalHeaderStories from './global-header.stories';
+import meta from './global-header.stories';
 import packageJson from '../package.json';
 
-<Meta of={GlobalHeaderStories} />
+<Meta of={meta} />
 
 # Global Header
 

--- a/packages/web-components/src/components/resizer/__stories__/resizer.mdx
+++ b/packages/web-components/src/components/resizer/__stories__/resizer.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Canvas, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as ResizerStories from './resizer.stories';
+import meta from './resizer.stories';
 import packageJson from '../package.json';
 
-<Meta of={ResizerStories} />
+<Meta of={meta} />
 
 # Resizer
 

--- a/packages/web-components/src/components/style-picker/__stories__/style-picker.disclosed.mdx
+++ b/packages/web-components/src/components/style-picker/__stories__/style-picker.disclosed.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as StylePickerDisclosedStories from './style-picker.disclosed.stories';
+import meta from './style-picker.disclosed.stories';
 import packageJson from '../package.json';
 
-<Meta of={StylePickerDisclosedStories} />
+<Meta of={meta} />
 
 # Style Picker
 

--- a/packages/web-components/src/components/style-picker/__stories__/style-picker.flat.mdx
+++ b/packages/web-components/src/components/style-picker/__stories__/style-picker.flat.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as StylePickerFlatStories from './style-picker.flat.stories';
+import meta from './style-picker.flat.stories';
 import packageJson from '../package.json';
 
-<Meta of={StylePickerFlatStories} />
+<Meta of={meta} />
 
 # Style Picker
 

--- a/packages/web-components/src/components/style-picker/__stories__/style-picker.single.mdx
+++ b/packages/web-components/src/components/style-picker/__stories__/style-picker.single.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as StylePickerSingleStories from './style-picker.single.stories';
+import meta from './style-picker.single.stories';
 import packageJson from '../package.json';
 
-<Meta of={StylePickerSingleStories} />
+<Meta of={meta} />
 
 # Style Picker
 

--- a/packages/web-components/src/components/tag/__stories__/tag.mdx
+++ b/packages/web-components/src/components/tag/__stories__/tag.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as TagStories from './tag.stories';
+import meta from './tag.stories';
 import packageJson from '../package.json';
 
-<Meta of={TagStories} />
+<Meta of={meta} />
 
 # Tag
 

--- a/packages/web-components/src/components/toolbar/__stories__/toolbar.mdx
+++ b/packages/web-components/src/components/toolbar/__stories__/toolbar.mdx
@@ -1,8 +1,9 @@
 import { ArgTypes, Canvas, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
+import meta from './toolbar.stories';
 import * as ToolbarStories from './toolbar.stories';
 
-<Meta of={ToolbarStories} />
+<Meta of={meta} />
 
 # Toolbar
 

--- a/packages/web-components/src/v12/components/date-picker/__stories__/date-picker-web-components.mdx
+++ b/packages/web-components/src/v12/components/date-picker/__stories__/date-picker-web-components.mdx
@@ -1,7 +1,8 @@
 import { ArgTypes, Canvas, Markdown, Meta } from '@storybook/addon-docs/blocks';
+import meta from './date-picker-web-components.stories';
 import * as DatePickerStories from './date-picker-web-components.stories';
 
-<Meta of={DatePickerStories} />
+<Meta of={meta} />
 
 # Date picker
 

--- a/packages/web-components/tasks/generate/templates/__stories__/DISPLAY_NAME.mdx
+++ b/packages/web-components/tasks/generate/templates/__stories__/DISPLAY_NAME.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Markdown, Meta } from '@storybook/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as PASCAL_CASEStories from './DISPLAY_NAME.stories';
+import meta from './DISPLAY_NAME.stories';
 import packageJson from '../package.json';
 
-<Meta of={PASCAL_CASEStories} />
+<Meta of={meta} />
 
 # TITLE_NAME
 


### PR DESCRIPTION
Closes #1245
https://github.com/carbon-design-system/carbon-labs/pull/1230 introduced a regression when upgrading to Vite 8. Vite/rolldown production builds split CSF stories into separate chunks. This breaks with `<Meta of="Stories" />` which expects everything to be together.

~This adds Rolldown's `strictExecutionOrder` option for production builds.~ This didn't work.

Importing default meta to all stories instead.

#### Changelog

**New**

- ~add `strictExecutionOrder` for prod builds.~
- import default `meta` to web component stories

#### Testing / Reviewing

Web components Storybook story docs should load correctly in prod environments. Testing can be done on this PR's deploy preview.
