### PR TITLE
chore: test the feasibility to add cell renderer to render custom content in calendar cells

### DIFF
--- a/packages/react/src/v12/components/DatePicker/__stories__/date-picker-react.mdx
+++ b/packages/react/src/v12/components/DatePicker/__stories__/date-picker-react.mdx
@@ -20,6 +20,7 @@ import * as DatePickerStories from './date-picker-react.stories.tsx';
   - [Single date picker](#single-date-picker)
   - [Range date picker](#range-date-picker)
   - [Skeleton state](#skeleton-state)
+  - [Event dots](#event-dots)
   - [AI label](#ai-label)
 - [Component API](#component-api)
   - [API Compatibility](#api-compatibility)
@@ -45,8 +46,8 @@ Date pickers allow users to select a single or a range of dates. Pickers are
 used to display past, present, or future dates. The kind of date (exact,
 approximate, memorable) you are requesting from the user will determine which
 picker is best to use. Each picker's format can be customized depending on
-location or need. The `DatePicker` component expects a `DatePickerInput`
-as a child.
+location or need. The `DatePicker` component expects a `DatePickerInput` as a
+child.
 
 <Canvas of={DatePickerStories.SingleWithCalendar} />
 
@@ -80,10 +81,18 @@ being fetched.
 
 <Canvas of={DatePickerStories.Skeleton} />
 
+### Event dots
+
+Use the `renderDay` prop to customize the content inside each day cell. This is
+the recommended integration point for showing per-date metadata such as events,
+availability, or status indicators.
+
+<Canvas of={DatePickerStories.WithEventDots} />
+
 ### AI label
 
-The input also supports Carbon AI label decoration through the
-`DatePickerInput` `decorator` prop.
+The input also supports Carbon AI label decoration through the `DatePickerInput`
+`decorator` prop.
 
 <Canvas of={DatePickerStories.withAILabel} />
 
@@ -91,9 +100,11 @@ The input also supports Carbon AI label decoration through the
 
 ### API Compatibility
 
-This implementation maintains **100% backward compatibility** with Carbon React v11 DatePicker API. All existing props and functionality work exactly as before:
+This implementation maintains **100% backward compatibility** with Carbon React
+v11 DatePicker API. All existing props and functionality work exactly as before:
 
 **`DatePicker` props:**
+
 - `allowInput` - Allow manual date entry
 - `appendTo` - Append the calendar to a specific element
 - `className` - Additional CSS class names
@@ -108,10 +119,12 @@ This implementation maintains **100% backward compatibility** with Carbon React 
 - `onClose` - Callback when the calendar closes
 - `onOpen` - Callback when the calendar opens
 - `readOnly` - Make date picker read-only
+- `renderDay` - Customize the content rendered inside each calendar day cell
 - `short` - Use short variant
 - `value` - Selected date value
 
 **`DatePickerInput` props:**
+
 - `autoComplete` - Autocomplete attribute
 - `className` - Additional CSS class names
 - `decorator` - Decorator component such as an AI label
@@ -144,17 +157,19 @@ This implementation maintains **100% backward compatibility** with Carbon React 
 
 ### Breaking Changes
 
-**None.** This implementation is a drop-in replacement with no breaking changes to the public API.
+**None.** This implementation is a drop-in replacement with no breaking changes
+to the public API.
 
 **What changed internally:**
+
 - Removed Flatpickr dependency (~15,000 lines of code)
 - Implemented native calendar using Temporal API and modern web standards
 - Added shared state machine with Web Components implementation
 - Enhanced keyboard navigation
 - Improved accessibility
 
-**Migration:**
-No migration needed. Existing code continues to work without modifications. Simply update your import path:
+**Migration:** No migration needed. Existing code continues to work without
+modifications. Simply update your import path:
 
 ```tsx
 // Before (Carbon React v11)
@@ -170,32 +185,33 @@ import { DatePicker, DatePickerInput } from '@carbon-labs/react/date-picker';
 
 ## `DatePickerInput`
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `id` | `string` | - | **Required.** Unique identifier for the input |
-| `labelText` | `ReactNode` | - | Label text |
-| `placeholder` | `string` | `'mm/dd/yyyy'` | Placeholder text |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Input size |
-| `disabled` | `boolean` | `false` | Whether the input is disabled |
-| `invalid` | `boolean` | `false` | Whether the input is invalid |
-| `invalidText` | `ReactNode` | - | Invalid text to display |
-| `warn` | `boolean` | `false` | Whether the input has a warning |
-| `warnText` | `ReactNode` | - | Warning text to display |
-| `helperText` | `ReactNode` | - | Helper text to display |
-| `hideLabel` | `boolean` | `false` | Whether to hide the label visually |
-| `readOnly` | `boolean` | `false` | Whether the input is read-only |
-| `value` | `string` | - | Input value (controlled) |
-| `defaultValue` | `string` | - | Default value (uncontrolled) |
-| `onChange` | `(event) => void` | - | Change handler |
-| `onFocus` | `(event) => void` | - | Focus handler |
-| `onBlur` | `(event) => void` | - | Blur handler |
+| Prop           | Type                   | Default        | Description                                   |
+| -------------- | ---------------------- | -------------- | --------------------------------------------- |
+| `id`           | `string`               | -              | **Required.** Unique identifier for the input |
+| `labelText`    | `ReactNode`            | -              | Label text                                    |
+| `placeholder`  | `string`               | `'mm/dd/yyyy'` | Placeholder text                              |
+| `size`         | `'sm' \| 'md' \| 'lg'` | `'md'`         | Input size                                    |
+| `disabled`     | `boolean`              | `false`        | Whether the input is disabled                 |
+| `invalid`      | `boolean`              | `false`        | Whether the input is invalid                  |
+| `invalidText`  | `ReactNode`            | -              | Invalid text to display                       |
+| `warn`         | `boolean`              | `false`        | Whether the input has a warning               |
+| `warnText`     | `ReactNode`            | -              | Warning text to display                       |
+| `helperText`   | `ReactNode`            | -              | Helper text to display                        |
+| `hideLabel`    | `boolean`              | `false`        | Whether to hide the label visually            |
+| `readOnly`     | `boolean`              | `false`        | Whether the input is read-only                |
+| `value`        | `string`               | -              | Input value (controlled)                      |
+| `defaultValue` | `string`               | -              | Default value (uncontrolled)                  |
+| `onChange`     | `(event) => void`      | -              | Change handler                                |
+| `onFocus`      | `(event) => void`      | -              | Focus handler                                 |
+| `onBlur`       | `(event) => void`      | -              | Blur handler                                  |
 
 ### Date picker `dateFormat`
 
-You can use the `dateFormat` prop to change how the selected date is
-displayed in the input. The default format is `m/d/Y` (MM/DD/YYYY).
+You can use the `dateFormat` prop to change how the selected date is displayed
+in the input. The default format is `m/d/Y` (MM/DD/YYYY).
 
 Supported format tokens:
+
 - `m` - Month (1-12)
 - `d` - Day (1-31)
 - `Y` - Year (4 digits)
@@ -216,7 +232,8 @@ There are three supported variations of `DatePicker` in Carbon.
 
 - `simple` will render a simple text input _without_ a calendar dropdown.
 - `single` will render a single text input _with_ a calendar dropdown.
-- For `range`, two `DatePickerInput` components will need to be provided as children.
+- For `range`, two `DatePickerInput` components will need to be provided as
+  children.
 
 ```tsx
 // Simple (no calendar)
@@ -260,8 +277,8 @@ minimum date will be disabled in the calendar and navigation will be restricted.
 
 ### Date picker `value`
 
-Pass a string value to either the `DatePicker` or the child `DatePickerInput`
-to initialize the selected date.
+Pass a string value to either the `DatePicker` or the child `DatePickerInput` to
+initialize the selected date.
 
 ```tsx
 <DatePicker value="04/17/2025">
@@ -273,14 +290,17 @@ to initialize the selected date.
 
 ### Modern implementation
 
-This date picker implementation uses modern web platform APIs and has **zero external dependencies**:
+This date picker implementation uses modern web platform APIs and has **zero
+external dependencies**:
 
-- **Temporal API** - Modern date/time handling (polyfilled for browser compatibility)
+- **Temporal API** - Modern date/time handling (polyfilled for browser
+  compatibility)
 - **Popover API** - Native browser popover for the calendar dropdown
 - **CSS Anchor Positioning** - Smart positioning relative to the input field
 - **State Machine** - Predictable state management shared with Web Components
 
 **Benefits:**
+
 - 🎯 **84% less code** compared to Flatpickr-based implementation
 - 📦 **~20-30% smaller bundle** size
 - 🚀 **Zero external dependencies** to maintain
@@ -290,15 +310,16 @@ This date picker implementation uses modern web platform APIs and has **zero ext
 
 ### State machine
 
-The date picker uses a finite state machine to manage all interactions and state transitions.
-This provides:
+The date picker uses a finite state machine to manage all interactions and state
+transitions. This provides:
 
 - **Predictable behavior** - All state changes are explicit and testable
 - **Clear event handling** - Events trigger specific state transitions
 - **Maintainable code** - State logic is centralized and documented
 - **Framework agnostic** - Same logic used in Web Components and React
 
-States include: `IDLE`, `FOCUSED`, `CALENDAR_OPEN`, `DATE_SELECTED`, `RANGE_START_SELECTED`, `RANGE_SELECTING`
+States include: `IDLE`, `FOCUSED`, `CALENDAR_OPEN`, `DATE_SELECTED`,
+`RANGE_START_SELECTED`, `RANGE_SELECTING`
 
 For detailed shared state logic, see the primitives package in
 [GitHub](https://github.com/carbon-design-system/carbon-labs/tree/main/packages/primitives/src/date-picker).
@@ -312,7 +333,8 @@ The calendar supports comprehensive keyboard navigation:
 - **Escape** - Close the calendar
 - **Tab** - Navigate through the date picker interface
   - **Single mode**: Input field → Calendar (when open) → Outside the component
-  - **Range mode**: First input → Calendar (when open) → Second input → Calendar (when open) → Outside the component
+  - **Range mode**: First input → Calendar (when open) → Second input → Calendar
+    (when open) → Outside the component
   - **Shift+Tab** - Reverse navigation through the same flow
 - **Page Up/Down** - Navigate between months
 - **Home/End** - Jump to start/end of week
@@ -320,42 +342,48 @@ The calendar supports comprehensive keyboard navigation:
 **Tab Navigation Flow:**
 
 In **single date mode**, pressing Tab follows this pattern:
+
 1. Focus on input field
 2. If calendar is open, Tab moves focus to the calendar
 3. Tab again moves focus outside the date picker
 
 In **range date mode**, pressing Tab follows this pattern:
+
 1. Focus on first input field (start date)
 2. If calendar is open, Tab moves focus to the calendar
 3. Tab again moves focus to second input field (end date)
 4. If calendar is open, Tab moves focus to the calendar again
 5. Tab again moves focus outside the date picker
 
-Shift+Tab reverses this flow, allowing you to navigate backward through the same sequence.
+Shift+Tab reverses this flow, allowing you to navigate backward through the same
+sequence.
 
-When the calendar opens without a selected date, focus automatically moves to today's date
-for easy keyboard navigation.
+When the calendar opens without a selected date, focus automatically moves to
+today's date for easy keyboard navigation.
 
 ## Migration from Carbon React v11
 
-This implementation is **100% backwards compatible** with Carbon React v11. No code changes are required:
+This implementation is **100% backwards compatible** with Carbon React v11. No
+code changes are required:
 
 ### Before (Carbon React v11)
+
 ```tsx
 import { DatePicker, DatePickerInput } from '@carbon/react';
 
 <DatePicker datePickerType="single" onChange={handleChange}>
   <DatePickerInput id="date" labelText="Date" />
-</DatePicker>
+</DatePicker>;
 ```
 
 ### After (Carbon Labs)
+
 ```tsx
 import { DatePicker, DatePickerInput } from '@carbon-labs/react/date-picker';
 
 <DatePicker datePickerType="single" onChange={handleChange}>
   <DatePickerInput id="date" labelText="Date" />
-</DatePicker>
+</DatePicker>;
 ```
 
 **All props work exactly the same!** The only change is the import path.
@@ -363,10 +391,17 @@ import { DatePicker, DatePickerInput } from '@carbon-labs/react/date-picker';
 ## References
 
 - [Carbon React v11 DatePicker Documentation](https://react.carbondesignsystem.com/?path=/docs/components-datepicker--overview)
-- The date picker uses the [Temporal API](https://tc39.es/proposal-temporal/docs/) for modern date handling
-- The calendar uses the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for dropdown behavior
-- Positioning uses [CSS Anchor Positioning](https://developer.chrome.com/blog/tether-elements-to-each-other-with-css-anchor-positioning) for smart placement
-- The `DatePickerInput` component takes in similar props to the Carbon `TextInput` component
+- The date picker uses the
+  [Temporal API](https://tc39.es/proposal-temporal/docs/) for modern date
+  handling
+- The calendar uses the
+  [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
+  for dropdown behavior
+- Positioning uses
+  [CSS Anchor Positioning](https://developer.chrome.com/blog/tether-elements-to-each-other-with-css-anchor-positioning)
+  for smart placement
+- The `DatePickerInput` component takes in similar props to the Carbon
+  `TextInput` component
 
 ## Feedback
 

--- a/packages/react/src/v12/components/DatePicker/__stories__/date-picker-react.stories.tsx
+++ b/packages/react/src/v12/components/DatePicker/__stories__/date-picker-react.stories.tsx
@@ -15,7 +15,12 @@ import {
   Button,
 } from '@carbon/react';
 import { View, FolderOpen, Folders, Layers } from '@carbon/icons-react';
-import { DatePicker, DatePickerInput, DatePickerSkeleton } from '../index';
+import {
+  DatePicker,
+  DatePickerInput,
+  DatePickerSkeleton,
+  type CalendarDayRenderProps,
+} from '../index';
 import '../components/date-picker.scss';
 import './with-layer.scss';
 import mdx from './date-picker-react.mdx';
@@ -91,6 +96,35 @@ export default {
       },
     },
   },
+};
+
+const eventDotsByDate: Record<string, Array<'blue' | 'green' | 'magenta'>> = {
+  '2026-05-04': ['blue'],
+  '2026-05-07': ['green', 'magenta'],
+  '2026-05-12': ['blue', 'green', 'magenta'],
+  '2026-05-18': ['magenta'],
+  '2026-05-22': ['blue', 'green'],
+  '2026-05-27': ['green', 'magenta', 'blue'],
+};
+
+const renderEventDay = ({ date, isCurrentMonth }: CalendarDayRenderProps) => {
+  const dots = isCurrentMonth ? (eventDotsByDate[date.toString()] ?? []) : [];
+
+  return (
+    <span className="cds--date-picker__day-content">
+      <span>{date.day}</span>
+      {dots.length > 0 && (
+        <span className="cds--date-picker__day-event-dots" aria-hidden="true">
+          {dots.slice(0, 3).map((color, index) => (
+            <span
+              key={`${date.toString()}-${color}-${index}`}
+              className={`cds--date-picker__day-event-dot cds--date-picker__day-event-dot--${color}`}
+            />
+          ))}
+        </span>
+      )}
+    </span>
+  );
 };
 
 const sharedArgTypes = {
@@ -307,6 +341,25 @@ Skeleton.parameters = {
     skip: true,
   },
 };
+
+export const WithEventDots = (args) => (
+  <DatePicker
+    datePickerType="single"
+    value="05/12/2026"
+    renderDay={renderEventDay}
+    {...args}>
+    <DatePickerInput
+      placeholder="mm/dd/yyyy"
+      labelText="Project schedule"
+      helperText="Dates may show one to three colored dots for different event types."
+      id="date-picker-with-event-dots"
+      size="md"
+      {...args}
+    />
+  </DatePicker>
+);
+
+WithEventDots.argTypes = { ...sharedArgTypes };
 
 export const withAILabel = (args) => {
   const aiLabel = (

--- a/packages/react/src/v12/components/DatePicker/components/Calendar.tsx
+++ b/packages/react/src/v12/components/DatePicker/components/Calendar.tsx
@@ -13,6 +13,46 @@ import { addDays, plainDateToDate } from '@carbon-labs/primitives/date-picker';
 /**
  * Calendar component props
  */
+export interface CalendarDayRenderProps {
+  /**
+   * Date represented by the day cell
+   */
+  date: Temporal.PlainDate;
+
+  /**
+   * Whether the date belongs to the current visible month
+   */
+  isCurrentMonth: boolean;
+
+  /**
+   * Whether the date is disabled
+   */
+  isDisabled: boolean;
+
+  /**
+   * Whether the date is today
+   */
+  isToday: boolean;
+
+  /**
+   * Whether the date is selected
+   */
+  isSelected: boolean;
+
+  /**
+   * Whether the date is inside a selected range
+   */
+  isInRange: boolean;
+
+  /**
+   * Whether the date is focused
+   */
+  isFocused: boolean;
+}
+
+/**
+ * Calendar component props
+ */
 export interface CalendarProps {
   /**
    * State machine context
@@ -33,6 +73,11 @@ export interface CalendarProps {
    * Additional CSS class names
    */
   className?: string;
+
+  /**
+   * Custom renderer for day cell content
+   */
+  renderDay?: (props: CalendarDayRenderProps) => React.ReactNode;
 }
 
 /**
@@ -114,6 +159,7 @@ export function Calendar({
   onDateSelect,
   onNavigate,
   className,
+  renderDay,
 }: CalendarProps) {
   // Use Carbon's standard 'cds' prefix to match Carbon's date-picker styles
   const prefix = 'cds';
@@ -342,6 +388,16 @@ export function Calendar({
             focused: focused,
           });
 
+          const renderProps: CalendarDayRenderProps = {
+            date,
+            isCurrentMonth,
+            isDisabled,
+            isToday,
+            isSelected: selected,
+            isInRange: inRange,
+            isFocused: focused,
+          };
+
           return (
             <button
               key={index}
@@ -352,10 +408,9 @@ export function Calendar({
               aria-label={`${monthNames[date.month - 1]} ${date.day}, ${
                 date.year
               }`}
-              aria-pressed={selected || undefined}
               aria-current={isToday ? 'date' : undefined}
               tabIndex={focused ? 0 : -1}>
-              {date.day}
+              {renderDay ? renderDay(renderProps) : date.day}
             </button>
           );
         })}

--- a/packages/react/src/v12/components/DatePicker/components/DatePicker.tsx
+++ b/packages/react/src/v12/components/DatePicker/components/DatePicker.tsx
@@ -9,6 +9,7 @@ import React, { Children, cloneElement, isValidElement, useRef } from 'react';
 import classNames from 'classnames';
 import { useDatePicker } from '../hooks/useDatePicker';
 import { Calendar } from './Calendar';
+import type { CalendarDayRenderProps } from './Calendar';
 import { formatPlainDate } from '@carbon-labs/primitives/date-picker';
 import type { DatePickerInputProps } from './DatePickerInput';
 
@@ -101,6 +102,11 @@ export interface DatePickerProps {
    * Append the calendar to a specific element
    */
   appendTo?: HTMLElement;
+
+  /**
+   * Custom renderer for calendar day content
+   */
+  renderDay?: (props: CalendarDayRenderProps) => React.ReactNode;
 }
 
 /**
@@ -125,6 +131,7 @@ export function DatePicker({
   className,
   children,
   value,
+  renderDay,
 }: DatePickerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -279,6 +286,7 @@ export function DatePicker({
             context={context}
             onDateSelect={selectDate}
             onNavigate={handleNavigate}
+            renderDay={renderDay}
           />
         </div>
       )}

--- a/packages/react/src/v12/components/DatePicker/components/date-picker.scss
+++ b/packages/react/src/v12/components/DatePicker/components/date-picker.scss
@@ -8,6 +8,7 @@
 // Import shared framework-agnostic styles from primitives (built output)
 // Uses Carbon's standard 'cds' prefix for compatibility with Carbon Design System
 @use '@carbon-labs/primitives/es/date-picker/styles/date-picker';
+@use '@carbon/styles/scss/theme' as *;
 
 // =============================================================================
 // REACT SPECIFIC STYLES
@@ -18,3 +19,39 @@
 
 // React uses standard class-based selectors, which are already defined
 // in the shared primitives SCSS file. No additional wrappers needed.
+
+.cds--date-picker__day-content {
+  display: inline-flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  inline-size: 100%;
+  block-size: 100%;
+}
+
+.cds--date-picker__day-event-dots {
+  position: absolute;
+  inset-block-end: 0.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  column-gap: 0.125rem;
+}
+
+.cds--date-picker__day-event-dot {
+  inline-size: 0.25rem;
+  block-size: 0.25rem;
+  border-radius: 50%;
+}
+
+.cds--date-picker__day-event-dot--blue {
+  background-color: $support-info;
+}
+
+.cds--date-picker__day-event-dot--green {
+  background-color: $support-success;
+}
+
+.cds--date-picker__day-event-dot--magenta {
+  background-color: $support-error;
+}

--- a/packages/react/src/v12/components/DatePicker/index.ts
+++ b/packages/react/src/v12/components/DatePicker/index.ts
@@ -17,7 +17,10 @@ export { useDatePicker } from './hooks/useDatePicker';
 // Types
 export type { DatePickerProps } from './components/DatePicker';
 export type { DatePickerInputProps } from './components/DatePickerInput';
-export type { CalendarProps } from './components/Calendar';
+export type {
+  CalendarProps,
+  CalendarDayRenderProps,
+} from './components/Calendar';
 export type { DatePickerSkeletonProps } from './components/DatePickerSkeleton';
 export type {
   UseDatePickerConfig,


### PR DESCRIPTION
ref: https://github.com/carbon-design-system/carbon/issues/21973

DO NOT MERGE. ONLY BUILT FOR FEASIBILITY CHECK.

the changes were roughly added. to check the feasibility of integrating custom cell renderer in calendar inside datepicker
[preview](https://deploy-preview-1257--carbon-labs-react.netlify.app/v12/?path=/story/react_v12-datepicker--with-event-dots&args=helperText)

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
