### PR TITLE
feat(clabs-wysiwyg): add wysiwyg editor component

### DIFF
--- a/examples/web-components/wysiwyg/cdn.html
+++ b/examples/web-components/wysiwyg/cdn.html
@@ -1,0 +1,36 @@
+<!--
+@license
+
+Copyright IBM Corp. 2026
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+  <head>
+    <title>@carbon-labs/wc-wysiwyg example</title>
+    <meta charset="UTF-8" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/themes.css" />
+    <style>
+      /* Suppress custom element until styles are loaded */
+      clabs-wysiwyg:not(:defined) {
+        display: none;
+      }
+    </style>
+    <script
+      type="module"
+      src="https://1.www.s81c.com/common/carbon/labs/wysiwyg/v0.4.0/index.min.js"></script>
+  </head>
+  <body class="cds-theme-zone-white">
+    <clabs-wysiwyg>Wysiwyg</clabs-wysiwyg>
+  </body>
+</html>

--- a/examples/web-components/wysiwyg/index.html
+++ b/examples/web-components/wysiwyg/index.html
@@ -18,6 +18,6 @@ LICENSE file in the root directory of this source tree.
     <script type="module" src="src/index.js"></script>
   </head>
   <body>
-    <clabs-wysiwyg>Wysiwyg</clabs-wysiwyg>
+    <clabs-wysiwyg></clabs-wysiwyg>
   </body>
 </html>

--- a/examples/web-components/wysiwyg/index.html
+++ b/examples/web-components/wysiwyg/index.html
@@ -1,0 +1,23 @@
+<!--
+@license
+
+Copyright IBM Corp. 2026
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+  <head>
+    <title>@carbon-labs/wc-wysiwyg example</title>
+    <meta charset="UTF-8" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+    <link rel="stylesheet" href="src/styles.scss" />
+    <script type="module" src="src/index.js"></script>
+  </head>
+  <body>
+    <clabs-wysiwyg>Wysiwyg</clabs-wysiwyg>
+  </body>
+</html>

--- a/examples/web-components/wysiwyg/package.json
+++ b/examples/web-components/wysiwyg/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "carbon-labs-web-components-wysiwyg",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "clean": "rimraf node_modules dist .cache",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2",
+    "sass": "^1.55.0",
+    "vite": "^8.0.12"
+  },
+  "dependencies": {
+    "@carbon-labs/wc-wysiwyg": "latest",
+    "@carbon/styles": "^1.88.0"
+  }
+}

--- a/examples/web-components/wysiwyg/src/index.js
+++ b/examples/web-components/wysiwyg/src/index.js
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '@carbon-labs/wc-wysiwyg/es/index.js';

--- a/examples/web-components/wysiwyg/src/styles.scss
+++ b/examples/web-components/wysiwyg/src/styles.scss
@@ -1,0 +1,17 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/web-components/src/components/wysiwyg/README.md
+++ b/packages/web-components/src/components/wysiwyg/README.md
@@ -1,0 +1,34 @@
+<p align="center">
+  <a href="https://www.carbondesignsystem.com">
+    <img alt="Carbon Design System" src="https://user-images.githubusercontent.com/3901764/57545698-ce5f2380-7320-11e9-8682-903df232d7b0.png" width="100%" />
+  </a>
+</p>
+<h1 align="center">
+  Carbon Labs
+</h1>
+
+> A community-driven incubation space enabling rapid prototyping, development,
+> and deployment of Carbon-based components.
+
+## Getting started
+
+Install `@carbon-labs/wc-wysiwyg` to use this package.
+
+### Storybook
+
+You can view the current state of the
+[component](https://labs.carbondesignsystem.com/web-components/).
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-labs/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/web-components/src/components/wysiwyg/__stories__/01-Default.stories.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/01-Default.stories.js
@@ -1,0 +1,190 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '../components/wysiwyg/wysiwyg';
+import { html } from 'lit';
+import {
+  generateToolbarOptions,
+  demoContent,
+  isContentEmpty,
+  updateButtonVisibility,
+} from './_story-utils';
+
+export default {
+  title: 'Components/Wysiwyg',
+  component: 'clabs-wysiwyg',
+  parameters: {
+    docs: {
+      story: {
+        name: 'Default',
+      },
+    },
+  },
+};
+
+/**
+ * Default story showcasing the WYSIWYG editor with full functionality
+ */
+export const Default = {
+  args: {
+    content: '',
+    toolbarOptions: generateToolbarOptions(), // only adding for showing controls to play with. not needed if we want to render everything.
+  },
+  argTypes: {
+    toolbarOptions: {
+      control: 'object',
+      description:
+        'Toolbar configuration. Pass undefined for all groups, [] for no toolbar, or custom array for specific groups.',
+      table: {
+        type: { summary: 'ToolbarOptions | undefined' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+  },
+
+  /**
+   * Renders the template for Storybook
+   * @param {object} args Storybook arguments
+   * @returns {TemplateResult<1>}
+   */
+  render: (args) => {
+    /**
+     * Handles editor content changes and updates button visibility
+     * @param {CustomEvent} event Content change event from the editor
+     */
+    const handleContentChange = (event) => {
+      // console.log('clabs-wysiwyg-on-change event:', {
+      //   content: event.detail.content,
+      //   contentLength: event.detail.content.length,
+      //   editor: event.detail.editor,
+      // });
+
+      const editor = event.target;
+      const form = editor.closest('form');
+      if (!form) {
+        return;
+      }
+
+      const isEmpty = isContentEmpty(event.detail.content);
+      updateButtonVisibility(form, isEmpty);
+    };
+
+    /**
+     * Injects kitchen sink demo content into the editor instance.
+     * @param {Event} event Click event from the story action button
+     */
+    const setKitchenSinkContent = (event) => {
+      const button = event.currentTarget;
+      // Find the editor in the same container as the button
+      const form = button.closest('form');
+      const editor = form?.querySelector('clabs-wysiwyg');
+
+      if (!editor) {
+        console.warn('Could not find clabs-wysiwyg element');
+        return;
+      }
+
+      // Set kitchen sink content
+      editor.content = demoContent;
+      // Button visibility will be updated by content-change event
+    };
+
+    /**
+     * Handles send button click and logs the payload.
+     * @param {Event} event Click event
+     */
+    const handleSubmit = (event) => {
+      const button = event.currentTarget;
+      const form = button.closest('form');
+      const editor = form?.querySelector('clabs-wysiwyg');
+
+      if (!editor) {
+        console.warn('Could not find clabs-wysiwyg element');
+        return;
+      }
+
+      // Create payload with editor content and attached files
+      const payload = {
+        content: editor.content,
+        files: editor.files || [],
+        timestamp: new Date().toISOString(),
+        contentLength: editor.content.length,
+        fileCount: editor.files?.length || 0,
+      };
+
+      console.log('Form submitted with payload:', payload);
+
+      // Reset to initial state after a delay
+      setTimeout(() => {
+        editor.content = '';
+        editor.files = [];
+        // Button visibility will be updated by content-change event
+      }, 2000);
+    };
+
+    /**
+     * Discards the editor content and resets to initial state.
+     * @param {Event} event Click event from the discard button
+     */
+    const discardContent = (event) => {
+      const button = event.currentTarget;
+      const form = button.closest('form');
+      const editor = form?.querySelector('clabs-wysiwyg');
+
+      if (!editor) {
+        console.warn('Could not find clabs-wysiwyg element');
+        return;
+      }
+
+      // Reset editor content - button visibility will be updated by content-change event
+      editor.content = '';
+      editor.files = [];
+    };
+
+    return html`<div class="wysiwyg-story-container">
+      <form
+        @submit=${handleSubmit}
+        style="display: flex; flex-direction: column; gap: 2rem;">
+        <clabs-wysiwyg
+          aria-label="WYSIWYG editor"
+          .content=${args.content}
+          .toolbarOptions=${args.toolbarOptions}
+          @clabs-wysiwyg-on-change=${handleContentChange}></clabs-wysiwyg>
+        <div style="display: flex; gap: 1rem;">
+          <cds-button
+            type="button"
+            data-action="set-content"
+            kind="primary"
+            size="md"
+            @click=${setKitchenSinkContent}>
+            Set Data
+          </cds-button>
+          <cds-button
+            type="button"
+            data-action="send"
+            kind="primary"
+            size="md"
+            style="display: none;"
+            @click=${handleSubmit}>
+            Send
+          </cds-button>
+          <cds-button
+            type="button"
+            data-action="discard"
+            kind="secondary"
+            size="md"
+            style="display: none;"
+            @click=${discardContent}>
+            Discard
+          </cds-button>
+        </div>
+      </form>
+    </div>`;
+  },
+};

--- a/packages/web-components/src/components/wysiwyg/__stories__/01-Default.stories.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/01-Default.stories.js
@@ -14,7 +14,7 @@ import {
   demoContent,
   isContentEmpty,
   updateButtonVisibility,
-} from './_story-utils';
+} from './story-utils';
 
 export default {
   title: 'Components/Wysiwyg',

--- a/packages/web-components/src/components/wysiwyg/__stories__/02-ToolbarOptions.stories.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/02-ToolbarOptions.stories.js
@@ -1,0 +1,117 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '../components/wysiwyg/wysiwyg';
+import { html } from 'lit';
+
+export default {
+  title: 'Components/Wysiwyg',
+  component: 'clabs-wysiwyg',
+  parameters: {
+    docs: {
+      story: {
+        name: 'Toolbar Options',
+      },
+    },
+  },
+};
+
+/**
+ * Story demonstrating toolbar customization options
+ */
+export const ToolbarOptions = {
+  args: {
+    content:
+      "<p>This editor demonstrates toolbar customization. Toolbar items render in the passed order. Specific toolbar groups or items within groups can be hidden as per your choice.</p><p><strong>Toolbar behavior:</strong></p><ul><li>Don't pass <code>.toolbarOptions</code> (undefined) → Renders all default toolbar groups</li><li>Pass <code>.toolbarOptions={[]}</code> (empty array) → Renders no toolbar at all</li><li>Pass <code>.toolbarOptions={[...]}</code> (with items) → Renders custom toolbar (this story)</li></ul>",
+    toolbarOptions: [
+      // Custom order: clipboard first
+      {
+        name: 'clipboard',
+        enabled: true,
+        items: {
+          cut: false, // Hide cut button
+          copy: true,
+          paste: true,
+        },
+      },
+      // Headings (all items shown by default)
+      { name: 'headings', enabled: true },
+      // Text formatting with selective items
+      {
+        name: 'textFormatting',
+        enabled: true,
+        items: {
+          bold: true,
+          italic: true,
+          underline: false, // Hide underline
+          strikethrough: false, // Hide strikethrough
+          code: true,
+        },
+      },
+      // Include color picker (all items shown by default)
+      { name: 'colorPicker', enabled: true },
+      // Lists with selective items
+
+      {
+        name: 'lists',
+        enabled: true,
+        items: {
+          bulletList: true,
+          numberedList: true,
+          taskList: false, // Hide task list
+        },
+      },
+      // Alignment with selective items
+      {
+        name: 'alignment',
+        enabled: true,
+        items: {
+          left: true,
+          center: true,
+          right: false, // Hide right align
+          justify: false, // Hide justify
+        },
+      },
+      // Blocks with selective items
+      {
+        name: 'blocks',
+        enabled: true,
+        items: {
+          blockquote: true,
+          codeBlock: false, // Hide code block
+        },
+      },
+      // Insert with selective items
+      {
+        name: 'insert',
+        enabled: true,
+        items: {
+          table: true,
+          link: true,
+          image: false, // Hide image
+          attachment: false, // Hide attachment
+        },
+      },
+      // Table operations at the end
+      { name: 'tableOperations', enabled: true },
+    ],
+  },
+
+  /**
+   * Renders the template for Storybook
+   * @param {object} args Storybook arguments
+   * @returns {TemplateResult<1>}
+   */
+  render: (args) => {
+    return html`<clabs-wysiwyg
+      aria-label="WYSIWYG editor with custom toolbar"
+      .content=${args.content}
+      .toolbarOptions=${args.toolbarOptions}></clabs-wysiwyg>`;
+  },
+};

--- a/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
@@ -178,7 +178,7 @@ export const CustomExtensions = {
       <h4>Try It Out</h4>
       <p>Select some text and click the <strong>Highlight</strong> button (yellow marker icon) in the toolbar to see the <mark>custom extension</mark> in action!</p>
       
-      <p>See the <strong>Docs</strong> tab for complete usage examples and how to add your own custom extensions with Carbon element styles.</p>
+      <p>See the <strong>Docs</strong> tab for complete usage examples and how to add your own custom extensions.</p>
     `,
     extensions: [HighlightExtension],
   },

--- a/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
@@ -1,0 +1,233 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '../components/wysiwyg/wysiwyg';
+import { html } from 'lit';
+import { ref } from 'lit/directives/ref.js';
+import Time16 from '@carbon/icons/es/time/16.js';
+import Edit16 from '@carbon/icons/es/edit/16.js';
+import ChartBar16 from '@carbon/icons/es/chart--bar/16.js';
+import TextClearFormat16 from '@carbon/icons/es/text--clear-format/16.js';
+import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
+
+/**
+ * Render clear formatting button
+ * @param {Editor | null} editor - Editor instance
+ * @returns {TemplateResult} Button template
+ */
+const renderClearFormattingButton = (editor) => html`
+  <cds-icon-button
+    size="md"
+    autoalign
+    kind="ghost"
+    enter-delay-ms="100"
+    leave-delay-ms="100"
+    align="top"
+    @click=${() => {
+      editor?.chain().focus().clearNodes().unsetAllMarks().run();
+    }}>
+    ${iconLoader(TextClearFormat16, { slot: 'icon' })}
+    <span slot="tooltip-content">Clear Formatting</span>
+  </cds-icon-button>
+`;
+
+/**
+ * Render timestamp button
+ * @param {Editor | null} editor - Editor instance
+ * @returns {TemplateResult} Button template
+ */
+const renderTimestampButton = (editor) => html`
+  <cds-icon-button
+    size="md"
+    autoalign
+    kind="ghost"
+    enter-delay-ms="100"
+    leave-delay-ms="100"
+    align="top"
+    @click=${() => {
+      const timestamp = new Date().toLocaleString();
+      editor
+        ?.chain()
+        .focus()
+        .insertContent(`<p><em>Timestamp: ${timestamp}</em></p>`)
+        .run();
+    }}>
+    ${iconLoader(Time16, { slot: 'icon' })}
+    <span slot="tooltip-content">Insert Timestamp</span>
+  </cds-icon-button>
+`;
+
+/**
+ * Render signature button
+ * @param {Editor | null} editor - Editor instance
+ * @returns {TemplateResult} Button template
+ */
+const renderSignatureButton = (editor) => html`
+  <cds-icon-button
+    size="md"
+    autoalign
+    kind="ghost"
+    enter-delay-ms="100"
+    leave-delay-ms="100"
+    align="top"
+    @click=${() => {
+      const signature = `<hr><p><strong>Best regards,</strong><br>Your Name</p>`;
+      editor?.chain().focus().insertContent(signature).run();
+    }}>
+    ${iconLoader(Edit16, { slot: 'icon' })}
+    <span slot="tooltip-content">Insert Signature</span>
+  </cds-icon-button>
+`;
+
+/**
+ * Render statistics button
+ * @param {Editor | null} editor - Editor instance
+ * @returns {TemplateResult} Button template
+ */
+const renderStatisticsButton = (editor) => html`
+  <cds-icon-button
+    size="md"
+    autoalign
+    kind="ghost"
+    enter-delay-ms="100"
+    leave-delay-ms="100"
+    align="top"
+    @click=${() => {
+      if (!editor) {
+        console.warn('Editor instance not available');
+        return;
+      }
+      const content = editor.getHTML();
+      const stats = {
+        characters: content.replace(/<[^>]*>/g, '').length,
+        words: content
+          .replace(/<[^>]*>/g, '')
+          .trim()
+          .split(/\s+/)
+          .filter(Boolean).length,
+        paragraphs: (content.match(/<p>/g) || []).length,
+      };
+      alert(
+        `Editor Statistics:\n\nCharacters: ${stats.characters}\nWords: ${stats.words}\nParagraphs: ${stats.paragraphs}`
+      );
+    }}>
+    ${iconLoader(ChartBar16, { slot: 'icon' })}
+    <span slot="tooltip-content">Show Statistics</span>
+  </cds-icon-button>
+`;
+
+export default {
+  title: 'Components/Wysiwyg',
+  component: 'clabs-wysiwyg',
+  parameters: {
+    docs: {
+      story: {
+        name: 'Custom Extensions',
+      },
+    },
+  },
+};
+
+/**
+ * Story demonstrating custom extension points
+ */
+export const CustomExtensions = {
+  args: {
+    content: `
+      <h3>Custom Extension Points</h3>
+      <p>This story demonstrates the extension API. Custom toolbar groups can be defined in <code>toolbarOptions</code>:</p>
+      <ul>
+        <li><strong>'custom-actions':</strong> Clear Formatting button (after clipboard)</li>
+        <li><strong>'custom-inserts':</strong> Timestamp and Signature buttons (before insert)</li>
+        <li><strong>'custom-utilities':</strong> Statistics button (at the end)</li>
+      </ul>
+      <p>Simply add custom group objects to <code>toolbarOptions</code> array to control their position:</p>
+      <pre><code>toolbarOptions: [
+  { name: 'clipboard' },
+  {
+    id: 'custom-actions',
+    items: [{ id: 'clear-formatting', render: (editor) => ... }]
+  },
+  { name: 'textFormatting' },
+  ...
+]</code></pre>
+      <p>The editor instance is passed to each custom item's render function, allowing direct access to TipTap methods.</p>
+      <p>Custom buttons participate in roving tab navigation and match internal button styling.</p>
+      <p>Try using the custom buttons in the toolbar above!</p>
+    `,
+  },
+
+  /**
+   * Renders the template for Storybook
+   * @param {object} args Storybook arguments
+   * @returns {TemplateResult<1>}
+   */
+  render: (args) => {
+    // Define toolbar options with custom groups
+    const toolbarOptions = [
+      { name: 'clipboard', enabled: true },
+      // Custom group after clipboard
+      {
+        id: 'custom-actions',
+        items: [
+          {
+            id: 'clear-formatting',
+            render: renderClearFormattingButton,
+          },
+        ],
+      },
+      { name: 'fontFamily', enabled: true },
+      { name: 'textFormatting', enabled: true },
+      { name: 'headings', enabled: true },
+      { name: 'colorPicker', enabled: true },
+      { name: 'lists', enabled: true },
+      { name: 'alignment', enabled: true },
+      { name: 'blocks', enabled: true },
+      // Custom group before insert
+      {
+        id: 'custom-inserts',
+        items: [
+          {
+            id: 'insert-timestamp',
+            render: renderTimestampButton,
+          },
+          {
+            id: 'insert-signature',
+            render: renderSignatureButton,
+          },
+        ],
+      },
+      { name: 'insert', enabled: true },
+      { name: 'search', enabled: true },
+      { name: 'tableOperations', enabled: true },
+      // Custom group at the end
+      {
+        id: 'custom-utilities',
+        items: [
+          {
+            id: 'show-stats',
+            render: renderStatisticsButton,
+          },
+        ],
+      },
+    ];
+
+    return html`<clabs-wysiwyg
+      ${ref((el) => {
+        if (el) {
+          el.updateComplete.then(() => {
+            console.log('Editor instance:', el.editor);
+          });
+        }
+      })}
+      aria-label="WYSIWYG editor with custom extensions"
+      .content=${args.content}
+      .toolbarOptions=${toolbarOptions}></clabs-wysiwyg>`;
+  },
+};

--- a/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
@@ -10,43 +10,13 @@
 import '../components/wysiwyg/wysiwyg';
 import { html } from 'lit';
 import { ref } from 'lit/directives/ref.js';
-import { Mark } from '@tiptap/core';
 import Time16 from '@carbon/icons/es/time/16.js';
 import Edit16 from '@carbon/icons/es/edit/16.js';
 import ChartBar16 from '@carbon/icons/es/chart--bar/16.js';
 import TextClearFormat16 from '@carbon/icons/es/text--clear-format/16.js';
 import TextHighlight16 from '@carbon/icons/es/text--highlight/16.js';
 import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
-
-// Create a custom TipTap extension for highlighting
-const HighlightExtension = Mark.create({
-  name: 'highlight',
-  parseHTML() {
-    return [{ tag: 'mark' }];
-  },
-  renderHTML({ HTMLAttributes }) {
-    return ['mark', HTMLAttributes, 0];
-  },
-  addCommands() {
-    return {
-      /**
-       * Toggle highlight mark
-       */
-      toggleHighlight:
-        () =>
-        ({ commands }) =>
-          commands.toggleMark(this.name),
-    };
-  },
-});
-
-// Add styles property to the extension
-HighlightExtension.styles = `
-  .ProseMirror mark {
-    background-color: #fddc69;
-    padding-inline: 0.125rem;
-  }
-`;
+import { HighlightExtension } from './story-utils.js';
 
 /**
  * Render clear formatting button
@@ -206,7 +176,7 @@ export const CustomExtensions = {
       </ul>
       
       <h4>Try It Out</h4>
-      <p>Select some text and click the <strong>Highlight</strong> button (yellow marker icon) in the toolbar to see the custom extension with <mark style="background-color: #ffd700; padding: 2px 4px; border-radius: 2px;">custom styling</mark> in action!</p>
+      <p>Select some text and click the <strong>Highlight</strong> button (yellow marker icon) in the toolbar to see the <mark>custom extension</mark> in action!</p>
       
       <p>See the <strong>Docs</strong> tab for complete usage examples and how to add your own custom extensions with Carbon element styles.</p>
     `,

--- a/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
@@ -10,11 +10,35 @@
 import '../components/wysiwyg/wysiwyg';
 import { html } from 'lit';
 import { ref } from 'lit/directives/ref.js';
+import { Mark } from '@tiptap/core';
 import Time16 from '@carbon/icons/es/time/16.js';
 import Edit16 from '@carbon/icons/es/edit/16.js';
 import ChartBar16 from '@carbon/icons/es/chart--bar/16.js';
 import TextClearFormat16 from '@carbon/icons/es/text--clear-format/16.js';
+import TextHighlight16 from '@carbon/icons/es/text--highlight/16.js';
 import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
+
+// Create a custom TipTap extension for highlighting
+const HighlightExtension = Mark.create({
+  name: 'highlight',
+  parseHTML() {
+    return [{ tag: 'mark' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['mark', HTMLAttributes, 0];
+  },
+  addCommands() {
+    return {
+      /**
+       * Toggle highlight mark
+       */
+      toggleHighlight:
+        () =>
+        ({ commands }) =>
+          commands.toggleMark(this.name),
+    };
+  },
+});
 
 /**
  * Render clear formatting button
@@ -135,32 +159,92 @@ export default {
 };
 
 /**
- * Story demonstrating custom extension points
+ * Render highlight button (uses custom TipTap extension)
+ * @param {Editor | null} editor - Editor instance
+ * @returns {TemplateResult} Button template
+ */
+const renderHighlightButton = (editor) => html`
+  <cds-icon-button
+    size="md"
+    autoalign
+    kind="ghost"
+    enter-delay-ms="100"
+    leave-delay-ms="100"
+    align="top"
+    @click=${() => {
+      editor?.chain().focus().toggleHighlight().run();
+    }}>
+    ${iconLoader(TextHighlight16, { slot: 'icon' })}
+    <span slot="tooltip-content">Toggle Highlight</span>
+  </cds-icon-button>
+`;
+
+/**
+ * Story demonstrating both custom toolbar buttons AND custom TipTap extensions
  */
 export const CustomExtensions = {
   args: {
     content: `
-      <h3>Custom Extension Points</h3>
-      <p>This story demonstrates the extension API. Custom toolbar groups can be defined in <code>toolbarOptions</code>:</p>
+      <h3>Custom Extensions</h3>
+      <p>This story demonstrates both types of extensibility:</p>
+      
+      <h4>1. Custom Toolbar Buttons</h4>
+      <p>Add custom buttons to the toolbar via the <code>toolbarOptions</code> property. Each custom group can contain multiple button items with custom render functions:</p>
       <ul>
-        <li><strong>'custom-actions':</strong> Clear Formatting button (after clipboard)</li>
-        <li><strong>'custom-inserts':</strong> Timestamp and Signature buttons (before insert)</li>
-        <li><strong>'custom-utilities':</strong> Statistics button (at the end)</li>
+        <li><strong>Clear Formatting:</strong> Removes all formatting from selected text</li>
+        <li><strong>Insert Timestamp:</strong> Adds current date/time to the document</li>
+        <li><strong>Insert Signature:</strong> Adds a signature block</li>
+        <li><strong>Show Statistics:</strong> Displays word/character count</li>
+        <li><strong>Toggle Highlight:</strong> Uses custom TipTap extension (see below)</li>
       </ul>
-      <p>Simply add custom group objects to <code>toolbarOptions</code> array to control their position:</p>
-      <pre><code>toolbarOptions: [
+      
+      <h4>2. Custom TipTap Extensions</h4>
+      <p>Add TipTap extensions via the <code>.extensions</code> property. This example includes a <strong>Highlight</strong> extension that renders <mark>highlighted text</mark> using Carbon element styles for marked-text.</p>
+      
+      <h4>Complete Usage Example:</h4>
+      <pre><code>import { Mark } from '@tiptap/core';
+
+// 1. Create custom TipTap extension
+const Highlight = Mark.create({
+  name: 'highlight',
+  parseHTML() { return [{ tag: 'mark' }]; },
+  renderHTML() { return ['mark', {}, 0]; },
+  addCommands() {
+    return {
+      toggleHighlight: () => ({ commands }) =>
+        commands.toggleMark(this.name)
+    };
+  },
+});
+
+// 2. Define custom toolbar buttons
+const toolbarOptions = [
   { name: 'clipboard' },
   {
     id: 'custom-actions',
-    items: [{ id: 'clear-formatting', render: (editor) => ... }]
+    items: [{
+      id: 'highlight',
+      render: (editor) => html\`
+        <cds-icon-button
+          @click=\${() => editor?.chain().focus().toggleHighlight().run()}>
+          ...
+        </cds-icon-button>
+      \`
+    }]
   },
-  { name: 'textFormatting' },
   ...
-]</code></pre>
-      <p>The editor instance is passed to each custom item's render function, allowing direct access to TipTap methods.</p>
-      <p>Custom buttons participate in roving tab navigation and match internal button styling.</p>
-      <p>Try using the custom buttons in the toolbar above!</p>
+];
+
+// 3. Use both together
+<clabs-wysiwyg
+  .extensions=\${[Highlight]}
+  .toolbarOptions=\${toolbarOptions}>
+</clabs-wysiwyg></code></pre>
+      
+      <p>Try the custom buttons in the toolbar above! The Highlight button uses the custom TipTap extension.</p>
+      <p>Learn more about TipTap extensions: <a href="https://tiptap.dev/docs/editor/extensions/overview" target="_blank" rel="noopener noreferrer">TipTap Extensions Overview</a></p>
     `,
+    extensions: [HighlightExtension],
   },
 
   /**
@@ -211,6 +295,10 @@ export const CustomExtensions = {
         id: 'custom-utilities',
         items: [
           {
+            id: 'highlight',
+            render: renderHighlightButton,
+          },
+          {
             id: 'show-stats',
             render: renderStatisticsButton,
           },
@@ -222,12 +310,14 @@ export const CustomExtensions = {
       ${ref((el) => {
         if (el) {
           el.updateComplete.then(() => {
-            console.log('Editor instance:', el.editor);
+            console.log('Editor instance:', el.editorInstance);
+            console.log('Custom extensions:', args.extensions);
           });
         }
       })}
       aria-label="WYSIWYG editor with custom extensions"
       .content=${args.content}
+      .extensions=${args.extensions}
       .toolbarOptions=${toolbarOptions}></clabs-wysiwyg>`;
   },
 };

--- a/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
@@ -40,6 +40,14 @@ const HighlightExtension = Mark.create({
   },
 });
 
+// Add styles property to the extension
+HighlightExtension.styles = `
+  .ProseMirror mark {
+    background-color: #fddc69;
+    padding-inline: 0.125rem;
+  }
+`;
+
 /**
  * Render clear formatting button
  * @param {Editor | null} editor - Editor instance
@@ -180,69 +188,27 @@ const renderHighlightButton = (editor) => html`
 `;
 
 /**
- * Story demonstrating both custom toolbar buttons AND custom TipTap extensions
+ * Story demonstrating custom toolbar buttons and TipTap extensions with styles
  */
 export const CustomExtensions = {
   args: {
     content: `
-      <h3>Custom Extensions</h3>
-      <p>This story demonstrates both types of extensibility:</p>
+      <h3>Custom Extensions Demo</h3>
+      <p>This story demonstrates custom extensibility:</p>
       
-      <h4>1. Custom Toolbar Buttons</h4>
-      <p>Add custom buttons to the toolbar via the <code>toolbarOptions</code> property. Each custom group can contain multiple button items with custom render functions:</p>
+      <h4>Custom Toolbar Buttons</h4>
       <ul>
         <li><strong>Clear Formatting:</strong> Removes all formatting from selected text</li>
         <li><strong>Insert Timestamp:</strong> Adds current date/time to the document</li>
         <li><strong>Insert Signature:</strong> Adds a signature block</li>
         <li><strong>Show Statistics:</strong> Displays word/character count</li>
-        <li><strong>Toggle Highlight:</strong> Uses custom TipTap extension (see below)</li>
+        <li><strong>Toggle Highlight:</strong> Uses custom TipTap extension with custom styles</li>
       </ul>
       
-      <h4>2. Custom TipTap Extensions</h4>
-      <p>Add TipTap extensions via the <code>.extensions</code> property. This example includes a <strong>Highlight</strong> extension that renders <mark>highlighted text</mark> using Carbon element styles for marked-text.</p>
+      <h4>Try It Out</h4>
+      <p>Select some text and click the <strong>Highlight</strong> button (yellow marker icon) in the toolbar to see the custom extension with <mark style="background-color: #ffd700; padding: 2px 4px; border-radius: 2px;">custom styling</mark> in action!</p>
       
-      <h4>Complete Usage Example:</h4>
-      <pre><code>import { Mark } from '@tiptap/core';
-
-// 1. Create custom TipTap extension
-const Highlight = Mark.create({
-  name: 'highlight',
-  parseHTML() { return [{ tag: 'mark' }]; },
-  renderHTML() { return ['mark', {}, 0]; },
-  addCommands() {
-    return {
-      toggleHighlight: () => ({ commands }) =>
-        commands.toggleMark(this.name)
-    };
-  },
-});
-
-// 2. Define custom toolbar buttons
-const toolbarOptions = [
-  { name: 'clipboard' },
-  {
-    id: 'custom-actions',
-    items: [{
-      id: 'highlight',
-      render: (editor) => html\`
-        <cds-icon-button
-          @click=\${() => editor?.chain().focus().toggleHighlight().run()}>
-          ...
-        </cds-icon-button>
-      \`
-    }]
-  },
-  ...
-];
-
-// 3. Use both together
-<clabs-wysiwyg
-  .extensions=\${[Highlight]}
-  .toolbarOptions=\${toolbarOptions}>
-</clabs-wysiwyg></code></pre>
-      
-      <p>Try the custom buttons in the toolbar above! The Highlight button uses the custom TipTap extension.</p>
-      <p>Learn more about TipTap extensions: <a href="https://tiptap.dev/docs/editor/extensions/overview" target="_blank" rel="noopener noreferrer">TipTap Extensions Overview</a></p>
+      <p>See the <strong>Docs</strong> tab for complete usage examples and how to add your own custom extensions with Carbon element styles.</p>
     `,
     extensions: [HighlightExtension],
   },

--- a/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/03-CustomExtensions.stories.js
@@ -177,8 +177,8 @@ export const CustomExtensions = {
       
       <h4>Try It Out</h4>
       <p>Select some text and click the <strong>Highlight</strong> button (yellow marker icon) in the toolbar to see the <mark>custom extension</mark> in action!</p>
-      
       <p>See the <strong>Docs</strong> tab for complete usage examples and how to add your own custom extensions.</p>
+      <p>Learn more about TipTap extensions at <a href="https://tiptap.dev/docs/editor/extensions/overview" target="_blank">https://tiptap.dev/docs/editor/extensions/overview</a>.</p>
     `,
     extensions: [HighlightExtension],
   },

--- a/packages/web-components/src/components/wysiwyg/__stories__/_story-utils.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/_story-utils.js
@@ -1,0 +1,213 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { DEFAULT_GROUP_ORDER } from '../components/wysiwyg/src/wysiwyg.template';
+
+/**
+ * Generate toolbar options in the correct order based on DEFAULT_GROUP_ORDER
+ */
+export const generateToolbarOptions = () => {
+  const toolbarConfig = {
+    clipboard: {
+      name: 'clipboard',
+      enabled: true,
+      items: {
+        cut: true,
+        copy: true,
+        paste: true,
+      },
+    },
+    fontFamily: { name: 'fontFamily', enabled: true },
+    textFormatting: {
+      name: 'textFormatting',
+      enabled: true,
+      items: {
+        bold: true,
+        italic: true,
+        underline: true,
+        strikethrough: true,
+        code: true,
+      },
+    },
+    blocks: {
+      name: 'blocks',
+      enabled: true,
+      items: {
+        blockquote: true,
+        codeBlock: true,
+      },
+    },
+    headings: { name: 'headings', enabled: true },
+    colorPicker: { name: 'colorPicker', enabled: true },
+    lists: {
+      name: 'lists',
+      enabled: true,
+      items: {
+        bulletList: true,
+        numberedList: true,
+        taskList: true,
+        outdent: true,
+        indent: true,
+      },
+    },
+    alignment: {
+      name: 'alignment',
+      enabled: true,
+      items: {
+        left: true,
+        center: true,
+        right: true,
+        justify: true,
+      },
+    },
+    insert: {
+      name: 'insert',
+      enabled: true,
+      items: {
+        table: true,
+        link: true,
+        image: true,
+        attachment: true,
+      },
+    },
+    search: { name: 'search', enabled: true },
+    tableOperations: { name: 'tableOperations', enabled: true },
+  };
+
+  // Return toolbar options in the order defined by DEFAULT_GROUP_ORDER
+  return DEFAULT_GROUP_ORDER.map((groupName) => toolbarConfig[groupName]);
+};
+
+/**
+ * Demo content showcasing all editor features
+ */
+export const demoContent = `
+  <h1>WYSIWYG Editor Demo</h1>
+  <p>This demo showcases the Carbon Design System text toolbar pattern features.</p>
+  
+  <h2>Text Formatting</h2>
+  <p>
+    Inline formatting: <strong>bold</strong>, <em>italic</em>, <u>underline</u>,
+    <s>strikethrough</s>, and <code>code</code>.
+  </p>
+  
+  <h2>Theme Colors</h2>
+  <p><span style="color: var(--cds-text-primary);">Primary</span> |
+  <span style="color: var(--cds-text-secondary);">Secondary</span> |
+  <span style="color: var(--cds-link-primary);">Link</span> |
+  <span style="color: var(--cds-support-success);">Success</span> |
+  <span style="color: var(--cds-support-error);">Error</span> |
+  <span style="color: var(--cds-support-warning);">Warning</span></p>
+  
+  <h2>Headings</h2>
+  <h3>Heading 3</h3>
+  <h4>Heading 4</h4>
+  <h5>Heading 5</h5>
+  <h6>Heading 6</h6>
+  
+  <h2>Lists</h2>
+  <ul>
+    <li>Bulleted item with <strong>bold</strong></li>
+    <li>Nested list:
+      <ul>
+        <li>Nested item</li>
+      </ul>
+    </li>
+  </ul>
+  
+  <ol>
+    <li>Numbered item</li>
+    <li>Another item</li>
+  </ol>
+  
+  <p><em>Use the toolbar to add task list items below:</em></p>
+  <ul data-type="taskList"></ul>
+  
+  <h2>Alignment</h2>
+  <p style="text-align: left;">Left aligned (default)</p>
+  <p style="text-align: center;">Center aligned</p>
+  <p style="text-align: right;">Right aligned</p>
+  <p style="text-align: justify;">Justified text spreads content to align with both margins, creating uniform edges commonly used in formal documents.</p>
+  
+  <h2>Links & Media</h2>
+  <p>Visit <a href="https://carbondesignsystem.com" target="_blank" rel="noopener noreferrer">Carbon Design System</a> for more information.</p>
+  
+  <p>
+    <img src="https://placehold.co/640x240/72ffbc/000000/png?text=Demo+Image" alt="Demo image" />
+  </p>
+  
+  <h2>Blockquote</h2>
+  <blockquote>
+    The Carbon text toolbar pattern provides comprehensive tools for rich text editing.
+  </blockquote>
+  
+  <h2>Code</h2>
+  <p>Use <code>clabs-wysiwyg</code> to add rich text editing to your app.</p>
+  
+  <pre><code>const editor = document.querySelector('clabs-wysiwyg')</code></pre>
+  
+  <h2>Table</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Feature</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Text Formatting</td>
+        <td>✓ Supported</td>
+      </tr>
+      <tr>
+        <td>Lists</td>
+        <td>✓ Supported</td>
+      </tr>
+      <tr>
+        <td>Tables</td>
+        <td>✓ Supported</td>
+      </tr>
+    </tbody>
+  </table>
+`;
+
+/**
+ * Checks if editor content is empty (only whitespace or empty tags)
+ * @param {string} content HTML content string
+ * @returns {boolean} True if content is empty
+ */
+export const isContentEmpty = (content) => {
+  if (!content) {
+    return true;
+  }
+  // Remove HTML tags and check if remaining text is empty
+  const textContent = content.replace(/<[^>]*>/g, '').trim();
+  return textContent.length === 0;
+};
+
+/**
+ * Updates button visibility based on editor content
+ * @param {HTMLElement} form The form element containing the buttons
+ * @param {boolean} isEmpty Whether the editor content is empty
+ */
+export const updateButtonVisibility = (form, isEmpty) => {
+  const setButton = form?.querySelector('[data-action="set-content"]');
+  const sendButton = form?.querySelector('[data-action="send"]');
+  const discardButton = form?.querySelector('[data-action="discard"]');
+
+  if (setButton) {
+    setButton.style.display = isEmpty ? 'inline-block' : 'none';
+  }
+  if (sendButton) {
+    sendButton.style.display = isEmpty ? 'none' : 'inline-block';
+  }
+  if (discardButton) {
+    discardButton.style.display = isEmpty ? 'none' : 'inline-block';
+  }
+};

--- a/packages/web-components/src/components/wysiwyg/__stories__/story-utils.js
+++ b/packages/web-components/src/components/wysiwyg/__stories__/story-utils.js
@@ -7,7 +7,46 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { Mark } from '@tiptap/core';
 import { DEFAULT_GROUP_ORDER } from '../components/wysiwyg/src/wysiwyg.template';
+
+/**
+ * Custom TipTap extension for highlighting text with custom styles
+ * Demonstrates how to create an extension with user-defined styles
+ */
+export const HighlightExtension = Object.assign(
+  Mark.create({
+    name: 'highlight',
+    parseHTML() {
+      return [{ tag: 'mark' }];
+    },
+    renderHTML({ HTMLAttributes }) {
+      return ['mark', HTMLAttributes, 0];
+    },
+    addCommands() {
+      return {
+        /**
+         * Toggle highlight mark
+         */
+        toggleHighlight:
+          () =>
+          ({ commands }) =>
+            commands.toggleMark(this.name),
+      };
+    },
+  }),
+  {
+    // Use a more specific selector to override Carbon element styles. uncomment below to see.
+    // styles: `
+    //   .clabs--wysiwyg__editor-content .ProseMirror mark {
+    //     background-color: var(--cds-tag-background-green);
+    //     color: var(--cds-tag-color-green);
+    //     border-block-end: 1px dashed;
+    //     padding: 0;
+    //   }
+    // `,
+  }
+);
 
 /**
  * Generate toolbar options in the correct order based on DEFAULT_GROUP_ORDER

--- a/packages/web-components/src/components/wysiwyg/__stories__/wysiwyg.mdx
+++ b/packages/web-components/src/components/wysiwyg/__stories__/wysiwyg.mdx
@@ -1,0 +1,542 @@
+import { ArgTypes, Canvas, Markdown, Meta } from '@storybook/addon-docs/blocks';
+import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
+import * as DefaultStories from './01-Default.stories';
+import packageJson from '../package.json';
+
+<Meta of={DefaultStories} name="Docs" />
+
+# WYSIWYG Editor
+
+- **Initiative owner(s):** Nandan Devadula
+- **Status:** Draft
+- **Target library:** Carbon Labs Web Components
+- **Target library maintainer(s) / PR Reviewer(s):** Nandan Devadula
+- **Support channel:** `#carbon-labs`
+
+> 💡 Check our
+> [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-labs/tree/main/examples/web-components/wysiwyg)
+> example implementation.
+
+[![Edit carbon-labs](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-labs/tree/main/examples/web-components/wysiwyg)
+
+## Overview
+
+> **Problem statement:** Carbon Design System lacks a rich text editor component
+> or an example that provides a consistent, accessible WYSIWYG editing
+> experience integrated with Carbon's design language and component ecosystem.
+
+The WYSIWYG (What You See Is What You Get) component fills the gap for rich text
+editing capabilities within Carbon applications. It addresses the need for users
+to create and edit formatted content with a visual interface, supporting common
+text formatting, lists, tables, images, and links.
+
+This component is built on top of open source TipTap editor and extensions along
+with Carbon Design System primitives. While Carbon provides form inputs and text
+areas for plain text, this component extends that capability to structured,
+formatted content editing.
+
+- [TipTap Core](https://tiptap.dev/docs/editor/getting-started/overview)
+- [Open source Extensions](https://tiptap.dev/docs/editor/extensions/overview?filter=opensource)
+
+**Key features:**
+
+- Text formatting (bold, italic, underline, strikethrough, code)
+- Headings (H1, H2, H3, H4, H5, H6) and paragraphs
+- Lists (bulleted and numbered)
+- Text alignment (left, center, right)
+- Block elements (blockquotes, code blocks)
+- Tables with full editing capabilities
+- Links and images
+- Undo/redo functionality
+- Full keyboard navigation support
+
+## Keyboard Shortcuts
+
+The WYSIWYG editor supports comprehensive keyboard shortcuts for efficient
+editing.
+
+### Text Formatting
+
+<table>
+  <thead>
+    <tr>
+      <th>Mac</th>
+      <th>Windows/Linux</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>Cmd + B</code>
+      </td>
+      <td>
+        <code>Ctrl + B</code>
+      </td>
+      <td>Bold text</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + I</code>
+      </td>
+      <td>
+        <code>Ctrl + I</code>
+      </td>
+      <td>Italic text</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + U</code>
+      </td>
+      <td>
+        <code>Ctrl + U</code>
+      </td>
+      <td>Underline text</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Shift + X</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + X</code>
+      </td>
+      <td>Strikethrough</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + E</code>
+      </td>
+      <td>
+        <code>Ctrl + E</code>
+      </td>
+      <td>Inline code</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Shift + C</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + C</code>
+      </td>
+      <td>Code block</td>
+    </tr>
+  </tbody>
+</table>
+
+### Headings
+
+<table>
+  <thead>
+    <tr>
+      <th>Mac</th>
+      <th>Windows/Linux</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>Cmd + Option + 1</code>
+      </td>
+      <td>
+        <code>Ctrl + Alt + 1</code>
+      </td>
+      <td>Heading 1</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Option + 2</code>
+      </td>
+      <td>
+        <code>Ctrl + Alt + 2</code>
+      </td>
+      <td>Heading 2</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Option + 3</code>
+      </td>
+      <td>
+        <code>Ctrl + Alt + 3</code>
+      </td>
+      <td>Heading 3</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Option + 4</code>
+      </td>
+      <td>
+        <code>Ctrl + Alt + 4</code>
+      </td>
+      <td>Heading 4</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Option + 5</code>
+      </td>
+      <td>
+        <code>Ctrl + Alt + 5</code>
+      </td>
+      <td>Heading 5</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Option + 6</code>
+      </td>
+      <td>
+        <code>Ctrl + Alt + 6</code>
+      </td>
+      <td>Heading 6</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Option + 0</code>
+      </td>
+      <td>
+        <code>Ctrl + Alt + 0</code>
+      </td>
+      <td>Paragraph</td>
+    </tr>
+  </tbody>
+</table>
+
+### Lists
+
+<table>
+  <thead>
+    <tr>
+      <th>Mac</th>
+      <th>Windows/Linux</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>Cmd + Shift + 8</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + 8</code>
+      </td>
+      <td>Bullet list</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Shift + 7</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + 7</code>
+      </td>
+      <td>Numbered list</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Shift + 9</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + 9</code>
+      </td>
+      <td>Task list</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Tab</code>
+      </td>
+      <td>
+        <code>Tab</code>
+      </td>
+      <td>Indent list item</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Shift + Tab</code>
+      </td>
+      <td>
+        <code>Shift + Tab</code>
+      </td>
+      <td>Outdent list item</td>
+    </tr>
+  </tbody>
+</table>
+
+### Text Alignment
+
+<table>
+  <thead>
+    <tr>
+      <th>Mac</th>
+      <th>Windows/Linux</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>Cmd + Shift + L</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + L</code>
+      </td>
+      <td>Align left</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Shift + E</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + E</code>
+      </td>
+      <td>Align center</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Shift + R</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + R</code>
+      </td>
+      <td>Align right</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Shift + J</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + J</code>
+      </td>
+      <td>Justify</td>
+    </tr>
+  </tbody>
+</table>
+
+### Blocks
+
+<table>
+  <thead>
+    <tr>
+      <th>Mac</th>
+      <th>Windows/Linux</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>Cmd + Shift + B</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + B</code>
+      </td>
+      <td>Blockquote</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Enter</code>
+      </td>
+      <td>
+        <code>Ctrl + Enter</code>
+      </td>
+      <td>Hard break</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--- + Space</code>
+      </td>
+      <td>
+        <code>--- + Space</code>
+      </td>
+      <td>Horizontal rule</td>
+    </tr>
+  </tbody>
+</table>
+
+### Editing
+
+<table>
+  <thead>
+    <tr>
+      <th>Mac</th>
+      <th>Windows/Linux</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>Cmd + Z</code>
+      </td>
+      <td>
+        <code>Ctrl + Z</code>
+      </td>
+      <td>Undo</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Shift + Z</code>
+      </td>
+      <td>
+        <code>Ctrl + Shift + Z</code>
+      </td>
+      <td>Redo</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + Y</code>
+      </td>
+      <td>
+        <code>Ctrl + Y</code>
+      </td>
+      <td>Redo (alternative)</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + X</code>
+      </td>
+      <td>
+        <code>Ctrl + X</code>
+      </td>
+      <td>Cut</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + C</code>
+      </td>
+      <td>
+        <code>Ctrl + C</code>
+      </td>
+      <td>Copy</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + V</code>
+      </td>
+      <td>
+        <code>Ctrl + V</code>
+      </td>
+      <td>Paste</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Cmd + A</code>
+      </td>
+      <td>
+        <code>Ctrl + A</code>
+      </td>
+      <td>Select all</td>
+    </tr>
+  </tbody>
+</table>
+
+### Toolbar Navigation
+
+<table>
+  <thead>
+    <tr>
+      <th>Shortcut</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>Arrow Left</code>
+      </td>
+      <td>Move focus to previous toolbar button</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Arrow Right</code>
+      </td>
+      <td>Move focus to next toolbar button</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Home</code>
+      </td>
+      <td>Move focus to first toolbar button</td>
+    </tr>
+    <tr>
+      <td>
+        <code>End</code>
+      </td>
+      <td>Move focus to last toolbar button</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Enter</code> or <code>Space</code>
+      </td>
+      <td>Activate focused toolbar button</td>
+    </tr>
+  </tbody>
+</table>
+
+**Note:** Toolbar navigation automatically skips disabled buttons (e.g.,
+Undo/Redo when unavailable).
+
+### Markdown Shortcuts
+
+The editor also supports common Markdown shortcuts:
+
+- Type `#` + `Space` for Heading 1
+- Type `##` + `Space` for Heading 2
+- Type `###` + `Space` for Heading 3 (and so on)
+- Type `*` or `-` + `Space` for bullet list
+- Type `1.` + `Space` for numbered list
+- Type `[ ]` + `Space` for task list
+- Type `` ` `` + text + `` ` `` for inline code
+- Type `>` + `Space` for blockquote
+
+## Getting started
+
+Here's a quick example to get you started.
+
+### JS (via import)
+
+```javascript
+import '@carbon-labs/wc-wysiwyg/es/index.js';
+```
+
+### Styles
+
+You'll also need to import the theming tokens from `@carbon/styles` either from
+npm or from our CDN helpers. Checkout our Stackblitz example above to see how
+that is implemented.
+
+<Markdown>{`${cdnJs({ components: ['wysiwyg'] }, packageJson)}`}</Markdown>
+<Markdown>{`${cdnCss()}`}</Markdown>
+
+### HTML
+
+```html
+web component supports content property through js
+<clabs-wysiwyg
+  aria-label="WYSIWYG editor"
+  .content="your rich content here"></clabs-wysiwyg>
+```
+
+## Events
+
+The WYSIWYG component dispatches the following custom events:
+
+### `clabs-wysiwyg-on-change`
+
+Fired whenever the editor content changes (typing, formatting, etc.).
+
+**Event detail:**
+
+- `content` (string): The current HTML content of the editor
+- `editor` (Editor): The TipTap editor instance
+
+**Example:**
+
+```javascript
+const editor = document.querySelector('clabs-wysiwyg');
+editor.addEventListener('clabs-wysiwyg-on-change', (event) => {
+  console.log('Content changed:', event.detail.content);
+  console.log('Editor instance:', event.detail.editor);
+});
+```
+
+## Preview
+
+<Canvas of={DefaultStories.Default} />

--- a/packages/web-components/src/components/wysiwyg/__stories__/wysiwyg.mdx
+++ b/packages/web-components/src/components/wysiwyg/__stories__/wysiwyg.mdx
@@ -50,6 +50,10 @@ formatted content editing.
 - Undo/redo functionality
 - Full keyboard navigation support
 
+## Preview
+
+<Canvas of={DefaultStories.Default} />
+
 ## Keyboard Shortcuts
 
 The WYSIWYG editor supports comprehensive keyboard shortcuts for efficient
@@ -350,6 +354,31 @@ editing.
   </tbody>
 </table>
 
+### Tables
+
+<table>
+  <thead>
+    <tr>
+      <th>Shortcut</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>Tab</code>
+      </td>
+      <td>Move to next cell in table</td>
+    </tr>
+    <tr>
+      <td>
+        <code>Shift + Tab</code>
+      </td>
+      <td>Move to previous cell in table</td>
+    </tr>
+  </tbody>
+</table>
+
 ### Editing
 
 <table>
@@ -451,13 +480,13 @@ editing.
     </tr>
     <tr>
       <td>
-        <code>Home</code>
+        <code>Home (coming soon)</code>
       </td>
       <td>Move focus to first toolbar button</td>
     </tr>
     <tr>
       <td>
-        <code>End</code>
+        <code>End (coming soon)</code>
       </td>
       <td>Move focus to last toolbar button</td>
     </tr>
@@ -537,6 +566,73 @@ editor.addEventListener('clabs-wysiwyg-on-change', (event) => {
 });
 ```
 
-## Preview
+## Custom Extensions
 
-<Canvas of={DefaultStories.Default} />
+The WYSIWYG component supports custom TipTap extensions with styles. You can add
+custom functionality and styling by creating TipTap extensions and attaching a
+`styles` property.
+
+### Adding Custom Extensions with Styles
+
+```javascript
+import { Mark } from '@tiptap/core';
+
+// Create custom TipTap extension
+const Highlight = Mark.create({
+  name: 'highlight',
+  parseHTML() {
+    return [{ tag: 'mark' }];
+  },
+  renderHTML() {
+    return ['mark', {}, 0];
+  },
+  addCommands() {
+    return {
+      toggleHighlight:
+        () =>
+        ({ commands }) =>
+          commands.toggleMark(this.name),
+    };
+  },
+});
+
+// Add styles property to extension
+Highlight.styles = `
+  .ProseMirror mark {
+    background-color: #ffd700;
+    padding: 2px 4px;
+    border-radius: 2px;
+  }
+`;
+
+// Use extension with styles
+<clabs-wysiwyg .extensions=${[Highlight]}></clabs-wysiwyg>;
+```
+
+### Using Carbon Element Styles
+
+You can compile SCSS with Carbon element styles and add it to the extension's
+`styles` property:
+
+```scss
+// custom-mark-styles.scss
+@use '@carbon/element-styles/scss/elements/marked-text' as mark;
+
+.ProseMirror {
+  @include mark.styles;
+
+  mark {
+    background-color: #ffd700;
+    padding: 2px 4px;
+  }
+}
+```
+
+```javascript
+// Import and use
+import markStyles from './custom-mark-styles.scss?inline';
+Highlight.styles = markStyles;
+```
+
+**Note:** The component automatically extracts and injects styles from all
+extensions into the shadow DOM.

--- a/packages/web-components/src/components/wysiwyg/__stories__/wysiwyg.mdx
+++ b/packages/web-components/src/components/wysiwyg/__stories__/wysiwyg.mdx
@@ -609,30 +609,5 @@ Highlight.styles = `
 <clabs-wysiwyg .extensions=${[Highlight]}></clabs-wysiwyg>;
 ```
 
-### Using Carbon Element Styles
-
-You can compile SCSS with Carbon element styles and add it to the extension's
-`styles` property:
-
-```scss
-// custom-mark-styles.scss
-@use '@carbon/element-styles/scss/elements/marked-text' as mark;
-
-.ProseMirror {
-  @include mark.styles;
-
-  mark {
-    background-color: #ffd700;
-    padding: 2px 4px;
-  }
-}
-```
-
-```javascript
-// Import and use
-import markStyles from './custom-mark-styles.scss?inline';
-Highlight.styles = markStyles;
-```
-
 **Note:** The component automatically extracts and injects styles from all
 extensions into the shadow DOM.

--- a/packages/web-components/src/components/wysiwyg/__stories__/wysiwyg.mdx
+++ b/packages/web-components/src/components/wysiwyg/__stories__/wysiwyg.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Canvas, Markdown, Meta } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
-import * as DefaultStories from './01-Default.stories';
+import meta, * as DefaultStories from './01-Default.stories';
 import packageJson from '../package.json';
 
-<Meta of={DefaultStories} name="Docs" />
+<Meta of={meta} name="Docs" />
 
 # WYSIWYG Editor
 

--- a/packages/web-components/src/components/wysiwyg/__tests__/__snapshots__/wysiwyg.test.snap.js
+++ b/packages/web-components/src/components/wysiwyg/__tests__/__snapshots__/wysiwyg.test.snap.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots['clabs-wysiwyg should render with cds-button minimum attributes'] =
+  `<clabs-wysiwyg
+  aria-label="test"
+  role="application"
+>
+  dummy content
+</clabs-wysiwyg>
+`;
+/* end snapshot clabs-wysiwyg should render with cds-button minimum attributes */
+
+snapshots['clabs-wysiwyg should render with minimum attributes'] =
+  `<clabs-wysiwyg
+  aria-label="WYSIWYG Editor"
+  role="application"
+>
+  dummy content
+</clabs-wysiwyg>
+`;
+/* end snapshot clabs-wysiwyg should render with minimum attributes */

--- a/packages/web-components/src/components/wysiwyg/__tests__/wysiwyg.test.js
+++ b/packages/web-components/src/components/wysiwyg/__tests__/wysiwyg.test.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html, fixture, expect } from '@open-wc/testing';
+import '@carbon-labs/wc-wysiwyg/es/index.js';
+
+describe('clabs-wysiwyg', function () {
+  it('should render with minimum attributes', async () => {
+    const el = await fixture(
+      html`<clabs-wysiwyg aria-label="WYSIWYG Editor">
+        dummy content
+      </clabs-wysiwyg>`
+    );
+
+    await expect(el).dom.to.equalSnapshot();
+    // TODO: fix upstream/implementation a11y
+    // await expect(el).shadowDom.to.be.accessible();
+  });
+});

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_carbon-elements.scss
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_carbon-elements.scss
@@ -22,7 +22,6 @@
 @use '@carbon/element-styles/scss/elements/anchor' as anchor;
 @use '@carbon/element-styles/scss/elements/horizontal-rule' as hr;
 @use '@carbon/element-styles/scss/elements/checkbox' as checkbox;
-@use '@carbon/element-styles/scss/elements/marked-text' as mark;
 
 // Apply Carbon element styles to ProseMirror editor content
 .ProseMirror {
@@ -42,5 +41,4 @@
   @include image.styles;
   @include anchor.styles;
   @include hr.styles;
-  @include mark.styles;
 }

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_carbon-elements.scss
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_carbon-elements.scss
@@ -5,40 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@use '@carbon/element-styles/scss/elements/heading-level-1' as h1;
-@use '@carbon/element-styles/scss/elements/heading-level-2' as h2;
-@use '@carbon/element-styles/scss/elements/heading-level-3' as h3;
-@use '@carbon/element-styles/scss/elements/heading-level-4' as h4;
-@use '@carbon/element-styles/scss/elements/heading-level-5' as h5;
-@use '@carbon/element-styles/scss/elements/heading-level-6' as h6;
-@use '@carbon/element-styles/scss/elements/paragraph' as paragraph;
-@use '@carbon/element-styles/scss/elements/ordered-list' as ol;
-@use '@carbon/element-styles/scss/elements/unordered-list' as ul;
-@use '@carbon/element-styles/scss/elements/block-quotation' as blockquote;
-@use '@carbon/element-styles/scss/elements/code' as code;
-@use '@carbon/element-styles/scss/elements/preformatted' as pre;
-@use '@carbon/element-styles/scss/elements/table' as table;
-@use '@carbon/element-styles/scss/elements/image' as image;
-@use '@carbon/element-styles/scss/elements/anchor' as anchor;
-@use '@carbon/element-styles/scss/elements/horizontal-rule' as hr;
-@use '@carbon/element-styles/scss/elements/checkbox' as checkbox;
+@use '@carbon/element-styles/scss/prebuilt/productive/elements';
 
-// Apply Carbon element styles to ProseMirror editor content
+// Apply all Carbon element styles to ProseMirror editor content
 .ProseMirror {
-  @include h1.styles;
-  @include h2.styles;
-  @include h3.styles;
-  @include h4.styles;
-  @include h5.styles;
-  @include h6.styles;
-  @include paragraph.styles;
-  @include ul.styles;
-  @include ol.styles;
-  @include blockquote.styles;
-  @include code.styles;
-  @include pre.styles;
-  @include table.styles;
-  @include image.styles;
-  @include anchor.styles;
-  @include hr.styles;
+  @include elements.styles;
 }

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_carbon-elements.scss
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_carbon-elements.scss
@@ -1,0 +1,44 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/element-styles/scss/elements/heading-level-1' as h1;
+@use '@carbon/element-styles/scss/elements/heading-level-2' as h2;
+@use '@carbon/element-styles/scss/elements/heading-level-3' as h3;
+@use '@carbon/element-styles/scss/elements/heading-level-4' as h4;
+@use '@carbon/element-styles/scss/elements/heading-level-5' as h5;
+@use '@carbon/element-styles/scss/elements/heading-level-6' as h6;
+@use '@carbon/element-styles/scss/elements/paragraph' as paragraph;
+@use '@carbon/element-styles/scss/elements/ordered-list' as ol;
+@use '@carbon/element-styles/scss/elements/unordered-list' as ul;
+@use '@carbon/element-styles/scss/elements/block-quotation' as blockquote;
+@use '@carbon/element-styles/scss/elements/code' as code;
+@use '@carbon/element-styles/scss/elements/preformatted' as pre;
+@use '@carbon/element-styles/scss/elements/table' as table;
+@use '@carbon/element-styles/scss/elements/image' as image;
+@use '@carbon/element-styles/scss/elements/anchor' as anchor;
+@use '@carbon/element-styles/scss/elements/horizontal-rule' as hr;
+@use '@carbon/element-styles/scss/elements/checkbox' as checkbox;
+
+// Apply Carbon element styles to ProseMirror editor content
+.ProseMirror {
+  @include h1.styles;
+  @include h2.styles;
+  @include h3.styles;
+  @include h4.styles;
+  @include h5.styles;
+  @include h6.styles;
+  @include paragraph.styles;
+  @include ul.styles;
+  @include ol.styles;
+  @include blockquote.styles;
+  @include code.styles;
+  @include pre.styles;
+  @include table.styles;
+  @include image.styles;
+  @include anchor.styles;
+  @include hr.styles;
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_carbon-elements.scss
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_carbon-elements.scss
@@ -22,6 +22,7 @@
 @use '@carbon/element-styles/scss/elements/anchor' as anchor;
 @use '@carbon/element-styles/scss/elements/horizontal-rule' as hr;
 @use '@carbon/element-styles/scss/elements/checkbox' as checkbox;
+@use '@carbon/element-styles/scss/elements/marked-text' as mark;
 
 // Apply Carbon element styles to ProseMirror editor content
 .ProseMirror {
@@ -41,4 +42,5 @@
   @include image.styles;
   @include anchor.styles;
   @include hr.styles;
+  @include mark.styles;
 }

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_overrides.scss
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/_overrides.scss
@@ -1,0 +1,174 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '../../../../../globals/scss/vars' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/element-styles/scss/elements/checkbox' as checkbox;
+
+// Carbon component overrides and customizations
+
+#{$cds-prefix}-icon-button[disabled]::part(button) {
+  color: $text-disabled;
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+// Style the text color icon's bottom bar to match selected color
+#{$cds-prefix}-icon-button.text-color-button svg path:last-child {
+  fill: var(--selected-text-color, $text-primary);
+}
+
+// Font family map for dropdown styling
+$font-families: (
+  'IBM Plex Sans': (
+    'IBM Plex Sans',
+    'Helvetica Neue',
+    Arial,
+    sans-serif,
+  ),
+  'IBM Plex Serif': (
+    'IBM Plex Serif',
+    'Georgia',
+    Times,
+    serif,
+  ),
+  'IBM Plex Mono': (
+    'IBM Plex Mono',
+    'Menlo',
+    'DejaVu Sans Mono',
+    'Bitstream Vera Sans Mono',
+    Courier,
+    monospace,
+  ),
+  'Arial': (
+    Arial,
+    sans-serif,
+  ),
+  'Helvetica': (
+    Helvetica,
+    Arial,
+    sans-serif,
+  ),
+  'Times New Roman': (
+    'Times New Roman',
+    Times,
+    serif,
+  ),
+  'Courier New': (
+    'Courier New',
+    Courier,
+    monospace,
+  ),
+);
+
+#{$cds-prefix}-dropdown {
+  --cds-border-strong: transparent;
+
+  inline-size: 100%;
+
+  // Apply font family to trigger button based on dropdown value attribute
+  @each $name, $stack in $font-families {
+    &[value='#{$name}']::part(trigger-button) {
+      font-family: $stack;
+    }
+  }
+}
+
+// Apply font family to dropdown items based on their value attribute
+#{$cds-prefix}-dropdown-item {
+  @each $name, $stack in $font-families {
+    &[value='#{$name}'] {
+      font-family: $stack;
+    }
+  }
+}
+
+#{$cds-prefix}-search {
+  --cds-border-strong: transparent;
+
+  input {
+    border: none;
+  }
+}
+
+#{$cds-prefix}-file-uploader-item {
+  flex: 1;
+  margin: 0;
+  border-inline-end: 1px solid $border-subtle-01;
+  min-inline-size: calc($spacing-10 * 2);
+}
+
+// ProseMirror-specific overrides for Carbon element styles
+.ProseMirror {
+  // Remove max-inline-size constraint from paragraphs
+  p {
+    max-inline-size: unset;
+  }
+
+  // Override code block background
+  pre,
+  code {
+    background-color: $layer-02;
+  }
+
+  // Table border and cell customizations
+  table {
+    border-block-start: 1px solid $border-subtle-01;
+    border-inline: 1px solid $border-subtle-01;
+
+    p {
+      margin: unset;
+    }
+
+    td {
+      border-color: $border-subtle-01;
+    }
+
+    td:not(:last-child) {
+      border-inline-end: 1px solid $border-subtle-01;
+    }
+  }
+
+  // Task list styles - custom ProseMirror extension
+  ul[data-type='taskList'] {
+    list-style: none;
+    padding-inline-start: 0;
+
+    li {
+      display: flex;
+      align-items: flex-start;
+      margin-inline-start: 0;
+      padding-inline-start: 0;
+    }
+  }
+}
+
+// Task list item content styles
+.ProseMirror ul[data-type='taskList'] li p {
+  margin: $spacing-01;
+}
+
+.ProseMirror ul[data-type='taskList'] li > label {
+  @include checkbox.styles(
+    (
+      selector: '&',
+    )
+  );
+
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.ProseMirror ul[data-type='taskList'] li > div {
+  flex: 1;
+}
+
+.ProseMirror ul[data-type='taskList'] li[data-checked='true'] > div {
+  color: $text-secondary;
+  text-decoration: line-through;
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/constants/editor.constants.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/constants/editor.constants.ts
@@ -96,10 +96,10 @@ export const NAVIGATION_KEYS = {
 } as const;
 
 /**
- * Focusable element selectors
+ * Focusable element selectors for toolbar navigation
  */
 export const FOCUSABLE_SELECTORS =
-  'cds-icon-button, cds-dropdown, cds-overflow-menu, cds-search' as const;
+  'cds-icon-button, cds-button, cds-dropdown, cds-overflow-menu, cds-search' as const;
 
 /**
  * Tooltip configuration

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/constants/editor.constants.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/constants/editor.constants.ts
@@ -1,0 +1,390 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { HeadingLevel, TableOptions } from '../types/editor.types.js';
+
+/**
+ * Default editor configuration
+ */
+export const DEFAULT_EDITOR_CONFIG = {
+  orientation: 'horizontal',
+  editable: true,
+  autofocus: false,
+} as const;
+
+/**
+ * Supported heading levels
+ */
+export const HEADING_LEVELS: readonly HeadingLevel[] = [
+  1, 2, 3, 4, 5, 6,
+] as const;
+
+/**
+ * Default table configuration
+ */
+export const DEFAULT_TABLE_OPTIONS: TableOptions = {
+  rows: 3,
+  cols: 3,
+  withHeaderRow: true,
+} as const;
+
+/**
+ * Link configuration
+ */
+export const LINK_CONFIG = {
+  openOnClick: false,
+  HTMLAttributes: {
+    target: '_blank',
+    rel: 'noopener noreferrer',
+  },
+} as const;
+
+/**
+ * Image configuration
+ */
+export const IMAGE_CONFIG = {
+  inline: true,
+  allowBase64: true,
+  HTMLAttributes: {
+    class: 'editor-image',
+  },
+  resize: {
+    enabled: true,
+    directions: [
+      'top',
+      'bottom',
+      'left',
+      'right',
+      'top-left',
+      'top-right',
+      'bottom-left',
+      'bottom-right',
+    ] as any,
+    minWidth: 50,
+    minHeight: 50,
+    alwaysPreserveAspectRatio: true,
+  },
+};
+
+/**
+ * Table configuration
+ */
+export const TABLE_CONFIG = {
+  resizable: true,
+} as const;
+
+/**
+ * Text align configuration
+ */
+export const TEXT_ALIGN_CONFIG = {
+  types: ['heading', 'paragraph'],
+};
+
+/**
+ * Keyboard navigation keys
+ */
+export const NAVIGATION_KEYS = {
+  horizontal: ['ArrowRight', 'ArrowLeft'],
+  vertical: ['ArrowDown', 'ArrowUp'],
+  all: ['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'],
+} as const;
+
+/**
+ * Focusable element selectors
+ */
+export const FOCUSABLE_SELECTORS =
+  'cds-icon-button, cds-dropdown, cds-overflow-menu, cds-search' as const;
+
+/**
+ * Tooltip configuration
+ */
+export const TOOLTIP_CONFIG = {
+  enterDelayMs: 100,
+  leaveDelayMs: 100,
+  align: 'top',
+} as const;
+
+/**
+ * Popover labels
+ */
+export const POPOVER_LABELS = {
+  link: {
+    title: 'Insert/Edit Link',
+    urlLabel: 'URL',
+    urlPlaceholder: 'https://example.com',
+    insertButton: 'Insert Link',
+    removeButton: 'Remove Link',
+  },
+  image: {
+    title: 'Insert Image',
+    urlLabel: 'Image URL',
+    urlPlaceholder: 'https://example.com/image.jpg',
+    altLabel: 'Alt Text',
+    altPlaceholder: 'Describe the image',
+    titleLabel: 'Title',
+    titlePlaceholder: 'Image title (optional)',
+    insertButton: 'Insert Image',
+    cancelButton: 'Cancel',
+  },
+} as const;
+
+/**
+ * Toolbar button labels
+ */
+export const TOOLBAR_LABELS = {
+  undo: 'Undo',
+  redo: 'Redo',
+  cut: 'Cut',
+  copy: 'Copy',
+  paste: 'Paste',
+  bold: 'Bold',
+  italic: 'Italic',
+  underline: 'Underline',
+  strikethrough: 'Strikethrough',
+  code: 'Code',
+  bulletList: 'Bullet List',
+  numberedList: 'Numbered List',
+  taskList: 'Task List',
+  alignLeft: 'Align Left',
+  alignCenter: 'Align Center',
+  alignRight: 'Align Right',
+  alignJustify: 'Justify',
+  indent: 'Indent More',
+  outdent: 'Indent Less',
+  textColor: 'Text Color',
+  blockquote: 'Blockquote',
+  codeBlock: 'Code Block',
+  insertTable: 'Insert Table',
+  insertLink: 'Insert Link',
+  insertImage: 'Insert Image',
+  attachment: 'Attach File',
+  tableOptions: 'Table Options',
+} as const;
+
+/**
+ * Table menu items
+ */
+export const TABLE_MENU_ITEMS = {
+  addColumnBefore: 'Add Column Before',
+  addColumnAfter: 'Add Column After',
+  deleteColumn: 'Delete Column',
+  addRowBefore: 'Add Row Before',
+  addRowAfter: 'Add Row After',
+  deleteRow: 'Delete Row',
+  toggleHeaderRow: 'Toggle Header Row',
+  deleteTable: 'Delete Table',
+} as const;
+
+/**
+ * Font family options
+ */
+export const FONT_FAMILIES = [
+  { label: 'IBM Plex Sans', value: 'IBM Plex Sans' },
+  { label: 'IBM Plex Serif', value: 'IBM Plex Serif' },
+  { label: 'IBM Plex Mono', value: 'IBM Plex Mono' },
+  { label: 'Arial', value: 'Arial' },
+  { label: 'Helvetica', value: 'Helvetica' },
+  { label: 'Times New Roman', value: 'Times New Roman' },
+  { label: 'Courier New', value: 'Courier New' },
+] as const;
+
+/**
+ * Font size options (in pixels)
+ */
+export const FONT_SIZES = [
+  { label: 'Small', value: '12px' },
+  { label: 'Normal', value: '14px' },
+  { label: 'Medium', value: '16px' },
+  { label: 'Large', value: '18px' },
+  { label: 'Extra Large', value: '24px' },
+] as const;
+
+/**
+ * Text color options using Carbon theme tokens
+ * These tokens automatically adapt to light/dark mode
+ */
+export const TEXT_COLOR_GROUPS = [
+  {
+    label: 'Text',
+    items: [
+      { label: 'Primary Text', token: 'text-primary' },
+      { label: 'Secondary Text', token: 'text-secondary' },
+      { label: 'Placeholder', token: 'text-placeholder' },
+      { label: 'Link', token: 'link-primary' },
+    ],
+  },
+  {
+    label: 'Status',
+    items: [
+      { label: 'Info', token: 'support-info' },
+      { label: 'Success', token: 'support-success' },
+      { label: 'Error', token: 'support-error' },
+      { label: 'Warning', token: 'support-warning' },
+      { label: 'Caution', token: 'support-caution-major' },
+    ],
+  },
+] as const;
+
+/**
+ * Heading dropdown options
+ */
+export const HEADING_OPTIONS = [
+  { value: 'p', label: 'Paragraph' },
+  { value: 'h1', label: 'Heading 1' },
+  { value: 'h2', label: 'Heading 2' },
+  { value: 'h3', label: 'Heading 3' },
+  { value: 'h4', label: 'Heading 4' },
+  { value: 'h5', label: 'Heading 5' },
+  { value: 'h6', label: 'Heading 6' },
+] as const;
+
+/**
+ * CSS class names used in the component
+ */
+export const CSS_CLASSES = {
+  editorContainer: 'clabs--wysiwyg__editor-container',
+  toolbar: 'clabs--wysiwyg__toolbar',
+  toolbarGroup: 'clabs--wysiwyg__toolbar-group',
+  editorContent: 'clabs--wysiwyg__editor-content',
+  popoverContent: 'clabs--wysiwyg__popover-content',
+  popoverActions: 'clabs--wysiwyg__popover-actions',
+  attachments: 'clabs--wysiwyg__attachments',
+  textColorButton: 'text-color-button',
+  toolbarButton: 'clabs--wysiwyg__toolbar-button',
+  popoverWrapper: 'clabs--wysiwyg__popover-wrapper',
+  proseMirror: 'tiptap.ProseMirror',
+} as const;
+
+/**
+ * File attachment configuration
+ */
+export const FILE_ATTACHMENT_CONFIG = {
+  attachmentPrefix: 'Attached: ',
+} as const;
+
+/**
+ * Button configuration for toolbar groups
+ * Defines the structure and behavior of toolbar buttons in a data-driven way
+ */
+export interface ButtonConfig {
+  id: string;
+  icon: string;
+  label: string;
+  action: string;
+  checkActive?: string;
+}
+
+/**
+ * Text formatting button configurations
+ */
+export const TEXT_FORMATTING_BUTTONS: ButtonConfig[] = [
+  {
+    id: 'bold',
+    icon: 'TextBold',
+    label: 'Bold',
+    action: 'toggleBold',
+    checkActive: 'bold',
+  },
+  {
+    id: 'italic',
+    icon: 'TextItalic',
+    label: 'Italic',
+    action: 'toggleItalic',
+    checkActive: 'italic',
+  },
+  {
+    id: 'underline',
+    icon: 'TextUnderline',
+    label: 'Underline',
+    action: 'toggleUnderline',
+    checkActive: 'underline',
+  },
+  {
+    id: 'strikethrough',
+    icon: 'TextStrikethrough',
+    label: 'Strikethrough',
+    action: 'toggleStrike',
+    checkActive: 'strike',
+  },
+  {
+    id: 'code',
+    icon: 'Code',
+    label: 'Code',
+    action: 'toggleCode',
+    checkActive: 'code',
+  },
+] as const;
+
+/**
+ * Clipboard button configurations
+ */
+export const CLIPBOARD_BUTTONS: ButtonConfig[] = [
+  { id: 'cut', icon: 'Cut', label: 'Cut', action: 'cut' },
+  { id: 'copy', icon: 'Copy', label: 'Copy', action: 'copy' },
+  { id: 'paste', icon: 'Paste', label: 'Paste', action: 'paste' },
+] as const;
+
+/**
+ * List button configurations
+ */
+export const LIST_BUTTONS: ButtonConfig[] = [
+  {
+    id: 'bulletList',
+    icon: 'ListBulleted',
+    label: 'Bullet List',
+    action: 'toggleBulletList',
+    checkActive: 'bulletList',
+  },
+  {
+    id: 'numberedList',
+    icon: 'ListNumbered',
+    label: 'Numbered List',
+    action: 'toggleOrderedList',
+    checkActive: 'orderedList',
+  },
+  {
+    id: 'taskList',
+    icon: 'ListChecked',
+    label: 'Task List',
+    action: 'toggleTaskList',
+    checkActive: 'taskList',
+  },
+  {
+    id: 'outdent',
+    icon: 'IndentLess',
+    label: 'Indent Less',
+    action: 'outdent',
+  },
+  {
+    id: 'indent',
+    icon: 'IndentMore',
+    label: 'Indent More',
+    action: 'indent',
+  },
+] as const;
+
+/**
+ * Block button configurations
+ */
+export const BLOCK_BUTTONS: ButtonConfig[] = [
+  {
+    id: 'blockquote',
+    icon: 'Quotes',
+    label: 'Blockquote',
+    action: 'toggleBlockquote',
+    checkActive: 'blockquote',
+  },
+  {
+    id: 'codeBlock',
+    icon: 'CodeBlock',
+    label: 'Code Block',
+    action: 'toggleCodeBlock',
+    checkActive: 'codeBlock',
+  },
+] as const;

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/constants/icons.constants.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/constants/icons.constants.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Carbon icons used in the WYSIWYG editor
+import Undo from '@carbon/icons/es/undo/16.js';
+import Redo from '@carbon/icons/es/redo/16.js';
+import Cut from '@carbon/icons/es/cut/16.js';
+import Copy from '@carbon/icons/es/copy/16.js';
+import Paste from '@carbon/icons/es/paste/16.js';
+import TextBold from '@carbon/icons/es/text--bold/16.js';
+import TextItalic from '@carbon/icons/es/text--italic/16.js';
+import TextUnderline from '@carbon/icons/es/text--underline/16.js';
+import TextStrikethrough from '@carbon/icons/es/text--strikethrough/16.js';
+import Code from '@carbon/icons/es/code/16.js';
+import CodeBlock from '@carbon/icons/es/code-block/16.js';
+import ListBulleted from '@carbon/icons/es/list--bulleted/16.js';
+import ListNumbered from '@carbon/icons/es/list--numbered/16.js';
+import ListChecked from '@carbon/icons/es/list--checked/16.js';
+import TextAlignLeft from '@carbon/icons/es/text--align--left/16.js';
+import TextAlignCenter from '@carbon/icons/es/text--align--center/16.js';
+import TextAlignRight from '@carbon/icons/es/text--align--right/16.js';
+import TextAlignJustify from '@carbon/icons/es/text--align--justify/16.js';
+import IndentMore from '@carbon/icons/es/text--indent--more/16.js';
+import IndentLess from '@carbon/icons/es/text--indent--less/16.js';
+import TextColor from '@carbon/icons/es/text--color/16.js';
+import Quotes from '@carbon/icons/es/quotes/16.js';
+import Table16 from '@carbon/icons/es/table/16.js';
+import Image16 from '@carbon/icons/es/image/16.js';
+import Link16 from '@carbon/icons/es/link/16.js';
+import Attachment from '@carbon/icons/es/attachment/16.js';
+import OverflowMenuVertical from '@carbon/icons/es/overflow-menu--vertical/16.js';
+
+/**
+ * Centralized icon exports for the WYSIWYG editor
+ */
+export const EDITOR_ICONS = {
+  // History
+  Undo,
+  Redo,
+
+  // Clipboard
+  Cut,
+  Copy,
+  Paste,
+
+  // Text formatting
+  TextBold,
+  TextItalic,
+  TextUnderline,
+  TextStrikethrough,
+  Code,
+  CodeBlock,
+
+  // Lists
+  ListBulleted,
+  ListNumbered,
+  ListChecked,
+
+  // Alignment
+  TextAlignLeft,
+  TextAlignCenter,
+  TextAlignRight,
+  TextAlignJustify,
+
+  // Indentation
+  IndentMore,
+  IndentLess,
+
+  // Color
+  TextColor,
+
+  // Blocks
+  Quotes,
+
+  // Insert
+  Table: Table16,
+  Image: Image16,
+  Link: Link16,
+  Attachment,
+
+  // Menu
+  OverflowMenuVertical,
+} as const;

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/services/editor.service.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/services/editor.service.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Editor } from '@tiptap/core';
+import { Editor, type Extensions } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import { Table } from '@tiptap/extension-table';
 import { TableRow } from '@tiptap/extension-table-row';
@@ -58,7 +58,7 @@ export class EditorService {
   ): Editor {
     this.editor = new Editor({
       element,
-      extensions: this.getExtensions(),
+      extensions: this.getExtensions(config.extensions),
       content: config.content || '',
       editable: config.editable ?? true,
       autofocus: config.autofocus ?? false,
@@ -83,9 +83,11 @@ export class EditorService {
 
   /**
    * Get configured extensions for the editor
+   * @param {Extensions} customExtensions - Optional custom TipTap extensions to add
+   * @returns {Extensions} Array of TipTap extensions
    */
-  private getExtensions() {
-    return [
+  private getExtensions(customExtensions?: Extensions) {
+    const defaultExtensions = [
       StarterKit.configure({
         heading: {
           levels: [...HEADING_LEVELS],
@@ -107,6 +109,11 @@ export class EditorService {
         nested: true,
       }),
     ];
+
+    // Merge custom extensions if provided
+    return customExtensions
+      ? [...defaultExtensions, ...customExtensions]
+      : defaultExtensions;
   }
 
   /**

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/services/editor.service.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/services/editor.service.ts
@@ -1,0 +1,413 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Table } from '@tiptap/extension-table';
+import { TableRow } from '@tiptap/extension-table-row';
+import { TableCell } from '@tiptap/extension-table-cell';
+import { TableHeader } from '@tiptap/extension-table-header';
+import Image from '@tiptap/extension-image';
+import TextAlign from '@tiptap/extension-text-align';
+import { TextStyle } from '@tiptap/extension-text-style';
+import { Color } from '@tiptap/extension-color';
+import { FontFamily } from '@tiptap/extension-font-family';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
+
+import type {
+  EditorConfig,
+  HeadingLevel,
+  TextAlignment,
+  LinkAttributes,
+  ImageAttributes,
+  TableOptions,
+} from '../types/editor.types.js';
+import {
+  HEADING_LEVELS,
+  LINK_CONFIG,
+  IMAGE_CONFIG,
+  TABLE_CONFIG,
+  TEXT_ALIGN_CONFIG,
+} from '../constants/editor.constants.js';
+
+/**
+ * Service class for managing TipTap editor operations
+ */
+export class EditorService {
+  private editor: Editor | null = null;
+
+  /**
+   * Initialize the editor with configuration
+   * @param {HTMLElement} element - The HTML element to attach the editor to
+   * @param {EditorConfig} config - Editor configuration options
+   * @param {Function} onUpdate - Callback function called when editor content updates
+   * @param {Function} onSelectionUpdate - Callback function called when selection changes
+   */
+  public initialize(
+    element: HTMLElement,
+    config: EditorConfig,
+    onUpdate: (editor: Editor) => void,
+    onSelectionUpdate: () => void
+  ): Editor {
+    this.editor = new Editor({
+      element,
+      extensions: this.getExtensions(),
+      content: config.content || '',
+      editable: config.editable ?? true,
+      autofocus: config.autofocus ?? false,
+      /**
+       * Handle editor update event
+       * @param {Object} root0 - Update event object
+       * @param {Editor} root0.editor - The editor instance
+       */
+      onUpdate: ({ editor }) => {
+        onUpdate(editor);
+      },
+      /**
+       * Handle selection update event
+       */
+      onSelectionUpdate: () => {
+        onSelectionUpdate();
+      },
+    });
+
+    return this.editor;
+  }
+
+  /**
+   * Get configured extensions for the editor
+   */
+  private getExtensions() {
+    return [
+      StarterKit.configure({
+        heading: {
+          levels: [...HEADING_LEVELS],
+        },
+        // Configure link through StarterKit with custom options
+        link: LINK_CONFIG,
+      }),
+      TextStyle,
+      Color,
+      FontFamily,
+      TextAlign.configure(TEXT_ALIGN_CONFIG),
+      Image.configure(IMAGE_CONFIG),
+      Table.configure(TABLE_CONFIG),
+      TableRow,
+      TableHeader,
+      TableCell,
+      TaskList,
+      TaskItem.configure({
+        nested: true,
+      }),
+    ];
+  }
+
+  /**
+   * Destroy the editor instance
+   */
+  public destroy(): void {
+    this.editor?.destroy();
+    this.editor = null;
+  }
+
+  /**
+   * Get the current editor instance
+   */
+  public getEditor(): Editor | null {
+    return this.editor;
+  }
+
+  /**
+   * Check if editor can perform undo
+   */
+  public canUndo(): boolean {
+    return this.editor?.can().undo() ?? false;
+  }
+
+  /**
+   * Check if editor can perform redo
+   */
+  public canRedo(): boolean {
+    return this.editor?.can().redo() ?? false;
+  }
+
+  /**
+   * Check if a mark or node is active
+   * @param {string} name - The name of the mark or node to check
+   * @param {Record<string, any>} attrs - Optional attributes to match
+   */
+  public isActive(name: string, attrs?: Record<string, any>): boolean {
+    return this.editor?.isActive(name, attrs) ?? false;
+  }
+
+  /**
+   * Execute a toggle command on the editor
+   * @param {string} command - The command name to toggle
+   */
+  private executeToggleCommand(command: string): void {
+    this.editor?.chain().focus()[command]().run();
+  }
+
+  /**
+   * Execute a command with attributes on the editor
+   * @param {string} command - The command name to execute
+   * @param {any} attrs - The attributes to pass to the command
+   */
+  private executeCommandWithAttrs(command: string, attrs: any): void {
+    this.editor?.chain().focus()[command](attrs).run();
+  }
+
+  /** Toggle bold formatting */
+  public toggleBold(): void {
+    this.executeToggleCommand('toggleBold');
+  }
+
+  /** Toggle italic formatting */
+  public toggleItalic(): void {
+    this.executeToggleCommand('toggleItalic');
+  }
+
+  /** Toggle underline formatting */
+  public toggleUnderline(): void {
+    this.executeToggleCommand('toggleUnderline');
+  }
+
+  /** Toggle strikethrough formatting */
+  public toggleStrike(): void {
+    this.executeToggleCommand('toggleStrike');
+  }
+
+  /** Toggle inline code formatting */
+  public toggleCode(): void {
+    this.executeToggleCommand('toggleCode');
+  }
+
+  /**
+   * Set heading level
+   * @param {HeadingLevel} level - The heading level (1-6)
+   */
+  public setHeading(level: HeadingLevel): void {
+    this.executeCommandWithAttrs('toggleHeading', { level });
+  }
+
+  /** Set paragraph */
+  public setParagraph(): void {
+    this.executeToggleCommand('setParagraph');
+  }
+
+  /** Toggle bullet list */
+  public toggleBulletList(): void {
+    this.executeToggleCommand('toggleBulletList');
+  }
+
+  /** Toggle ordered list */
+  public toggleOrderedList(): void {
+    this.executeToggleCommand('toggleOrderedList');
+  }
+
+  /** Toggle task list */
+  public toggleTaskList(): void {
+    this.executeToggleCommand('toggleTaskList');
+  }
+
+  /**
+   * Set text alignment
+   * @param {TextAlignment} alignment - The text alignment
+   */
+  public setTextAlign(alignment: TextAlignment): void {
+    this.executeCommandWithAttrs('setTextAlign', alignment);
+  }
+
+  /** Toggle blockquote */
+  public toggleBlockquote(): void {
+    this.executeToggleCommand('toggleBlockquote');
+  }
+
+  /** Toggle code block */
+  public toggleCodeBlock(): void {
+    this.executeToggleCommand('toggleCodeBlock');
+  }
+
+  /**
+   * Insert table
+   * @param {TableOptions} options - Table configuration including rows, cols, and withHeaderRow
+   */
+  public insertTable(options: TableOptions): void {
+    this.editor?.chain().focus().insertTable(options).run();
+  }
+
+  /**
+   * Set link
+   * @param {LinkAttributes} attrs - Link attributes including href, target, and rel
+   */
+  public setLink(attrs: LinkAttributes): void {
+    this.editor?.chain().focus().extendMarkRange('link').setLink(attrs).run();
+  }
+
+  /**
+   * Unset link
+   */
+  public unsetLink(): void {
+    this.editor?.chain().focus().extendMarkRange('link').unsetLink().run();
+  }
+
+  /**
+   * Get link attributes
+   */
+  public getLinkAttributes(): LinkAttributes {
+    return this.editor?.getAttributes('link') as LinkAttributes;
+  }
+
+  /**
+   * Insert image
+   * @param {ImageAttributes} attrs - Image attributes including src, alt, and title
+   */
+  public insertImage(attrs: ImageAttributes): void {
+    this.editor?.chain().focus().setImage(attrs).run();
+  }
+
+  /** Add column before current column */
+  public addColumnBefore(): void {
+    this.executeToggleCommand('addColumnBefore');
+  }
+
+  /** Add column after current column */
+  public addColumnAfter(): void {
+    this.executeToggleCommand('addColumnAfter');
+  }
+
+  /** Delete current column */
+  public deleteColumn(): void {
+    this.executeToggleCommand('deleteColumn');
+  }
+
+  /** Add row before current row */
+  public addRowBefore(): void {
+    this.executeToggleCommand('addRowBefore');
+  }
+
+  /** Add row after current row */
+  public addRowAfter(): void {
+    this.executeToggleCommand('addRowAfter');
+  }
+
+  /** Delete current row */
+  public deleteRow(): void {
+    this.executeToggleCommand('deleteRow');
+  }
+
+  /** Toggle header row */
+  public toggleHeaderRow(): void {
+    this.executeToggleCommand('toggleHeaderRow');
+  }
+
+  /** Delete table */
+  public deleteTable(): void {
+    this.executeToggleCommand('deleteTable');
+  }
+
+  /** Undo last action */
+  public undo(): void {
+    this.executeToggleCommand('undo');
+  }
+
+  /** Redo last undone action */
+  public redo(): void {
+    this.executeToggleCommand('redo');
+  }
+
+  /**
+   * Get HTML content
+   */
+  public getHTML(): string {
+    return this.editor?.getHTML() ?? '';
+  }
+
+  /**
+   * Set content
+   * @param {string} content - The HTML content to set in the editor
+   */
+  public setContent(content: string): void {
+    this.editor?.commands.setContent(content);
+  }
+
+  /**
+   * Cut selected text to clipboard
+   */
+  public cut(): void {
+    if (this.editor) {
+      const { from, to } = this.editor.state.selection;
+      const text = this.editor.state.doc.textBetween(from, to, ' ');
+      navigator.clipboard.writeText(text);
+      this.editor.chain().focus().deleteSelection().run();
+    }
+  }
+
+  /**
+   * Copy selected text to clipboard
+   */
+  public copy(): void {
+    if (this.editor) {
+      const { from, to } = this.editor.state.selection;
+      const text = this.editor.state.doc.textBetween(from, to, ' ');
+      navigator.clipboard.writeText(text);
+    }
+  }
+
+  /**
+   * Paste text from clipboard
+   */
+  public async paste(): Promise<void> {
+    if (this.editor) {
+      try {
+        const text = await navigator.clipboard.readText();
+        this.editor.chain().focus().insertContent(text).run();
+      } catch (err) {
+        console.error('Failed to paste:', err);
+      }
+    }
+  }
+
+  /** Increase indent */
+  public indent(): void {
+    this.executeCommandWithAttrs('sinkListItem', 'listItem');
+  }
+
+  /** Decrease indent */
+  public outdent(): void {
+    this.executeCommandWithAttrs('liftListItem', 'listItem');
+  }
+
+  /**
+   * Set text color
+   * @param {string} color - The color value (hex, rgb, etc.)
+   */
+  public setColor(color: string): void {
+    this.executeCommandWithAttrs('setColor', color);
+  }
+
+  /** Unset text color */
+  public unsetColor(): void {
+    this.executeToggleCommand('unsetColor');
+  }
+
+  /**
+   * Set font family
+   * @param {string} fontFamily - The font family name
+   */
+  public setFontFamily(fontFamily: string): void {
+    this.executeCommandWithAttrs('setFontFamily', fontFamily);
+  }
+
+  /** Unset font family */
+  public unsetFontFamily(): void {
+    this.executeToggleCommand('unsetFontFamily');
+  }
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/services/popover.service.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/services/popover.service.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { PopoverState } from '../types/editor.types.js';
+
+/**
+ * Service class for managing popover state
+ */
+export class PopoverService {
+  public static readonly initialState: PopoverState = {
+    showLinkPopover: false,
+    showImagePopover: false,
+    linkUrl: '',
+    imageUrl: '',
+    imageAlt: '',
+    imageTitle: '',
+  };
+
+  /**
+   * Create initial popover state.
+   */
+  public static createInitialState(): PopoverState {
+    return { ...this.initialState };
+  }
+
+  /**
+   * Merge partial updates into the current popover state.
+   * @param {PopoverState} currentState - Current popover state.
+   * @param {Partial<PopoverState>} updates - Partial state updates to merge.
+   * @returns {PopoverState} Updated popover state.
+   */
+  public static update(
+    currentState: PopoverState,
+    updates: Partial<PopoverState>
+  ): PopoverState {
+    return { ...currentState, ...updates };
+  }
+
+  /**
+   * Reset selected keys back to their initial values.
+   * @param {PopoverState} currentState - Current popover state.
+   * @param {...Array<keyof PopoverState>} keys - State keys to reset.
+   * @returns {PopoverState} Updated popover state.
+   */
+  public static reset(
+    currentState: PopoverState,
+    ...keys: Array<keyof PopoverState>
+  ): PopoverState {
+    return this.update(
+      currentState,
+      keys.reduce(
+        (updates, key) => ({ ...updates, [key]: this.initialState[key] }),
+        {} as Partial<PopoverState>
+      )
+    );
+  }
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/types/editor.types.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/types/editor.types.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { Editor } from '@tiptap/core';
+import type { Editor, Extensions } from '@tiptap/core';
 import type { TemplateResult } from 'lit';
 
 /**
@@ -68,6 +68,7 @@ export interface EditorConfig {
   orientation?: EditorOrientation;
   editable?: boolean;
   autofocus?: boolean;
+  extensions?: Extensions;
 }
 
 /**

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/types/editor.types.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/types/editor.types.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { Editor } from '@tiptap/core';
+import type { TemplateResult } from 'lit';
+
+/**
+ * Editor orientation for toolbar layout
+ */
+export type EditorOrientation = 'horizontal' | 'vertical';
+
+/**
+ * Heading levels supported by the editor
+ */
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+/**
+ * Text alignment options
+ */
+export type TextAlignment = 'left' | 'center' | 'right' | 'justify';
+
+/**
+ * Editor content change event detail
+ */
+export interface EditorContentChangeDetail {
+  content: string;
+  editor: Editor;
+}
+
+/**
+ * Link attributes for the editor
+ */
+export interface LinkAttributes {
+  href: string;
+  target?: string;
+  rel?: string;
+}
+
+/**
+ * Image attributes for the editor
+ */
+export interface ImageAttributes {
+  src: string;
+  alt?: string;
+  title?: string;
+}
+
+/**
+ * Table insertion options
+ */
+export interface TableOptions {
+  rows: number;
+  cols: number;
+  withHeaderRow: boolean;
+}
+
+/**
+ * Editor configuration options
+ */
+export interface EditorConfig {
+  content?: string;
+  orientation?: EditorOrientation;
+  editable?: boolean;
+  autofocus?: boolean;
+}
+
+/**
+ * Popover state interface
+ */
+export interface PopoverState {
+  showLinkPopover: boolean;
+  showImagePopover: boolean;
+  linkUrl: string;
+  imageUrl: string;
+  imageAlt: string;
+  imageTitle: string;
+}
+
+/**
+ * Built-in toolbar group names
+ */
+export type BuiltInToolbarGroupName =
+  | 'clipboard'
+  | 'fontFamily'
+  | 'textFormatting'
+  | 'headings'
+  | 'colorPicker'
+  | 'lists'
+  | 'alignment'
+  | 'blocks'
+  | 'insert'
+  | 'search'
+  | 'tableOperations';
+
+/**
+ * Toolbar group configuration with optional item-level control
+ */
+export interface ToolbarGroup {
+  name: BuiltInToolbarGroupName | string;
+  enabled?: boolean;
+  items?: Record<string, boolean>;
+}
+
+/**
+ * Toolbar options as an array for controlling order and visibility of groups
+ * Can include both built-in toolbar groups and custom toolbar groups
+ */
+export type ToolbarOptions = (ToolbarGroup | CustomToolbarGroup)[];
+
+/**
+ * Custom toolbar item configuration
+ * Allows users to add custom buttons or controls to the toolbar
+ */
+export interface CustomToolbarItem {
+  /** Unique identifier for the item */
+  id: string;
+  /** Render function that returns a Lit template */
+  render: (editor: Editor | null) => TemplateResult;
+  /** Optional tooltip text */
+  tooltip?: string;
+}
+
+/**
+ * Custom toolbar group configuration
+ * Groups custom items together in the toolbar
+ * Reference the group by its ID in toolbarOptions to control position
+ */
+export interface CustomToolbarGroup {
+  /** Unique identifier for the group - use this in toolbarOptions array */
+  id: string;
+  /** Array of custom toolbar items */
+  items: CustomToolbarItem[];
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/dom.utils.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/dom.utils.ts
@@ -38,10 +38,10 @@ export class DOMUtils {
   }
 
   /**
-   * Get focusable elements from shadow root, excluding disabled elements
+   * Get focusable elements from shadow root, excluding disabled elements and nested elements eg. popover internals.
    * @param {ShadowRoot} shadowRoot - The shadow root to query for focusable elements
    * @param {string} selector - CSS selector for focusable elements
-   * @returns {HTMLElement[]} Array of focusable, non-disabled elements
+   * @returns {HTMLElement[]} Array of focusable, non-disabled, top-level elements
    */
   public static getFocusableElements(
     shadowRoot: ShadowRoot,
@@ -50,7 +50,9 @@ export class DOMUtils {
     const allElements = Array.from(
       shadowRoot.querySelectorAll<HTMLElement>(selector)
     );
-    return allElements.filter((el) => !this.isElementDisabled(el));
+    return allElements.filter(
+      (el) => !this.isElementDisabled(el) && !el.closest('cds-popover-content')
+    );
   }
 
   /**

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/dom.utils.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/dom.utils.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { EditorOrientation } from '../types/editor.types.js';
+
+/**
+ * Utility functions for DOM manipulation and keyboard navigation
+ */
+export class DOMUtils {
+  /**
+   * Check if an element is disabled
+   * @param {HTMLElement} element - The element to check
+   * @returns {boolean} True if the element is disabled
+   */
+  private static isElementDisabled(element: HTMLElement): boolean {
+    // Check for disabled attribute
+    if (element.hasAttribute('disabled')) {
+      return true;
+    }
+
+    // Check for aria-disabled
+    if (element.getAttribute('aria-disabled') === 'true') {
+      return true;
+    }
+
+    // For custom elements like cds-icon-button, check the disabled property
+    if ('disabled' in element && (element as any).disabled === true) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Get focusable elements from shadow root, excluding disabled elements
+   * @param {ShadowRoot} shadowRoot - The shadow root to query for focusable elements
+   * @param {string} selector - CSS selector for focusable elements
+   * @returns {HTMLElement[]} Array of focusable, non-disabled elements
+   */
+  public static getFocusableElements(
+    shadowRoot: ShadowRoot,
+    selector: string
+  ): HTMLElement[] {
+    const allElements = Array.from(
+      shadowRoot.querySelectorAll<HTMLElement>(selector)
+    );
+    return allElements.filter((el) => !this.isElementDisabled(el));
+  }
+
+  /**
+   * Find the first non-disabled element index
+   * @param {HTMLElement[]} elements - Array of HTML elements
+   * @returns {number} Index of the first non-disabled element, or 0 if all are disabled
+   */
+  public static findFirstEnabledIndex(elements: HTMLElement[]): number {
+    const index = elements.findIndex((el) => !this.isElementDisabled(el));
+    return index === -1 ? 0 : index;
+  }
+
+  /**
+   * Update tab indexes for keyboard navigation
+   * @param {HTMLElement[]} elements - Array of HTML elements to update
+   * @param {number} activeIndex - Index of the currently active element
+   */
+  public static updateTabIndexes(
+    elements: HTMLElement[],
+    activeIndex: number
+  ): void {
+    elements.forEach((el, i) => {
+      const tabindexValue = i === activeIndex ? '0' : '-1';
+
+      // For cds-icon-button, set tabindex on the button inside shadow DOM
+      if (el.tagName.toLowerCase() === 'cds-icon-button') {
+        const button = el.shadowRoot?.querySelector('button');
+        if (button) {
+          button.setAttribute('tabindex', tabindexValue);
+        }
+      } else {
+        // For other elements, set on the element itself
+        el.setAttribute('tabindex', tabindexValue);
+      }
+    });
+  }
+
+  /**
+   * Calculate next focusable element index based on arrow key and orientation
+   * @param {string} key - The arrow key pressed
+   * @param {number} currentIndex - Current focused element index
+   * @param {number} totalElements - Total number of focusable elements
+   * @param {EditorOrientation} orientation - Toolbar orientation
+   * @returns {number} Next element index to focus
+   */
+  public static getNextFocusIndex(
+    key: string,
+    currentIndex: number,
+    totalElements: number,
+    orientation: EditorOrientation
+  ): number {
+    const horizontal = orientation === 'horizontal';
+
+    switch (key) {
+      case 'ArrowRight':
+        return horizontal ? (currentIndex + 1) % totalElements : currentIndex;
+      case 'ArrowLeft':
+        return horizontal
+          ? (currentIndex - 1 + totalElements) % totalElements
+          : currentIndex;
+      case 'ArrowDown':
+        return !horizontal ? (currentIndex + 1) % totalElements : currentIndex;
+      case 'ArrowUp':
+        return !horizontal
+          ? (currentIndex - 1 + totalElements) % totalElements
+          : currentIndex;
+      default:
+        return currentIndex;
+    }
+  }
+
+  /**
+   * Check if the active element is within the editor content area
+   * @param {Element | null} editorContent - The editor content element
+   * @param {Element | null} activeElement - The currently active element
+   * @returns {boolean} True if active element is in editor content
+   */
+  public static isActiveElementInEditor(
+    editorContent: Element | null,
+    activeElement: Element | null
+  ): boolean {
+    if (!editorContent || !activeElement) {
+      return false;
+    }
+
+    return (
+      editorContent.contains(activeElement) ||
+      editorContent === activeElement ||
+      editorContent.querySelector('.ProseMirror')?.contains(activeElement) ||
+      false
+    );
+  }
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/editor.utils.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/editor.utils.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { HeadingLevel } from '../types/editor.types.js';
+import type { EditorService } from '../services/editor.service.js';
+
+/**
+ * Utility functions for editor-specific operations
+ */
+export class EditorUtils {
+  /**
+   * Get the currently active heading value for the dropdown
+   * @param {EditorService} editorService - The editor service instance
+   * @returns {string} The current heading value
+   */
+  public static getCurrentHeadingValue(
+    editorService: EditorService
+  ): 'p' | `h${HeadingLevel}` {
+    const headingValues: Array<`h${HeadingLevel}`> = [
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+    ];
+
+    for (const value of headingValues) {
+      const level = Number.parseInt(value.replace('h', ''), 10) as HeadingLevel;
+      if (editorService.isActive('heading', { level })) {
+        return value;
+      }
+    }
+
+    return 'p';
+  }
+
+  /**
+   * Parse heading value string to heading level number
+   * @param {string} value - The heading value (e.g., 'h1', 'h2')
+   * @returns {HeadingLevel | null} The heading level or null if invalid
+   */
+  public static parseHeadingLevel(value: string): HeadingLevel | null {
+    if (value === 'p') {
+      return null;
+    }
+    const level = Number.parseInt(value.replace('h', ''), 10);
+    if (level >= 1 && level <= 6) {
+      return level as HeadingLevel;
+    }
+    return null;
+  }
+
+  /**
+   * Validate URL format
+   * @param {string} url - The URL string to validate
+   * @returns {boolean} True if the URL is valid, false otherwise
+   */
+  public static isValidURL(url: string): boolean {
+    try {
+      new URL(url);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/file.utils.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/file.utils.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * File metadata interface
+ */
+export interface FileMetadata {
+  name: string;
+  size: number;
+}
+
+/**
+ * Utility functions for file handling
+ */
+export class FileUtils {
+  /**
+   * Create a file input element and trigger file selection
+   * @param {boolean} multiple - Whether to allow multiple file selection
+   * @param {(files: FileList) => void} onFilesSelected - Callback when files are selected
+   */
+  public static triggerFileSelection(
+    multiple: boolean,
+    onFilesSelected: (files: FileList) => void
+  ): void {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.multiple = multiple;
+
+    /**
+     * Handle file input change event
+     * @param {Event} e - File input change event
+     */
+    input.onchange = (e: Event) => {
+      const files = (e.target as HTMLInputElement).files;
+      if (files && files.length > 0) {
+        onFilesSelected(files);
+      }
+    };
+
+    input.click();
+  }
+
+  /**
+   * Convert FileList to array of file metadata
+   * @param {FileList} files - The FileList to convert
+   * @returns {FileMetadata[]} Array of file metadata
+   */
+  public static fileListToMetadata(files: FileList): FileMetadata[] {
+    return Array.from(files).map((file) => ({
+      name: file.name,
+      size: file.size,
+    }));
+  }
+
+  /**
+   * Format file names as comma-separated string
+   * @param {FileList} files - The FileList to format
+   * @returns {string} Comma-separated file names
+   */
+  public static formatFileNames(files: FileList): string {
+    return Array.from(files)
+      .map((f) => f.name)
+      .join(', ');
+  }
+
+  /**
+   * Check if a file is an image based on its MIME type
+   * @param {File} file - The file to check
+   * @returns {boolean} True if the file is an image
+   */
+  public static isImageFile(file: File): boolean {
+    return file.type.startsWith('image/');
+  }
+
+  /**
+   * Convert a File to a data URL
+   * @param {File} file - The file to convert
+   * @returns {Promise<string>} Promise that resolves to the data URL
+   */
+  public static fileToDataURL(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      /**
+       * Handle FileReader load event
+       */
+      reader.onload = () => resolve(reader.result as string);
+      /**
+       * Handle FileReader error event
+       */
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/render.utils.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/utils/render.utils.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html } from 'lit';
+import type { TemplateResult } from 'lit';
+import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
+import { CSS_CLASSES, TOOLTIP_CONFIG } from '../constants/editor.constants.js';
+import type { ToolbarOptions } from '../types/editor.types.js';
+
+/**
+ * Utility functions for theme and color management
+ */
+export class ThemeUtils {
+  /**
+   * Get computed color value from CSS custom property token
+   * @param {string} token - The token name (e.g., 'text-primary')
+   * @returns {string} The computed color value
+   */
+  public static getTokenColor(token: string): string {
+    const computedStyle = getComputedStyle(document.documentElement);
+    return computedStyle.getPropertyValue(`--cds-${token}`).trim();
+  }
+
+  /**
+   * Get the default text color from theme
+   * @returns {string} The default text color value
+   */
+  public static getDefaultTextColor(): string {
+    return this.getTokenColor('text-primary');
+  }
+}
+
+/**
+ * Utility functions for rendering UI elements
+ */
+export class RenderUtils {
+  /**
+   * Render a toolbar icon button with consistent styling
+   * @param {any} icon - Carbon icon descriptor
+   * @param {string} tooltip - Tooltip text
+   * @param {(e?: Event) => void} onClick - Click handler
+   * @param {boolean} isActive - Whether button is selected
+   * @param {boolean} isDisabled - Whether button is disabled
+   * @returns {TemplateResult} Icon button template
+   */
+  public static renderIconButton(
+    icon: any,
+    tooltip: string,
+    onClick: (e?: Event) => void,
+    isActive = false,
+    isDisabled = false
+  ): TemplateResult {
+    return html`
+      <cds-icon-button
+        size="md"
+        autoalign
+        kind="ghost"
+        class="${CSS_CLASSES.toolbarButton}"
+        enter-delay-ms="${TOOLTIP_CONFIG.enterDelayMs}"
+        leave-delay-ms="${TOOLTIP_CONFIG.leaveDelayMs}"
+        align="${TOOLTIP_CONFIG.align}"
+        ?isselected=${isActive}
+        ?disabled=${isDisabled}
+        @click=${onClick}>
+        ${iconLoader(icon, { slot: 'icon' })}
+        <span slot="tooltip-content">${tooltip}</span>
+      </cds-icon-button>
+    `;
+  }
+
+  /**
+   * Render a toolbar group wrapper
+   * @param {TemplateResult} content - Group content
+   * @param {string} className - CSS class name for the group
+   * @returns {TemplateResult} Toolbar group template
+   */
+  public static renderToolbarGroup(
+    content: TemplateResult,
+    className: string
+  ): TemplateResult {
+    return html`
+      <div class="${className}" role="presentation">${content}</div>
+    `;
+  }
+}
+
+/**
+ * Utility functions for toolbar configuration
+ */
+export class ToolbarUtils {
+  /**
+   * Find a toolbar group configuration by name
+   * @param {ToolbarOptions | undefined} toolbarOptions - Toolbar configuration array
+   * @param {string} groupName - Name of the toolbar group
+   * @returns {ToolbarGroup | undefined} The group configuration if found
+   */
+  private static findGroup(
+    toolbarOptions: ToolbarOptions | undefined,
+    groupName: string
+  ): any {
+    if (!toolbarOptions) {
+      return undefined;
+    }
+    return toolbarOptions.find((group) =>
+      'name' in group ? group.name === groupName : group.id === groupName
+    );
+  }
+
+  /**
+   * Check if a toolbar group should be rendered based on configuration
+   * @param {ToolbarOptions | undefined} toolbarOptions - Toolbar configuration array
+   * @param {string} groupName - Name of the toolbar group
+   * @returns {boolean} True if the group should be rendered
+   */
+  public static shouldRenderGroup(
+    toolbarOptions: ToolbarOptions | undefined,
+    groupName: string
+  ): boolean {
+    const groupConfig = this.findGroup(toolbarOptions, groupName);
+
+    // If no config provided, render by default
+    if (!groupConfig) {
+      return true;
+    }
+
+    // If enabled is explicitly set, use that value
+    if (groupConfig.enabled !== undefined) {
+      return groupConfig.enabled;
+    }
+
+    // Default to true if enabled is not specified
+    return true;
+  }
+
+  /**
+   * Check if a specific item within a group should be rendered
+   * @param {ToolbarOptions | undefined} toolbarOptions - Toolbar configuration array
+   * @param {string} groupName - Name of the toolbar group
+   * @param {string} itemName - Name of the item within the group
+   * @returns {boolean} True if the item should be rendered
+   */
+  public static shouldRenderItem(
+    toolbarOptions: ToolbarOptions | undefined,
+    groupName: string,
+    itemName: string
+  ): boolean {
+    const groupConfig = this.findGroup(toolbarOptions, groupName);
+
+    // If no group config or no items config, render by default
+    if (!groupConfig?.items) {
+      return true;
+    }
+
+    // If item is explicitly configured, use that value
+    if (groupConfig.items[itemName] !== undefined) {
+      return groupConfig.items[itemName];
+    }
+
+    // Default to true if item is not specified
+    return true;
+  }
+}
+
+/**
+ * Utility functions for color picker interactions
+ */
+export class ColorPickerUtils {
+  /**
+   * Toggle color picker open/closed state
+   * @param {ShadowRoot} renderRoot - The shadow root containing the color picker
+   * @param {Event} event - Click event from the trigger button
+   */
+  public static toggleColorPicker(renderRoot: ShadowRoot, event: Event): void {
+    event.stopPropagation();
+    const picker = renderRoot.querySelector('clabs-style-picker');
+    if (picker) {
+      picker.toggleAttribute('open');
+    }
+  }
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.scss
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.scss
@@ -1,0 +1,226 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+$css--plex: true !default;
+
+@use '../../../../../globals/scss/vars' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/type' as *;
+@use './carbon-elements' as *;
+@use './overrides' as *;
+
+:host(#{$clabs-prefix}-wysiwyg) {
+  display: block;
+  box-sizing: border-box;
+  block-size: 100%;
+  inline-size: 100%;
+
+  .#{$clabs-prefix}--wysiwyg__editor-container {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid $border-subtle-01;
+    background: $layer-01;
+    block-size: 100%;
+  }
+
+  .#{$clabs-prefix}--wysiwyg__toolbar {
+    position: sticky;
+    z-index: 1000;
+    display: flex;
+    flex-wrap: wrap;
+    background: $layer;
+    box-shadow: inset 0 -1px 0 0 $border-subtle-01;
+    inset-block-start: 0;
+    margin-block-start: -1px;
+    margin-inline-start: -1px;
+    padding-block-start: 1px;
+
+    svg {
+      pointer-events: none;
+    }
+  }
+
+  .#{$clabs-prefix}--wysiwyg__toolbar-group {
+    display: flex;
+    flex-direction: row;
+    border: 1px solid $border-subtle-01;
+    background: $layer;
+    margin-block-start: -1px;
+    margin-inline-end: -1px;
+
+    // stylelint-disable-next-line selector-type-no-unknown
+    &:has(cds-dropdown, cds-search) {
+      flex: 1;
+    }
+  }
+
+  .#{$clabs-prefix}--wysiwyg__toolbar-button {
+    display: inline-block;
+  }
+
+  .#{$clabs-prefix}--wysiwyg__editor-content {
+    flex: 1;
+    padding: $spacing-05;
+    background: $layer;
+    overflow-y: auto;
+  }
+
+  .#{$clabs-prefix}--wysiwyg__popover-wrapper {
+    position: relative;
+  }
+
+  .#{$clabs-prefix}--wysiwyg__popover-content {
+    display: flex;
+    flex-direction: column;
+    padding: $spacing-05;
+    background-color: $layer-02;
+    gap: $spacing-03;
+    min-inline-size: 300px;
+  }
+
+  .#{$clabs-prefix}--wysiwyg__popover-actions {
+    display: grid;
+    gap: $spacing-03;
+    grid-auto-columns: 1fr;
+    grid-auto-flow: column;
+    margin-block-start: $spacing-05;
+  }
+
+  .#{$clabs-prefix}--wysiwyg__attachments {
+    display: flex;
+    overflow: scroll;
+    border-block-start: 1px solid $border-subtle-01;
+  }
+
+  // ProseMirror editor base styles
+  .ProseMirror {
+    color: $text-primary;
+    min-block-size: 200px;
+    outline: none;
+    white-space: pre-wrap;
+  }
+
+  // Image resize wrapper
+  .ProseMirror [data-resize-wrapper] {
+    position: relative;
+    display: inline-block;
+
+    img {
+      display: block;
+      block-size: auto;
+      max-inline-size: 100%;
+    }
+  }
+
+  // Hide resize handles by default
+  .ProseMirror [data-resize-wrapper] [data-resize-handle] {
+    position: absolute;
+    z-index: 10;
+    background: $border-interactive;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s;
+  }
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    .ProseMirror [data-resize-wrapper] [data-resize-handle] {
+      transition: none;
+    }
+  }
+
+  // Show handles on hover or when image is selected
+  .ProseMirror [data-resize-wrapper]:hover [data-resize-handle],
+  .ProseMirror
+    [data-resize-wrapper]:has(img.ProseMirror-selectednode)
+    [data-resize-handle] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  // Edge handles - bars
+  .ProseMirror [data-resize-wrapper] [data-resize-handle='top'] {
+    block-size: 2px;
+    cursor: ns-resize;
+    inline-size: 100%;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+  }
+
+  .ProseMirror [data-resize-wrapper] [data-resize-handle='bottom'] {
+    block-size: 2px;
+    cursor: ns-resize;
+    inline-size: 100%;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+  }
+
+  .ProseMirror [data-resize-wrapper] [data-resize-handle='left'] {
+    block-size: 100%;
+    cursor: ew-resize;
+    inline-size: 2px;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+  }
+
+  .ProseMirror [data-resize-wrapper] [data-resize-handle='right'] {
+    block-size: 100%;
+    cursor: ew-resize;
+    inline-size: 2px;
+    inset-block-start: 0;
+    inset-inline-end: 0;
+  }
+
+  // Corner handles - triangles
+  .ProseMirror [data-resize-wrapper] [data-resize-handle='top-left'] {
+    border-width: 12px 12px 0 0;
+    border-style: solid;
+    border-color: $border-interactive transparent transparent transparent;
+    background: transparent;
+    block-size: 0;
+    cursor: nwse-resize;
+    inline-size: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+  }
+
+  .ProseMirror [data-resize-wrapper] [data-resize-handle='top-right'] {
+    border-width: 0 12px 12px 0;
+    border-style: solid;
+    border-color: transparent $border-interactive transparent transparent;
+    background: transparent;
+    block-size: 0;
+    cursor: nesw-resize;
+    inline-size: 0;
+    inset-block-start: 0;
+    inset-inline-end: 0;
+  }
+
+  .ProseMirror [data-resize-wrapper] [data-resize-handle='bottom-left'] {
+    border-width: 12px 0 0 12px;
+    border-style: solid;
+    border-color: transparent transparent transparent $border-interactive;
+    background: transparent;
+    block-size: 0;
+    cursor: nesw-resize;
+    inline-size: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+  }
+
+  .ProseMirror [data-resize-wrapper] [data-resize-handle='bottom-right'] {
+    border-width: 0 0 12px 12px;
+    border-style: solid;
+    border-color: transparent transparent $border-interactive;
+    background: transparent;
+    block-size: 0;
+    cursor: nwse-resize;
+    inline-size: 0;
+    inset-block-end: 0;
+    inset-inline-end: 0;
+  }
+}

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.scss
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.scss
@@ -17,7 +17,7 @@ $css--plex: true !default;
 :host(#{$clabs-prefix}-wysiwyg) {
   display: block;
   box-sizing: border-box;
-  block-size: 100%;
+  block-size: calc(100% - 2px);
   inline-size: 100%;
 
   .#{$clabs-prefix}--wysiwyg__editor-container {
@@ -99,6 +99,8 @@ $css--plex: true !default;
 
   // ProseMirror editor base styles
   .ProseMirror {
+    overflow: auto;
+    block-size: 100%;
     color: $text-primary;
     min-block-size: 200px;
     outline: none;

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.scss
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.scss
@@ -64,8 +64,8 @@ $css--plex: true !default;
   }
 
   .#{$clabs-prefix}--wysiwyg__editor-content {
-    flex: 1;
     display: contents;
+    flex: 1;
     background: $layer;
     overflow-y: auto;
   }
@@ -93,19 +93,19 @@ $css--plex: true !default;
 
   .#{$clabs-prefix}--wysiwyg__attachments {
     display: flex;
-    flex: none;
     overflow: scroll;
+    flex: none;
     border-block-start: 1px solid $border-subtle-01;
   }
 
   // ProseMirror editor base styles
   .ProseMirror {
     overflow: auto;
+    padding: $spacing-05;
     block-size: 100%;
     color: $text-primary;
     min-block-size: 200px;
     outline: none;
-    padding: $spacing-05;
     white-space: pre-wrap;
   }
 

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.scss
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.scss
@@ -65,7 +65,7 @@ $css--plex: true !default;
 
   .#{$clabs-prefix}--wysiwyg__editor-content {
     flex: 1;
-    padding: $spacing-05;
+    display: contents;
     background: $layer;
     overflow-y: auto;
   }
@@ -93,6 +93,7 @@ $css--plex: true !default;
 
   .#{$clabs-prefix}--wysiwyg__attachments {
     display: flex;
+    flex: none;
     overflow: scroll;
     border-block-start: 1px solid $border-subtle-01;
   }
@@ -104,6 +105,7 @@ $css--plex: true !default;
     color: $text-primary;
     min-block-size: 200px;
     outline: none;
+    padding: $spacing-05;
     white-space: pre-wrap;
   }
 

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
@@ -1090,13 +1090,19 @@ class wysiwyg extends LitElement {
       <div class="${CSS_CLASSES.editorContainer}">
         ${shouldRenderToolbar
           ? html`
-              <div class="${CSS_CLASSES.toolbar}" orientation="horizontal">
+              <div
+                part="toolbar"
+                class="${CSS_CLASSES.toolbar}"
+                orientation="horizontal">
                 ${this.renderUndoRedoGroup()} ${this.renderAllToolbarGroups()}
               </div>
             `
           : nothing}
 
-        <div class="${CSS_CLASSES.editorContent}" role="region"></div>
+        <div
+          part="editor"
+          class="${CSS_CLASSES.editorContent}"
+          role="region"></div>
 
         ${this.renderAttachedFiles()}
       </div>

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
@@ -1090,19 +1090,13 @@ class wysiwyg extends LitElement {
       <div class="${CSS_CLASSES.editorContainer}">
         ${shouldRenderToolbar
           ? html`
-              <div
-                part="toolbar"
-                class="${CSS_CLASSES.toolbar}"
-                orientation="horizontal">
+              <div class="${CSS_CLASSES.toolbar}" orientation="horizontal">
                 ${this.renderUndoRedoGroup()} ${this.renderAllToolbarGroups()}
               </div>
             `
           : nothing}
 
-        <div
-          part="editor"
-          class="${CSS_CLASSES.editorContent}"
-          role="region"></div>
+        <div class="${CSS_CLASSES.editorContent}" role="region"></div>
 
         ${this.renderAttachedFiles()}
       </div>

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
@@ -986,9 +986,6 @@ class wysiwyg extends LitElement {
   }
 
   /**
-   * Renders the editor toolbar, content area, and active popovers.
-   */
-  /**
    * Default order for toolbar groups when no custom configuration is provided
    */
   private readonly DEFAULT_GROUP_ORDER = DEFAULT_GROUP_ORDER;
@@ -1024,10 +1021,6 @@ class wysiwyg extends LitElement {
     tableOperations: () => this.renderTableOperations(),
   };
 
-  /**
-   * Render toolbar groups based on array configuration
-   * @returns {Array} Array of template results for toolbar groups
-   */
   /**
    * Render all toolbar groups (standard + custom) in the correct order
    * @returns {Array<TemplateResult | typeof nothing>} Array of toolbar group templates
@@ -1094,7 +1087,7 @@ class wysiwyg extends LitElement {
                 ${this.renderUndoRedoGroup()} ${this.renderAllToolbarGroups()}
               </div>
             `
-          : ''}
+          : nothing}
 
         <div class="${CSS_CLASSES.editorContent}" role="region"></div>
 

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
@@ -1,0 +1,1107 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { LitElement, html, nothing } from 'lit';
+import type { TemplateResult } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import type { Editor } from '@tiptap/core';
+import { settings } from '@carbon-labs/utilities';
+
+const { stablePrefix: clabsPrefix } = settings;
+
+// Carbon components
+import '@carbon/web-components/es/components/icon-button/index.js';
+import '@carbon/web-components/es/components/button/index.js';
+import '@carbon/web-components/es/components/dropdown/index.js';
+import '@carbon/web-components/es/components/overflow-menu/index.js';
+import '@carbon/web-components/es/components/popover/index.js';
+import '@carbon/web-components/es/components/text-input/index.js';
+import '@carbon/web-components/es/components/file-uploader/index.js';
+import '@carbon/web-components/es/components/search/index.js';
+import '@carbon-labs/wc-style-picker/es/index.js';
+import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
+
+// Services and utilities
+import { EditorService } from './services/editor.service';
+import { PopoverService } from './services/popover.service';
+import { DOMUtils } from './utils/dom.utils';
+import { EditorUtils } from './utils/editor.utils';
+import { FileUtils, FileMetadata } from './utils/file.utils';
+import {
+  ThemeUtils,
+  RenderUtils,
+  ToolbarUtils,
+  ColorPickerUtils,
+} from './utils/render.utils';
+
+// Types and constants
+import type {
+  HeadingLevel,
+  PopoverState,
+  EditorContentChangeDetail,
+  ToolbarOptions,
+  CustomToolbarGroup,
+} from './types/editor.types.js';
+import {
+  DEFAULT_TABLE_OPTIONS,
+  NAVIGATION_KEYS,
+  FOCUSABLE_SELECTORS,
+  TOOLTIP_CONFIG,
+  POPOVER_LABELS,
+  TOOLBAR_LABELS,
+  TABLE_MENU_ITEMS,
+  FONT_FAMILIES,
+  TEXT_COLOR_GROUPS,
+  CSS_CLASSES,
+  FILE_ATTACHMENT_CONFIG,
+  TEXT_FORMATTING_BUTTONS,
+  CLIPBOARD_BUTTONS,
+  LIST_BUTTONS,
+  BLOCK_BUTTONS,
+  type ButtonConfig,
+} from './constants/editor.constants.js';
+import { EDITOR_ICONS } from './constants/icons.constants.js';
+
+// @ts-ignore
+import styles from './wysiwyg.scss?inline';
+
+/**
+ * Default order for toolbar groups when no custom configuration is provided
+ */
+export const DEFAULT_GROUP_ORDER = [
+  'clipboard',
+  'fontFamily',
+  'textFormatting',
+  'blocks',
+  'headings',
+  'colorPicker',
+  'lists',
+  'alignment',
+  'insert',
+  'search',
+  'tableOperations',
+] as const;
+
+/**
+ * WYSIWYG Editor Web Component
+ * A rich text editor built with TipTap and Carbon Design System
+ */
+class wysiwyg extends LitElement {
+  static styles = styles;
+
+  @property({ type: String })
+  content = '';
+
+  @property({ type: Array })
+  toolbarOptions?: ToolbarOptions;
+
+  @property({ type: Array })
+  files: FileMetadata[] = [];
+
+  @state() private popoverState: PopoverState =
+    PopoverService.createInitialState();
+
+  @state() private selectedColor = ThemeUtils.getDefaultTextColor();
+
+  private editorService = new EditorService();
+  public editor: Editor | null = null; // public for extensions
+  private isUpdatingFromEditor = false; // Flag to track editor-initiated updates
+
+  /**
+   * Get the TipTap editor instance
+   * Allows users to call custom methods on the editor
+   * @returns {Editor | null} The editor instance or null if not initialized
+   * @example
+   * const editor = document.querySelector('clabs-wysiwyg').editor;
+   * if (editor) {
+   *   editor.chain().focus().toggleBold().run();
+   * }
+   */
+  public get editorInstance(): Editor | null {
+    return this.editor;
+  }
+
+  /**
+   * Runs after the component's DOM has been rendered for the first time.
+   */
+  protected firstUpdated(): void {
+    this.setAttribute('role', 'application');
+    this.addEventListener('keydown', this.handleKeydown);
+    this.initializeEditor();
+    this.initializeFocusableElements();
+  }
+
+  /**
+   * Cleans up editor resources and event listeners when disconnected.
+   */
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.editorService.destroy();
+    this.removeEventListener('keydown', this.handleKeydown);
+  }
+
+  /**
+   * Called before update to handle property changes.
+   * Syncs external content updates into the editor instance.
+   *
+   * @param {Map<string, unknown>} changedProperties - Changed reactive properties.
+   */
+  protected willUpdate(changedProperties: Map<string, unknown>): void {
+    if (
+      changedProperties.has('content') &&
+      this.editor &&
+      this.content !== this.editor.getHTML() &&
+      !this.isUpdatingFromEditor
+    ) {
+      // Update editor content without triggering another update cycle
+      this.editorService.setContent(this.content);
+    }
+  }
+
+  /**
+   * Initializes the TipTap editor instance.
+   */
+  private initializeEditor(): void {
+    const editorElement = this.renderRoot.querySelector(
+      `.${CSS_CLASSES.editorContent}`
+    ) as HTMLElement;
+    if (!editorElement) {
+      return;
+    }
+
+    // Destroy existing editor if any to prevent duplicate extensions
+    if (this.editor) {
+      this.editorService.destroy();
+    }
+
+    this.editor = this.editorService.initialize(
+      editorElement,
+      { content: this.content, orientation: 'horizontal' },
+      (editor: Editor) => {
+        // Mark that this update is coming from the editor to prevent circular updates
+        this.isUpdatingFromEditor = true;
+        this.content = editor.getHTML();
+        this.dispatchEvent(
+          new CustomEvent(`${clabsPrefix}-wysiwyg-on-change`, {
+            detail: {
+              content: this.content,
+              editor,
+            } satisfies EditorContentChangeDetail,
+            bubbles: true,
+            composed: true,
+          })
+        );
+        // Reset flag after the current microtask completes
+        queueMicrotask(() => {
+          this.isUpdatingFromEditor = false;
+        });
+      },
+      () => {
+        // Use requestAnimationFrame to defer update and avoid scheduling during update
+        requestAnimationFrame(() => this.requestUpdate());
+      }
+    );
+  }
+
+  /**
+   * Initializes roving tabindex behavior for toolbar controls.
+   * Sets focus on the first non-disabled element.
+   */
+  private initializeFocusableElements(): void {
+    requestAnimationFrame(() => {
+      const elements = DOMUtils.getFocusableElements(
+        this.renderRoot as ShadowRoot,
+        FOCUSABLE_SELECTORS
+      );
+      const firstEnabledIndex = DOMUtils.findFirstEnabledIndex(elements);
+      DOMUtils.updateTabIndexes(elements, firstEnabledIndex);
+    });
+  }
+
+  /**
+   * Handles keyboard navigation across toolbar controls.
+   *
+   * @param {KeyboardEvent} event - Keyboard event from the component root.
+   */
+  private handleKeydown = (event: KeyboardEvent): void => {
+    // Only handle arrow keys
+    if (
+      !NAVIGATION_KEYS.all.includes(
+        event.key as (typeof NAVIGATION_KEYS.all)[number]
+      )
+    ) {
+      return;
+    }
+
+    const activeElement =
+      this.renderRoot instanceof ShadowRoot
+        ? this.renderRoot.activeElement
+        : document.activeElement;
+
+    // Only handle keyboard navigation when focus is on toolbar elements
+    // Do not interfere with arrow key navigation in the editor content
+    const toolbar = this.renderRoot.querySelector(`.${CSS_CLASSES.toolbar}`);
+    const isInToolbar = toolbar?.contains(activeElement as Node);
+
+    if (!isInToolbar) {
+      return;
+    }
+
+    const elements = DOMUtils.getFocusableElements(
+      this.renderRoot as ShadowRoot,
+      FOCUSABLE_SELECTORS
+    );
+    const current = elements.findIndex((el) => {
+      // For cds-icon-button, check the button inside shadow DOM
+      if (el.tagName.toLowerCase() === 'cds-icon-button') {
+        const button = el.shadowRoot?.querySelector('button');
+        return button?.getAttribute('tabindex') === '0';
+      }
+      // For other elements, check the element itself
+      return el.getAttribute('tabindex') === '0';
+    });
+    if (current === -1) {
+      return;
+    }
+
+    event.preventDefault();
+    const next = DOMUtils.getNextFocusIndex(
+      event.key,
+      current,
+      elements.length,
+      'horizontal'
+    );
+
+    DOMUtils.updateTabIndexes(elements, next);
+    elements[next].focus();
+  };
+
+  /**
+   * Returns the currently active heading value for the dropdown.
+   */
+  private getHeadingValue(): 'p' | `h${HeadingLevel}` {
+    return EditorUtils.getCurrentHeadingValue(this.editorService);
+  }
+
+  /**
+   * Handles heading dropdown selection changes.
+   *
+   * @param {CustomEvent} e - Dropdown selection event.
+   */
+  private handleHeadingChange = (
+    e: CustomEvent<{ item: { value: 'p' | `h${HeadingLevel}` } }>
+  ): void => {
+    const value = e.detail.item.value;
+    const level = EditorUtils.parseHeadingLevel(value);
+    if (level === null) {
+      this.editorService.setParagraph();
+    } else {
+      this.editorService.setHeading(level);
+    }
+  };
+
+  /**
+   * Generic handler for popover input changes.
+   * @param {keyof PopoverState} field - The field to update
+   * @param {InputEvent} e - Input event
+   */
+  private handlePopoverInput = (
+    field: keyof PopoverState,
+    e: InputEvent
+  ): void => {
+    this.popoverState = PopoverService.update(this.popoverState, {
+      [field]: (e.target as HTMLInputElement).value,
+    } as Partial<PopoverState>);
+  };
+
+  /**
+   * Opens the link popover and preloads the current link value.
+   */
+  private openLinkPopover = (): void => {
+    this.popoverState = PopoverService.update(this.popoverState, {
+      showLinkPopover: true,
+      linkUrl: this.editorService.getLinkAttributes()?.href || '',
+    });
+  };
+
+  /**
+   * Closes the link popover and resets its input state.
+   */
+  private closeLinkPopover = (): void => {
+    this.popoverState = PopoverService.reset(
+      PopoverService.update(this.popoverState, { showLinkPopover: false }),
+      'linkUrl'
+    );
+  };
+
+  /**
+   * Applies the current link popover value to the editor selection.
+   */
+  private setLink = (): void => {
+    if (!this.popoverState.linkUrl) {
+      this.editorService.unsetLink();
+    } else if (EditorUtils.isValidURL(this.popoverState.linkUrl)) {
+      this.editorService.setLink({ href: this.popoverState.linkUrl });
+    }
+    this.closeLinkPopover();
+  };
+
+  /**
+   * Removes the current link from the editor selection.
+   */
+  private unsetLink = (): void => {
+    this.editorService.unsetLink();
+    this.closeLinkPopover();
+  };
+
+  /**
+   * Opens the image insertion popover.
+   */
+  private openImagePopover = (): void => {
+    this.popoverState = PopoverService.update(this.popoverState, {
+      showImagePopover: true,
+    });
+  };
+
+  /**
+   * Closes the image popover and resets its input state.
+   */
+  private closeImagePopover = (): void => {
+    this.popoverState = PopoverService.reset(
+      PopoverService.update(this.popoverState, { showImagePopover: false }),
+      'imageUrl',
+      'imageAlt',
+      'imageTitle'
+    );
+  };
+
+  /**
+   * Inserts an image when the popover contains a valid URL.
+   */
+  private insertImage = (): void => {
+    if (
+      this.popoverState.imageUrl &&
+      EditorUtils.isValidURL(this.popoverState.imageUrl)
+    ) {
+      this.editorService.insertImage({
+        src: this.popoverState.imageUrl,
+        alt: this.popoverState.imageAlt || undefined,
+        title: this.popoverState.imageTitle || undefined,
+      });
+      this.closeImagePopover();
+    }
+  };
+
+  /**
+   * Renders undo and redo controls.
+   */
+  private renderUndoRedoGroup(): TemplateResult {
+    return RenderUtils.renderToolbarGroup(
+      html`
+        ${RenderUtils.renderIconButton(
+          EDITOR_ICONS.Undo,
+          TOOLBAR_LABELS.undo,
+          () => this.editorService.undo(),
+          false,
+          !this.editorService.canUndo()
+        )}
+        ${RenderUtils.renderIconButton(
+          EDITOR_ICONS.Redo,
+          TOOLBAR_LABELS.redo,
+          () => this.editorService.redo(),
+          false,
+          !this.editorService.canRedo()
+        )}
+      `,
+      CSS_CLASSES.toolbarGroup
+    );
+  }
+
+  /**
+   * Helper to render conditional toolbar button.
+   * @param {string} group - Toolbar group name
+   * @param {string} item - Item name within the group
+   * @param {string} icon - Icon to display
+   * @param {string} label - Button label/tooltip
+   * @param {() => void} onClick - Click handler
+   * @param {boolean} [isActive] - Whether button is in active state
+   * @returns {TemplateResult | typeof nothing} Button template or nothing
+   */
+  /**
+   * Render a button from configuration
+   * @param {string} group - The toolbar group name
+   * @param {ButtonConfig} config - Button configuration
+   */
+  private renderButtonFromConfig(
+    group: string,
+    config: ButtonConfig
+  ): TemplateResult | typeof nothing {
+    if (!ToolbarUtils.shouldRenderItem(this.toolbarOptions, group, config.id)) {
+      return nothing;
+    }
+
+    const icon = EDITOR_ICONS[config.icon];
+    const isActive = config.checkActive
+      ? this.editorService.isActive(config.checkActive)
+      : undefined;
+
+    return RenderUtils.renderIconButton(
+      icon,
+      config.label,
+      () => this.editorService[config.action](),
+      isActive
+    );
+  }
+
+  /**
+   * Render buttons from configuration array
+   * @param {string} group - The toolbar group name
+   * @param {Array} buttons - Array of button configurations
+   */
+  private renderButtonGroup(
+    group: string,
+    buttons: readonly ButtonConfig[]
+  ): TemplateResult {
+    return RenderUtils.renderToolbarGroup(
+      html`${buttons.map((btn) => this.renderButtonFromConfig(group, btn))}`,
+      CSS_CLASSES.toolbarGroup
+    );
+  }
+
+  /**
+   * Render a conditional button
+   * @param {string} group - The toolbar group name
+   * @param {string} item - Item name within group
+   * @param {string} icon - Icon to display
+   * @param {string} label - Button label/tooltip
+   * @param {() => void} onClick - Click handler
+   * @param {boolean} [isActive] - Whether button is in active state
+   * @returns {TemplateResult | typeof nothing} Button template or nothing
+   */
+  private renderConditionalButton(
+    group: string,
+    item: string,
+    icon: string,
+    label: string,
+    onClick: () => void,
+    isActive?: boolean
+  ): TemplateResult | typeof nothing {
+    return ToolbarUtils.shouldRenderItem(this.toolbarOptions, group, item)
+      ? RenderUtils.renderIconButton(icon, label, onClick, isActive)
+      : nothing;
+  }
+
+  /** Renders cut, copy, paste controls */
+  private renderClipboardGroup(): TemplateResult {
+    return this.renderButtonGroup('clipboard', CLIPBOARD_BUTTONS);
+  }
+
+  /** Renders inline text formatting controls */
+  private renderTextFormattingGroup(): TemplateResult {
+    return this.renderButtonGroup('textFormatting', TEXT_FORMATTING_BUTTONS);
+  }
+
+  /**
+   * Renders the heading selection control.
+   */
+  private renderHeadingsGroup(): TemplateResult {
+    return RenderUtils.renderToolbarGroup(
+      html`
+        <cds-dropdown
+          label="Text style"
+          title="Text style"
+          value=${this.getHeadingValue()}
+          @cds-dropdown-selected=${this.handleHeadingChange}>
+          <cds-dropdown-item value="p">Paragraph</cds-dropdown-item>
+          <cds-dropdown-item value="h1">Heading 1</cds-dropdown-item>
+          <cds-dropdown-item value="h2">Heading 2</cds-dropdown-item>
+          <cds-dropdown-item value="h3">Heading 3</cds-dropdown-item>
+          <cds-dropdown-item value="h4">Heading 4</cds-dropdown-item>
+          <cds-dropdown-item value="h5">Heading 5</cds-dropdown-item>
+          <cds-dropdown-item value="h6">Heading 6</cds-dropdown-item>
+        </cds-dropdown>
+      `,
+      CSS_CLASSES.toolbarGroup
+    );
+  }
+
+  /**
+   * Renders the font family selection control.
+   */
+  private renderFontFamilyGroup(): TemplateResult {
+    const currentFont =
+      this.editor?.getAttributes('textStyle')?.fontFamily || 'IBM Plex Sans';
+
+    return RenderUtils.renderToolbarGroup(
+      html`
+        <cds-dropdown
+          label="Typeface"
+          title="Typeface"
+          value=${currentFont}
+          @cds-dropdown-selected=${(
+            e: CustomEvent<{ item: { value: string } }>
+          ) => {
+            const value = e.detail.item.value;
+            if (value) {
+              this.editorService.setFontFamily(value);
+            } else {
+              this.editorService.unsetFontFamily();
+            }
+          }}>
+          ${FONT_FAMILIES.map(
+            (font) => html`
+              <cds-dropdown-item value=${font.value}
+                >${font.label}</cds-dropdown-item
+              >
+            `
+          )}
+        </cds-dropdown>
+      `,
+      CSS_CLASSES.toolbarGroup
+    );
+  }
+
+  /**
+   * Renders list formatting controls including task list.
+   */
+  /** Renders list controls */
+  private renderListsGroup(): TemplateResult {
+    return this.renderButtonGroup('lists', LIST_BUTTONS);
+  }
+
+  /**
+   * Renders text alignment controls including justify.
+   */
+  /**
+   * Helper to render alignment button with toggle logic.
+   * @param {string} item - Item name within alignment group
+   * @param {string} icon - Icon to display
+   * @param {string} label - Button label/tooltip
+   * @param {'left' | 'center' | 'right' | 'justify'} alignment - Text alignment value
+   * @returns {TemplateResult | typeof nothing} Button template or nothing
+   */
+  private renderAlignmentButton(
+    item: string,
+    icon: string,
+    label: string,
+    alignment: 'left' | 'center' | 'right' | 'justify'
+  ): TemplateResult | typeof nothing {
+    return this.renderConditionalButton(
+      'alignment',
+      item,
+      icon,
+      label,
+      () => {
+        const isActive = this.editorService.isActive('textAlign', {
+          textAlign: alignment,
+        });
+        this.editorService.setTextAlign(isActive ? 'left' : alignment);
+      },
+      this.editorService.isActive('textAlign', { textAlign: alignment })
+    );
+  }
+
+  /**
+   * Renders text alignment controls including justify.
+   */
+  private renderAlignmentGroup(): TemplateResult {
+    return RenderUtils.renderToolbarGroup(
+      html`
+        ${this.renderAlignmentButton(
+          'left',
+          EDITOR_ICONS.TextAlignLeft,
+          TOOLBAR_LABELS.alignLeft,
+          'left'
+        )}
+        ${this.renderAlignmentButton(
+          'center',
+          EDITOR_ICONS.TextAlignCenter,
+          TOOLBAR_LABELS.alignCenter,
+          'center'
+        )}
+        ${this.renderAlignmentButton(
+          'right',
+          EDITOR_ICONS.TextAlignRight,
+          TOOLBAR_LABELS.alignRight,
+          'right'
+        )}
+        ${this.renderAlignmentButton(
+          'justify',
+          EDITOR_ICONS.TextAlignJustify,
+          TOOLBAR_LABELS.alignJustify,
+          'justify'
+        )}
+      `,
+      CSS_CLASSES.toolbarGroup
+    );
+  }
+
+  /**
+   * Toggles the color picker open/closed state.
+   *
+   * @param {Event} e - Click event from the trigger button.
+   */
+  private toggleColorPicker = (e: Event): void => {
+    ColorPickerUtils.toggleColorPicker(this.renderRoot as ShadowRoot, e);
+  };
+
+  /**
+   * Renders text color picker control using clabs-style-picker.
+   */
+  private renderColorPickerGroup(): TemplateResult {
+    return RenderUtils.renderToolbarGroup(
+      html`
+        <clabs-style-picker kind="single" heading="Text Color">
+          <cds-icon-button
+            slot="trigger"
+            size="md"
+            kind="ghost"
+            class="${CSS_CLASSES.textColorButton}"
+            style="--selected-text-color: ${this.selectedColor ||
+            ThemeUtils.getDefaultTextColor()}"
+            enter-delay-ms="${TOOLTIP_CONFIG.enterDelayMs}"
+            leave-delay-ms="${TOOLTIP_CONFIG.leaveDelayMs}"
+            align="${TOOLTIP_CONFIG.align}"
+            @click=${this.toggleColorPicker}>
+            ${iconLoader(EDITOR_ICONS.TextColor, { slot: 'icon' })}
+            <span slot="tooltip-content">${TOOLBAR_LABELS.textColor}</span>
+          </cds-icon-button>
+          <clabs-style-picker-group heading="Colors">
+            ${TEXT_COLOR_GROUPS.map((group) =>
+              group.items.map((option) => {
+                const colorValue = ThemeUtils.getTokenColor(option.token);
+                return html`
+                  <clabs-style-picker-option
+                    value=${colorValue}
+                    title=${option.label}
+                    ?selected=${this.selectedColor === colorValue}
+                    @clabs-style-picker-option-select=${(e: CustomEvent) => {
+                      const color = e.detail.value;
+                      if (color) {
+                        this.selectedColor = color;
+                        this.editorService.setColor(color);
+                      }
+                    }}>
+                    <clabs-style-picker-color
+                      label=${option.label}
+                      color=${colorValue}></clabs-style-picker-color>
+                  </clabs-style-picker-option>
+                `;
+              })
+            )}
+          </clabs-style-picker-group>
+        </clabs-style-picker>
+      `,
+      CSS_CLASSES.toolbarGroup
+    );
+  }
+
+  /**
+   * Renders block-level formatting controls.
+   */
+  /** Renders block controls */
+  private renderBlocksGroup(): TemplateResult {
+    return this.renderButtonGroup('blocks', BLOCK_BUTTONS);
+  }
+
+  /**
+   * Renders insert actions for tables, links, and images.
+   */
+  private renderInsertGroup(): TemplateResult {
+    return RenderUtils.renderToolbarGroup(
+      html`
+        ${this.renderConditionalButton(
+          'insert',
+          'table',
+          EDITOR_ICONS.Table,
+          TOOLBAR_LABELS.insertTable,
+          () => this.editorService.insertTable(DEFAULT_TABLE_OPTIONS)
+        )}
+        ${ToolbarUtils.shouldRenderItem(this.toolbarOptions, 'insert', 'link')
+          ? html`
+              <cds-popover
+                tabtip
+                autoalign
+                ?open=${this.popoverState.showLinkPopover}
+                align="bottom"
+                @cds-popover-closed=${this.closeLinkPopover}>
+                ${RenderUtils.renderIconButton(
+                  EDITOR_ICONS.Link,
+                  TOOLBAR_LABELS.insertLink,
+                  this.openLinkPopover,
+                  this.editorService.isActive('link')
+                )}
+                <cds-popover-content>
+                  <div class="${CSS_CLASSES.popoverContent}">
+                    <cds-text-input
+                      label="${POPOVER_LABELS.link.urlLabel}"
+                      placeholder="${POPOVER_LABELS.link.urlPlaceholder}"
+                      .value=${this.popoverState.linkUrl}
+                      @input=${(e: InputEvent) =>
+                        this.handlePopoverInput('linkUrl', e)}></cds-text-input>
+                    <div class="${CSS_CLASSES.popoverActions}">
+                      <cds-button
+                        size="sm"
+                        kind="secondary"
+                        @click=${this.unsetLink}>
+                        ${POPOVER_LABELS.link.removeButton}
+                      </cds-button>
+                      <cds-button
+                        size="sm"
+                        kind="primary"
+                        @click=${this.setLink}>
+                        ${POPOVER_LABELS.link.insertButton}
+                      </cds-button>
+                    </div>
+                  </div>
+                </cds-popover-content>
+              </cds-popover>
+            `
+          : nothing}
+        ${ToolbarUtils.shouldRenderItem(this.toolbarOptions, 'insert', 'image')
+          ? html`
+              <cds-popover
+                ?open=${this.popoverState.showImagePopover}
+                align="bottom"
+                tabtip
+                autoalign
+                @cds-popover-closed=${this.closeImagePopover}>
+                ${RenderUtils.renderIconButton(
+                  EDITOR_ICONS.Image,
+                  TOOLBAR_LABELS.insertImage,
+                  this.openImagePopover
+                )}
+                <cds-popover-content>
+                  <div class="${CSS_CLASSES.popoverContent}">
+                    <cds-text-input
+                      size="sm"
+                      label="${POPOVER_LABELS.image.urlLabel}"
+                      placeholder="${POPOVER_LABELS.image.urlPlaceholder}"
+                      .value=${this.popoverState.imageUrl}
+                      @input=${(e: InputEvent) =>
+                        this.handlePopoverInput(
+                          'imageUrl',
+                          e
+                        )}></cds-text-input>
+                    <cds-text-input
+                      size="sm"
+                      label="${POPOVER_LABELS.image.altLabel}"
+                      placeholder="${POPOVER_LABELS.image.altPlaceholder}"
+                      .value=${this.popoverState.imageAlt}
+                      @input=${(e: InputEvent) =>
+                        this.handlePopoverInput(
+                          'imageAlt',
+                          e
+                        )}></cds-text-input>
+                    <cds-text-input
+                      size="sm"
+                      label="${POPOVER_LABELS.image.titleLabel}"
+                      placeholder="${POPOVER_LABELS.image.titlePlaceholder}"
+                      .value=${this.popoverState.imageTitle}
+                      @input=${(e: InputEvent) =>
+                        this.handlePopoverInput(
+                          'imageTitle',
+                          e
+                        )}></cds-text-input>
+                    <div class="${CSS_CLASSES.popoverActions}">
+                      <cds-button
+                        size="sm"
+                        kind="secondary"
+                        @click=${this.closeImagePopover}>
+                        ${POPOVER_LABELS.image.cancelButton}
+                      </cds-button>
+                      <cds-button
+                        size="sm"
+                        kind="primary"
+                        @click=${this.insertImage}>
+                        ${POPOVER_LABELS.image.insertButton}
+                      </cds-button>
+                    </div>
+                  </div>
+                </cds-popover-content>
+              </cds-popover>
+            `
+          : nothing}
+        ${this.renderConditionalButton(
+          'insert',
+          'attachment',
+          EDITOR_ICONS.Attachment,
+          TOOLBAR_LABELS.attachment,
+          () => this.handleFileAttachment()
+        )}
+      `,
+      CSS_CLASSES.toolbarGroup
+    );
+  }
+
+  /**
+   * Handles file attachment logic.
+   */
+  private handleFileAttachment(): void {
+    FileUtils.triggerFileSelection(true, async (selectedFiles) => {
+      const newFiles = FileUtils.fileListToMetadata(selectedFiles);
+      this.files = [...this.files, ...newFiles];
+
+      const filesArray = Array.from(selectedFiles);
+      const imageFiles = filesArray.filter((file) =>
+        FileUtils.isImageFile(file)
+      );
+      const nonImageFiles = filesArray.filter(
+        (file) => !FileUtils.isImageFile(file)
+      );
+
+      // Insert images as actual images
+      for (const imageFile of imageFiles) {
+        try {
+          const dataURL = await FileUtils.fileToDataURL(imageFile);
+          this.editorService.insertImage({
+            src: dataURL,
+            alt: imageFile.name,
+          });
+        } catch (error) {
+          console.error('Failed to insert image:', error);
+        }
+      }
+
+      // Insert non-image files as text
+      if (nonImageFiles.length > 0) {
+        const fileNames = nonImageFiles.map((f) => f.name).join(', ');
+        this.editor
+          ?.chain()
+          .focus()
+          .insertContent(
+            `<p>${FILE_ATTACHMENT_CONFIG.attachmentPrefix}${fileNames}</p>`
+          )
+          .run();
+      }
+    });
+  }
+
+  /**
+   * Renders search component for finding text in the editor.
+   */
+  private renderSearchGroup(): TemplateResult {
+    return RenderUtils.renderToolbarGroup(
+      html`
+        <cds-search placeholder="No Integration yet" size="md"> </cds-search>
+      `,
+      CSS_CLASSES.toolbarGroup
+    );
+  }
+
+  /**
+   * Renders table-specific operations when the selection is inside a table.
+   */
+  private renderTableOperations(): TemplateResult | typeof nothing {
+    if (!this.editorService.isActive('table')) {
+      return nothing;
+    }
+
+    return RenderUtils.renderToolbarGroup(
+      html`
+        <div data-floating-menu-container class="${CSS_CLASSES.popoverWrapper}">
+          <cds-overflow-menu
+            autoalign
+            enter-delay-ms="${TOOLTIP_CONFIG.enterDelayMs}"
+            leave-delay-ms="${TOOLTIP_CONFIG.leaveDelayMs}">
+            ${iconLoader(EDITOR_ICONS.OverflowMenuVertical, {
+              class: 'cds--overflow-menu__icon',
+              slot: 'icon',
+            })}
+            <span slot="tooltip-content">${TOOLBAR_LABELS.tableOptions}</span>
+            <cds-overflow-menu-body flipped>
+              <cds-overflow-menu-item
+                @click=${() => this.editorService.addColumnBefore()}>
+                ${TABLE_MENU_ITEMS.addColumnBefore}
+              </cds-overflow-menu-item>
+              <cds-overflow-menu-item
+                @click=${() => this.editorService.addColumnAfter()}>
+                ${TABLE_MENU_ITEMS.addColumnAfter}
+              </cds-overflow-menu-item>
+              <cds-overflow-menu-item
+                @click=${() => this.editorService.deleteColumn()}>
+                ${TABLE_MENU_ITEMS.deleteColumn}
+              </cds-overflow-menu-item>
+              <cds-overflow-menu-item
+                divider
+                @click=${() => this.editorService.addRowBefore()}>
+                ${TABLE_MENU_ITEMS.addRowBefore}
+              </cds-overflow-menu-item>
+              <cds-overflow-menu-item
+                @click=${() => this.editorService.addRowAfter()}>
+                ${TABLE_MENU_ITEMS.addRowAfter}
+              </cds-overflow-menu-item>
+              <cds-overflow-menu-item
+                @click=${() => this.editorService.deleteRow()}>
+                ${TABLE_MENU_ITEMS.deleteRow}
+              </cds-overflow-menu-item>
+              <cds-overflow-menu-item
+                divider
+                @click=${() => this.editorService.toggleHeaderRow()}>
+                ${TABLE_MENU_ITEMS.toggleHeaderRow}
+              </cds-overflow-menu-item>
+              <cds-overflow-menu-item
+                divider
+                danger
+                @click=${() => this.editorService.deleteTable()}>
+                ${TABLE_MENU_ITEMS.deleteTable}
+              </cds-overflow-menu-item>
+            </cds-overflow-menu-body>
+          </cds-overflow-menu>
+        </div>
+      `,
+      CSS_CLASSES.toolbarGroup
+    );
+  }
+
+  /**
+   * Renders attached files as file uploader items.
+   */
+  private renderAttachedFiles(): TemplateResult | typeof nothing {
+    if (this.files.length === 0) {
+      return nothing;
+    }
+
+    return html`
+      <div class="${CSS_CLASSES.attachments}">
+        ${this.files.map(
+          (file, index) => html`
+            <cds-file-uploader-item
+              state="edit"
+              @cds-file-uploader-item-deleted=${() => {
+                this.files = this.files.filter((_, i) => i !== index);
+              }}>
+              ${file.name}
+            </cds-file-uploader-item>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  /**
+   * Renders the editor toolbar, content area, and active popovers.
+   */
+  /**
+   * Default order for toolbar groups when no custom configuration is provided
+   */
+  private readonly DEFAULT_GROUP_ORDER = DEFAULT_GROUP_ORDER;
+
+  /**
+   * Map of group names to their render methods
+   */
+  private groupRenderMap: Record<
+    string,
+    () => TemplateResult | typeof nothing
+  > = {
+    /** Clipboard group render method */
+    clipboard: () => this.renderClipboardGroup(),
+    /** Font family group render method */
+    fontFamily: () => this.renderFontFamilyGroup(),
+    /** Text formatting group render method */
+    textFormatting: () => this.renderTextFormattingGroup(),
+    /** Blocks group render method */
+    blocks: () => this.renderBlocksGroup(),
+    /** Headings group render method */
+    headings: () => this.renderHeadingsGroup(),
+    /** Color picker group render method */
+    colorPicker: () => this.renderColorPickerGroup(),
+    /** Lists group render method */
+    lists: () => this.renderListsGroup(),
+    /** Alignment group render method */
+    alignment: () => this.renderAlignmentGroup(),
+    /** Insert group render method */
+    insert: () => this.renderInsertGroup(),
+    /** Search group render method */
+    search: () => this.renderSearchGroup(),
+    /** Table operations group render method */
+    tableOperations: () => this.renderTableOperations(),
+  };
+
+  /**
+   * Render toolbar groups based on array configuration
+   * @returns {Array} Array of template results for toolbar groups
+   */
+  /**
+   * Render all toolbar groups (standard + custom) in the correct order
+   * @returns {Array<TemplateResult | typeof nothing>} Array of toolbar group templates
+   */
+  private renderAllToolbarGroups(): Array<TemplateResult | typeof nothing> {
+    const result: Array<TemplateResult | typeof nothing> = [];
+
+    // Determine which groups to render
+    const groupsToRender = !this.toolbarOptions
+      ? this.DEFAULT_GROUP_ORDER.map((name) => ({ name, enabled: true }))
+      : this.toolbarOptions.filter((group) => {
+          const groupIdentifier = 'name' in group ? group.name : group.id;
+          return ToolbarUtils.shouldRenderGroup(
+            this.toolbarOptions,
+            groupIdentifier
+          );
+        });
+
+    // Render each group in order (standard or custom)
+    groupsToRender.forEach((group) => {
+      // Check if this is a custom group (has 'id' and 'items' properties)
+      const isCustomGroup = 'id' in group && 'items' in group;
+
+      if (isCustomGroup) {
+        const customGroup = group as CustomToolbarGroup;
+        // Render custom group
+        result.push(
+          html`<div
+            class="${CSS_CLASSES.toolbarGroup}"
+            data-custom-group="${customGroup.id}">
+            ${customGroup.items.map((item) => item.render(this.editor))}
+          </div>`
+        );
+      } else {
+        // Render standard group
+        const standardGroup = group as {
+          name: string;
+          enabled?: boolean;
+          items?: Record<string, boolean>;
+        };
+        const renderMethod = this.groupRenderMap[standardGroup.name];
+        if (renderMethod) {
+          result.push(renderMethod());
+        }
+      }
+    });
+
+    return result;
+  }
+
+  /**
+   * Render the complete editor component
+   * @returns {TemplateResult} The editor template
+   */
+  protected render(): TemplateResult {
+    const shouldRenderToolbar =
+      !this.toolbarOptions || this.toolbarOptions.length > 0;
+
+    return html`
+      <div class="${CSS_CLASSES.editorContainer}">
+        ${shouldRenderToolbar
+          ? html`
+              <div class="${CSS_CLASSES.toolbar}" orientation="horizontal">
+                ${this.renderUndoRedoGroup()} ${this.renderAllToolbarGroups()}
+              </div>
+            `
+          : ''}
+
+        <div class="${CSS_CLASSES.editorContent}" role="region"></div>
+
+        ${this.renderAttachedFiles()}
+      </div>
+    `;
+  }
+}
+
+export default wysiwyg;

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
@@ -1086,7 +1086,17 @@ class wysiwyg extends LitElement {
     const shouldRenderToolbar =
       !this.toolbarOptions || this.toolbarOptions.length > 0;
 
+    const extensionStyles = this.extensions
+      ?.map((ext: any) => ext.styles)
+      .filter(Boolean)
+      .join('\n');
+
     return html`
+      ${extensionStyles
+        ? html`<style>
+            ${extensionStyles}
+          </style>`
+        : nothing}
       <div class="${CSS_CLASSES.editorContainer}">
         ${shouldRenderToolbar
           ? html`

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/src/wysiwyg.template.ts
@@ -10,7 +10,7 @@
 import { LitElement, html, nothing } from 'lit';
 import type { TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import type { Editor } from '@tiptap/core';
+import type { Editor, Extensions } from '@tiptap/core';
 import { settings } from '@carbon-labs/utilities';
 
 const { stablePrefix: clabsPrefix } = settings;
@@ -102,6 +102,9 @@ class wysiwyg extends LitElement {
   toolbarOptions?: ToolbarOptions;
 
   @property({ type: Array })
+  extensions?: Extensions;
+
+  @property({ type: Array })
   files: FileMetadata[] = [];
 
   @state() private popoverState: PopoverState =
@@ -110,7 +113,7 @@ class wysiwyg extends LitElement {
   @state() private selectedColor = ThemeUtils.getDefaultTextColor();
 
   private editorService = new EditorService();
-  public editor: Editor | null = null; // public for extensions
+  private editor: Editor | null = null;
   private isUpdatingFromEditor = false; // Flag to track editor-initiated updates
 
   /**
@@ -118,7 +121,7 @@ class wysiwyg extends LitElement {
    * Allows users to call custom methods on the editor
    * @returns {Editor | null} The editor instance or null if not initialized
    * @example
-   * const editor = document.querySelector('clabs-wysiwyg').editor;
+   * const editor = document.querySelector('clabs-wysiwyg').editorInstance;
    * if (editor) {
    *   editor.chain().focus().toggleBold().run();
    * }
@@ -182,7 +185,11 @@ class wysiwyg extends LitElement {
 
     this.editor = this.editorService.initialize(
       editorElement,
-      { content: this.content, orientation: 'horizontal' },
+      {
+        content: this.content,
+        orientation: 'horizontal',
+        extensions: this.extensions,
+      },
       (editor: Editor) => {
         // Mark that this update is coming from the editor to prevent circular updates
         this.isUpdatingFromEditor = true;

--- a/packages/web-components/src/components/wysiwyg/components/wysiwyg/wysiwyg.ts
+++ b/packages/web-components/src/components/wysiwyg/components/wysiwyg/wysiwyg.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { customElement } from 'lit/decorators.js';
+import { settings } from '@carbon-labs/utilities';
+import wysiwyg from './src/wysiwyg.template.js';
+
+const { stablePrefix: clabsPrefix } = settings;
+
+/**
+ * Component extending the wysiwyg template class
+ */
+@customElement(`${clabsPrefix}-wysiwyg`)
+class CLABSWysiwyg extends wysiwyg {}
+
+export default CLABSWysiwyg;

--- a/packages/web-components/src/components/wysiwyg/index.ts
+++ b/packages/web-components/src/components/wysiwyg/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './components/wysiwyg/wysiwyg.js';

--- a/packages/web-components/src/components/wysiwyg/package.json
+++ b/packages/web-components/src/components/wysiwyg/package.json
@@ -38,7 +38,7 @@
     "@carbon-labs/wc-style-picker": "0.21.0",
     "@carbon/element-styles": "^0.2.5",
     "@carbon/styles": "^1.107.0",
-    "@carbon/web-components": "^2.40.0",
+    "@carbon/web-components": "^2.41.0",
     "@tiptap/core": "^3.23.6",
     "@tiptap/extension-blockquote": "^3.23.6",
     "@tiptap/extension-bold": "^3.23.6",

--- a/packages/web-components/src/components/wysiwyg/package.json
+++ b/packages/web-components/src/components/wysiwyg/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@carbon-labs/wc-wysiwyg",
+  "version": "0.0.1",
+  "author": "Your Name <your@email.com>",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "description": "Carbon Labs - wysiwyg component",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/carbon-labs",
+    "directory": "packages/wysiwyg"
+  },
+  "exports": {
+    ".": {
+      "default": "./src/index.js"
+    },
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*"
+  },
+  "files": [
+    "es/",
+    "lib/"
+  ],
+  "types": "./src/index.d.ts",
+  "customElements": "custom-elements.json",
+  "scripts": {
+    "build": "node ../../../tasks/build.js",
+    "build:dist": "rm -rf dist && rollup --config ../../../tasks/build-dist.js",
+    "build:dist:canary": "rm -rf dist && rollup --config ../../../tasks/build-dist.js --configCanary",
+    "clean": "rimraf es lib"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.23.2",
+    "@carbon-labs/utilities": "0.21.0",
+    "@carbon-labs/wc-style-picker": "0.21.0",
+    "@carbon/element-styles": "^0.2.5",
+    "@carbon/styles": "^1.107.0",
+    "@carbon/web-components": "^2.40.0",
+    "@tiptap/core": "^3.23.6",
+    "@tiptap/extension-blockquote": "^3.23.6",
+    "@tiptap/extension-bold": "^3.23.6",
+    "@tiptap/extension-bullet-list": "^3.23.6",
+    "@tiptap/extension-code": "^3.23.6",
+    "@tiptap/extension-code-block": "^3.23.6",
+    "@tiptap/extension-color": "^3.23.6",
+    "@tiptap/extension-document": "^3.23.6",
+    "@tiptap/extension-font-family": "^3.23.6",
+    "@tiptap/extension-heading": "^3.23.6",
+    "@tiptap/extension-history": "^3.23.6",
+    "@tiptap/extension-image": "^3.23.6",
+    "@tiptap/extension-italic": "^3.23.6",
+    "@tiptap/extension-list-item": "^3.23.6",
+    "@tiptap/extension-ordered-list": "^3.23.6",
+    "@tiptap/extension-paragraph": "^3.23.6",
+    "@tiptap/extension-strike": "^3.23.6",
+    "@tiptap/extension-table": "^3.23.6",
+    "@tiptap/extension-table-cell": "^3.23.6",
+    "@tiptap/extension-table-header": "^3.23.6",
+    "@tiptap/extension-table-row": "^3.23.6",
+    "@tiptap/extension-task-item": "^3.23.6",
+    "@tiptap/extension-task-list": "^3.23.6",
+    "@tiptap/extension-text": "^3.23.6",
+    "@tiptap/extension-text-align": "^3.23.6",
+    "@tiptap/extension-text-style": "^3.23.6",
+    "@tiptap/starter-kit": "^3.23.6",
+    "lit": "^3.1.0"
+  },
+  "peerDependencies": {
+    "@carbon/icons": "^11.0.0"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,7 +2212,7 @@ __metadata:
     "@carbon-labs/wc-style-picker": "npm:0.21.0"
     "@carbon/element-styles": "npm:^0.2.5"
     "@carbon/styles": "npm:^1.107.0"
-    "@carbon/web-components": "npm:^2.40.0"
+    "@carbon/web-components": "npm:^2.41.0"
     "@tiptap/core": "npm:^3.23.6"
     "@tiptap/extension-blockquote": "npm:^3.23.6"
     "@tiptap/extension-bold": "npm:^3.23.6"
@@ -2447,15 +2447,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons@npm:^11.81.0":
-  version: 11.81.0
-  resolution: "@carbon/icons@npm:11.81.0"
-  dependencies:
-    "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/5aece39af7143e068ee64d23ae228d28f73ff27903866342738739a6fc840839f6d43eadf9e66a7faedcc9250b2fd0de9bc7cb37f7bc6cd4a96495b1f9ce8487
-  languageName: node
-  linkType: hard
-
 "@carbon/layout@npm:^11.43.0, @carbon/layout@npm:^11.52.0":
   version: 11.52.0
   resolution: "@carbon/layout@npm:11.52.0"
@@ -2637,25 +2628,6 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     tslib: "npm:^2.6.3"
   checksum: 10c0/758e23c128343b6a70ef3c76ab2e0896e0464163086e44b7aa15e17eb5625ffdb7e8af8fe9d88032a06420d57266e693e31b9640c20effa7c38238f650ae3557
-  languageName: node
-  linkType: hard
-
-"@carbon/web-components@npm:^2.40.0":
-  version: 2.55.0
-  resolution: "@carbon/web-components@npm:2.55.0"
-  dependencies:
-    "@carbon/icon-helpers": "npm:10.47.0"
-    "@carbon/icons": "npm:^11.81.0"
-    "@carbon/styles": "npm:^1.107.0"
-    "@carbon/utilities": "npm:^0.17.0"
-    "@floating-ui/dom": "npm:^1.6.3"
-    "@ibm/telemetry-js": "npm:^1.10.2"
-    "@lit/context": "npm:^1.1.3"
-    flatpickr: "npm:*"
-    lit: "npm:^3.1.0"
-    lodash-es: "npm:^4.17.21"
-    tslib: "npm:^2.6.3"
-  checksum: 10c0/a7d65908494808d7ca3fe8661139ff593a374716138f0127c6a3817bf0bd47b46cfa20a3f5a81da5cfe9038af671e42266f341880a1ccdbd421fa51214ece8e1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,6 +1969,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon-labs/utilities@npm:0.20.0":
+  version: 0.20.0
+  resolution: "@carbon-labs/utilities@npm:0.20.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/e647f964a2b426802a0245840ef653bffab41f5b0c48de0d72c08b7fd1923112b9d66a16009369de5f50cd0a4d3c164877cdbf4f6d980eb502a360189398c542
+  languageName: node
+  linkType: hard
+
 "@carbon-labs/utilities@npm:0.21.0":
   version: 0.21.0
   resolution: "@carbon-labs/utilities@npm:0.21.0"
@@ -2077,6 +2087,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@carbon-labs/wc-empty-state@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "@carbon-labs/wc-empty-state@npm:0.12.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.2"
+    "@carbon-labs/utilities": "npm:0.20.0"
+    "@carbon/web-components": "npm:^2.41.0"
+    "@ibm/telemetry-js": "npm:^1.10.2"
+    uuid: "npm:^9.0.1"
+  checksum: 10c0/486cb7b4def0cd0b55b4175cd8d20d7f1ec330a9edfb84efb8d819f5c71675b2e484b651ca9f9024f7a72de3e5c1f5c695e3d73771a663ec1810179c44b5bf65
+  languageName: node
+  linkType: hard
+
 "@carbon-labs/wc-empty-state@npm:^0.9.0":
   version: 0.9.0
   resolution: "@carbon-labs/wc-empty-state@npm:0.9.0"
@@ -2153,6 +2176,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@carbon-labs/wc-style-picker@npm:0.21.0":
+  version: 0.21.0
+  resolution: "@carbon-labs/wc-style-picker@npm:0.21.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.2"
+    "@carbon-labs/utilities": "npm:0.20.0"
+    "@carbon-labs/wc-empty-state": "npm:^0.12.0"
+    "@carbon/web-components": "npm:^2.41.0"
+    "@ibm/telemetry-js": "npm:^1.10.2"
+    "@lit/context": "npm:^1.1.5"
+  checksum: 10c0/3f1cd0c0a9c1ff431efbf922a454b0f57d06b38ab749347c212e804a21a39976542d4b730e0371f6ca27d68ee0cfe55d12edec33e4e2ccbf847820f81498946d
+  languageName: node
+  linkType: hard
+
 "@carbon-labs/wc-style-picker@workspace:^, @carbon-labs/wc-style-picker@workspace:packages/web-components/src/components/style-picker":
   version: 0.0.0-use.local
   resolution: "@carbon-labs/wc-style-picker@workspace:packages/web-components/src/components/style-picker"
@@ -2163,6 +2200,49 @@ __metadata:
     "@carbon/web-components": "npm:^2.41.0"
     "@ibm/telemetry-js": "npm:^1.10.2"
     "@lit/context": "npm:^1.1.5"
+  languageName: unknown
+  linkType: soft
+
+"@carbon-labs/wc-wysiwyg@workspace:packages/web-components/src/components/wysiwyg":
+  version: 0.0.0-use.local
+  resolution: "@carbon-labs/wc-wysiwyg@workspace:packages/web-components/src/components/wysiwyg"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.2"
+    "@carbon-labs/utilities": "npm:0.21.0"
+    "@carbon-labs/wc-style-picker": "npm:0.21.0"
+    "@carbon/element-styles": "npm:^0.2.5"
+    "@carbon/styles": "npm:^1.107.0"
+    "@carbon/web-components": "npm:^2.40.0"
+    "@tiptap/core": "npm:^3.23.6"
+    "@tiptap/extension-blockquote": "npm:^3.23.6"
+    "@tiptap/extension-bold": "npm:^3.23.6"
+    "@tiptap/extension-bullet-list": "npm:^3.23.6"
+    "@tiptap/extension-code": "npm:^3.23.6"
+    "@tiptap/extension-code-block": "npm:^3.23.6"
+    "@tiptap/extension-color": "npm:^3.23.6"
+    "@tiptap/extension-document": "npm:^3.23.6"
+    "@tiptap/extension-font-family": "npm:^3.23.6"
+    "@tiptap/extension-heading": "npm:^3.23.6"
+    "@tiptap/extension-history": "npm:^3.23.6"
+    "@tiptap/extension-image": "npm:^3.23.6"
+    "@tiptap/extension-italic": "npm:^3.23.6"
+    "@tiptap/extension-list-item": "npm:^3.23.6"
+    "@tiptap/extension-ordered-list": "npm:^3.23.6"
+    "@tiptap/extension-paragraph": "npm:^3.23.6"
+    "@tiptap/extension-strike": "npm:^3.23.6"
+    "@tiptap/extension-table": "npm:^3.23.6"
+    "@tiptap/extension-table-cell": "npm:^3.23.6"
+    "@tiptap/extension-table-header": "npm:^3.23.6"
+    "@tiptap/extension-table-row": "npm:^3.23.6"
+    "@tiptap/extension-task-item": "npm:^3.23.6"
+    "@tiptap/extension-task-list": "npm:^3.23.6"
+    "@tiptap/extension-text": "npm:^3.23.6"
+    "@tiptap/extension-text-align": "npm:^3.23.6"
+    "@tiptap/extension-text-style": "npm:^3.23.6"
+    "@tiptap/starter-kit": "npm:^3.23.6"
+    lit: "npm:^3.1.0"
+  peerDependencies:
+    "@carbon/icons": ^11.0.0
   languageName: unknown
   linkType: soft
 
@@ -2230,6 +2310,17 @@ __metadata:
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
   checksum: 10c0/6db9bd678be108eb3e3576a045244c3e1bc94d371d166ea3e0d50192b6787d87bd26f2787318a5f2f5a03d2c106b9623ae782242570b9af547f0d55108d99b03
+  languageName: node
+  linkType: hard
+
+"@carbon/element-styles@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "@carbon/element-styles@npm:0.2.5"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.11.0"
+  peerDependencies:
+    "@carbon/styles": ^1.102.0
+  checksum: 10c0/a2c8801c11f9d5546cf251a7698a348208d54f1f0d03265d5cd215b20ed1b234fb95c87a8a0229157bcd875821f019bfb62daeec77b172c52462b697eaa438a4
   languageName: node
   linkType: hard
 
@@ -2353,6 +2444,15 @@ __metadata:
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
   checksum: 10c0/724ed19b2bf9039de32d43b718899d10f46f91b615ea50e52f83618c8a80e9f315afa519ffde36e55cfd698b818a46dff49fdf02c91c22dbffbab12ae9fc64ef
+  languageName: node
+  linkType: hard
+
+"@carbon/icons@npm:^11.81.0":
+  version: 11.81.0
+  resolution: "@carbon/icons@npm:11.81.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.5.0"
+  checksum: 10c0/5aece39af7143e068ee64d23ae228d28f73ff27903866342738739a6fc840839f6d43eadf9e66a7faedcc9250b2fd0de9bc7cb37f7bc6cd4a96495b1f9ce8487
   languageName: node
   linkType: hard
 
@@ -2537,6 +2637,25 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     tslib: "npm:^2.6.3"
   checksum: 10c0/758e23c128343b6a70ef3c76ab2e0896e0464163086e44b7aa15e17eb5625ffdb7e8af8fe9d88032a06420d57266e693e31b9640c20effa7c38238f650ae3557
+  languageName: node
+  linkType: hard
+
+"@carbon/web-components@npm:^2.40.0":
+  version: 2.55.0
+  resolution: "@carbon/web-components@npm:2.55.0"
+  dependencies:
+    "@carbon/icon-helpers": "npm:10.47.0"
+    "@carbon/icons": "npm:^11.81.0"
+    "@carbon/styles": "npm:^1.107.0"
+    "@carbon/utilities": "npm:^0.17.0"
+    "@floating-ui/dom": "npm:^1.6.3"
+    "@ibm/telemetry-js": "npm:^1.10.2"
+    "@lit/context": "npm:^1.1.3"
+    flatpickr: "npm:*"
+    lit: "npm:^3.1.0"
+    lodash-es: "npm:^4.17.21"
+    tslib: "npm:^2.6.3"
+  checksum: 10c0/a7d65908494808d7ca3fe8661139ff593a374716138f0127c6a3817bf0bd47b46cfa20a3f5a81da5cfe9038af671e42266f341880a1ccdbd421fa51214ece8e1
   languageName: node
   linkType: hard
 
@@ -8353,6 +8472,382 @@ __metadata:
   dependencies:
     "@textlint/ast-node-types": "npm:15.7.0"
   checksum: 10c0/07acb736e14ea4f666f5d988fffd1c0cfc10472624a581abbe67b7ad2f7bed981a45cbdd507335df834273ab775b9b71ed7c07222b977a2a3d913250d83778a1
+  languageName: node
+  linkType: hard
+
+"@tiptap/core@npm:^3.23.6, @tiptap/core@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/core@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/pm": 3.24.0
+  checksum: 10c0/e73e0665d7195df1fdf7ae15bb58136f279d1d48d69004c2ebbe3ef1cacfd4db7e846a6ea0fa55e18b6277f646f29928c89923418f391445b139c02b094db3f0
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-blockquote@npm:^3.23.6, @tiptap/extension-blockquote@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-blockquote@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/b8d32e03d08a15169fc7dfb20348eb8c8654a1bcf4d433a23748ff03f65d99873a101b8727b25694de39bf46a93c69b61db048af3ce2daee89fd1c4de24b9b7b
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-bold@npm:^3.23.6, @tiptap/extension-bold@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-bold@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/9ff29601f44ec0ea90bd1ba35d1892ed41072ab999207d62b2488447748e88971af0eac8f4193aa58a7ac5b0de02d421b5ec5e9c57e0fc277fd2c104415b35d9
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-bullet-list@npm:^3.23.6, @tiptap/extension-bullet-list@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-bullet-list@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-list": 3.24.0
+  checksum: 10c0/09f827034221ff64555fc596eb8d9b2f8392e15e5276cf5f4b8bcb848162bfd8727cfdabf3487407ec0b7f9bfbfdd7c1baad949efaa34e50ae4fd0cc946e3b71
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-code-block@npm:^3.23.6, @tiptap/extension-code-block@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-code-block@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+    "@tiptap/pm": 3.24.0
+  checksum: 10c0/f6579d6d61fde714e34021227ec81bdbc769ea24c46913d70bc78a37503ae8942fb094714d72f69f02b8992affd37f9959758298bfade8132641b4ff5bc35784
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-code@npm:^3.23.6, @tiptap/extension-code@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-code@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/d93c697ef482586f2aaa77f171d73374280c0e0d1969e7808ac25ba0ee8832553f72d54b2dbf8ed80218ff8b255fde5d341aef6a24dd7fe854d395bc1aba7caa
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-color@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-color@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-text-style": 3.24.0
+  checksum: 10c0/0752a2aeb8955961db73eda908e7046db90a3a0b20b89c6eb4ccd0a982a625383724f2bcf8cb2d176ae1daf409e52356672fd4c81b35326e51f2bb90f2ba4cac
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-document@npm:^3.23.6, @tiptap/extension-document@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-document@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/698a09a7d465f01e081d7fa42220f3831edf207e4c0c5b50fbaf84b33de2593134202f2d29ccbdd1bb6887b7fbd3592c6128f45f0ccf5bd8f73e986482e9fb14
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-dropcursor@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-dropcursor@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extensions": 3.24.0
+  checksum: 10c0/5fc0c616995a40b8c6ea2738b4955d30627356d0aab9baf9a105c85ff50fbb9513b906411ba5b2254e1d1d819888fbb9f6dc676c1de3c974cc6a8ea59ffcd6ba
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-font-family@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-font-family@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-text-style": 3.24.0
+  checksum: 10c0/255a1a599e0f779e16e0d04f7e6055ac091864fd4f8f7de333eaf2d9211b5b517f74ee318d886b53dbf0206e00043ba0b6592d22bcd62ec8331e85e02c8a1cb6
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-gapcursor@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-gapcursor@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extensions": 3.24.0
+  checksum: 10c0/13de935ef3eac7d341badbfc2bd5fcc83237cee277c1f9b2b4ad00ae60084d6cb8cc8639710f49967be8f19f3321493c9502904c44bfe783223a7cf01f013259
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-hard-break@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-hard-break@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/dc9f7c0ba4c0444a30113c6370ebfb1b4c42ea56773b60480ad5bbc3feb51bc8c5921771f3a47ec8e79f6a5e151b552ae268adfe85b44f3bd3f16deed9510c22
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-heading@npm:^3.23.6, @tiptap/extension-heading@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-heading@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/74c6317c3254af394e5f3fff77dc1cf97d2716f5199df2ab7b7b7a232acb147370fb7ca414297923a15b58f1628a2e0ef01b73b2e97178da27770c6ccdeb3ce2
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-history@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-history@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extensions": 3.24.0
+  checksum: 10c0/a65da4f0338df4394bd8278512be26bbbe8925bba692bc1e7d270e4103fa5cbffdf6b0de10622045d771a774c71a6be93696f40abd5774a020bd033613846b61
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-horizontal-rule@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-horizontal-rule@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+    "@tiptap/pm": 3.24.0
+  checksum: 10c0/b9811157d9e9469089ef32f8a1d2da8f3ccf0c94a5e03821f8c9b917bc02c319fcb1cbc0e146a541abf4e8ab3eec9d3fbc3804184acc005320f7f00ceea8e904
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-image@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-image@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/10b16193d41d5407fe2354e1f4142ec09b4de6aef289ca3e3bdf2133a44f446a09f3bf37dcf2c660e4d04bcd5137a1df548b329fe37df4eda7b726a08998b4da
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-italic@npm:^3.23.6, @tiptap/extension-italic@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-italic@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/1c6cb33814e6dce97851e20335fb22388ad39dd6121f2732beb6c751a4d6deb737d9ad8194605b41a60e7d5fd5c2d447072b6fad14e8cffcc5b32f3b796893dc
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-link@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-link@npm:3.24.0"
+  dependencies:
+    linkifyjs: "npm:^4.3.3"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+    "@tiptap/pm": 3.24.0
+  checksum: 10c0/a806717c44fb6b233e8944b984a1c4c29f8f397d9271cb3f3f0c6e0a6529d77d7f3a0bd877ca4ec3ff7a1c7ee30039c53250fe852e4e7f5ca179c5f2fbcdfe5f
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-list-item@npm:^3.23.6, @tiptap/extension-list-item@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-list-item@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-list": 3.24.0
+  checksum: 10c0/605f9f2628745bde39d292723479b58cd16d81e4dfb51075bef8b2b7ecae74bf9779242e643dd054503c419a7c14eff3ec665dd259bc40634722da2353741326
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-list-keymap@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-list-keymap@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-list": 3.24.0
+  checksum: 10c0/3514efcc31c46af04b6ee83e1ccf45c0ca6af3f8c5e760030c343190000d5599e706c5ee35e9c21de59bdd748da56922bf484780ecd1cea8a57528935ff2a768
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-list@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-list@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+    "@tiptap/pm": 3.24.0
+  checksum: 10c0/d56eaf5e835e9aaba440adc445a9ddcd987d27573d1a7c1f8760242d214ebfd41d5b8ebab25722eaf042cd4c2c0df48dc83c0f98d209e8ba280720262371dc84
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-ordered-list@npm:^3.23.6, @tiptap/extension-ordered-list@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-ordered-list@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-list": 3.24.0
+  checksum: 10c0/08ee6971f262b9243007ad03f43b20b52399eb044ad0bf9279a6995f3807e323a9281e5bd299a9c73a388f4e4382facfb0cb253fa65fddbf25aaaa3fa13c6072
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-paragraph@npm:^3.23.6, @tiptap/extension-paragraph@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-paragraph@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/7b358622dfdb05976b220401d50c6597ebc77a1a9841305bb339ad0578d0256b3d006b169335ca0fa74eb8a1f92798b245dde9769b22335b42c978aed8ed0d01
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-strike@npm:^3.23.6, @tiptap/extension-strike@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-strike@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/9475e2426e8679ce2a73c3c58f677321237e163e812cd392e9c129112f839949d7ba9f73c667fc0767f098cca850de71f51f8ff4fdf32ad93783331a1b2711ad
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-table-cell@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-table-cell@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-table": 3.24.0
+  checksum: 10c0/6a5d912c6d28e134a5cbe633d08df54f020819811a3c5da9b4fe0462e41f318a0534ccde3d50a7fc22df0cde7a87a643ef241be4597c51144c4ba4d043fec6af
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-table-header@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-table-header@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-table": 3.24.0
+  checksum: 10c0/997dedfaf2db779e217015f24f35db1e6ee60e78e9523926b880b498fc2b6e20a2fe2b0078c16911e73872672b22c551ec0e7abaa78aee4c0ea909f0c92fa62e
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-table-row@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-table-row@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-table": 3.24.0
+  checksum: 10c0/5e7bc1b02cfd8e3b8717ad9a0f767e14ae52b4e1460afcfa4bda2507942505dea55f68584acf2e8525d349d33fd82855d4b32d0ac2e3358aea324ce74b21e8e5
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-table@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-table@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+    "@tiptap/pm": 3.24.0
+  checksum: 10c0/8e4645760f267fc1030a56a28ddcd51b9378ec4ee517aa4719714a022bebb7444acf116646e0954d35bcd776172b16cf6ff838b0c7f54b9b1232a8f162e9dcc2
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-task-item@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-task-item@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-list": 3.24.0
+  checksum: 10c0/ddb17003eeb4d9a647ab40ac9b98e179c4adbe4d0af445b2580d12878f9416010df622d5c21cbaa8792e0e564aaddf61a9220eb40dbd90927c91a51ff5e05981
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-task-list@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-task-list@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/extension-list": 3.24.0
+  checksum: 10c0/ecdbbdfbacefe307bebef35e20568d0d5504179811747500f557ee210021832fd9cfc4c4ff24bea179cfc5da628416e494a798231cccfceaed6903f9319d584a
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-text-align@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-text-align@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/5514c4c29c26e115f1719debd6e152e709381b1268bdf5a6d28ba291cc7984096db26bc29559f59432c1d4ff1c41492e0f901cb7d7e830934acde167700138f5
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-text-style@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/extension-text-style@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/a8964be16f6f1f36af94b43717a517c75f5fb563db863ee6f6517572c9a8328a0bb078d98737901d7ccc9980e528e75f7801786c4f43b20511290aef3de1bedf
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-text@npm:^3.23.6, @tiptap/extension-text@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-text@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/d3737cd7f19b1900b94187df3065f0b8df4c665f8943fdab8a95121b7b87256cf1b4304c604c16b502a38bbd5046ca7a3510f67c11b77c77b41f6d56a0146b24
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-underline@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-underline@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/4473081b3ce25871e7b4ad2f56db7c0682ec2f31576221de6cc983d66fe2cf027d9b5312c917dde1246e166ad5f4b1f55141ce04bc560649b18822481dea5572
+  languageName: node
+  linkType: hard
+
+"@tiptap/extensions@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extensions@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+    "@tiptap/pm": 3.24.0
+  checksum: 10c0/777d01787cc20ffc2fd42765f708dd0e0da8e168932a158f75f847f3f942255a4ae778380adc49f64cbdc5e367b2d2ee9e250a8330da173cfa52625a29d9d272
+  languageName: node
+  linkType: hard
+
+"@tiptap/pm@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/pm@npm:3.24.0"
+  dependencies:
+    prosemirror-changeset: "npm:^2.3.0"
+    prosemirror-commands: "npm:^1.6.2"
+    prosemirror-dropcursor: "npm:^1.8.1"
+    prosemirror-gapcursor: "npm:^1.3.2"
+    prosemirror-history: "npm:^1.4.1"
+    prosemirror-inputrules: "npm:^1.4.0"
+    prosemirror-keymap: "npm:^1.2.2"
+    prosemirror-model: "npm:^1.24.1"
+    prosemirror-schema-list: "npm:^1.5.0"
+    prosemirror-state: "npm:^1.4.3"
+    prosemirror-tables: "npm:^1.6.4"
+    prosemirror-transform: "npm:^1.10.2"
+    prosemirror-view: "npm:^1.38.1"
+  checksum: 10c0/a35b650e58a1a17cc27e73767ef5c508e7bbca96ed69fea56ba8d8ca1d58eb6ed62d3896feeb7a42bab06392fd5ec148fa92d28228de24f8e8276a9593135cf1
+  languageName: node
+  linkType: hard
+
+"@tiptap/starter-kit@npm:^3.23.6":
+  version: 3.24.0
+  resolution: "@tiptap/starter-kit@npm:3.24.0"
+  dependencies:
+    "@tiptap/core": "npm:^3.24.0"
+    "@tiptap/extension-blockquote": "npm:^3.24.0"
+    "@tiptap/extension-bold": "npm:^3.24.0"
+    "@tiptap/extension-bullet-list": "npm:^3.24.0"
+    "@tiptap/extension-code": "npm:^3.24.0"
+    "@tiptap/extension-code-block": "npm:^3.24.0"
+    "@tiptap/extension-document": "npm:^3.24.0"
+    "@tiptap/extension-dropcursor": "npm:^3.24.0"
+    "@tiptap/extension-gapcursor": "npm:^3.24.0"
+    "@tiptap/extension-hard-break": "npm:^3.24.0"
+    "@tiptap/extension-heading": "npm:^3.24.0"
+    "@tiptap/extension-horizontal-rule": "npm:^3.24.0"
+    "@tiptap/extension-italic": "npm:^3.24.0"
+    "@tiptap/extension-link": "npm:^3.24.0"
+    "@tiptap/extension-list": "npm:^3.24.0"
+    "@tiptap/extension-list-item": "npm:^3.24.0"
+    "@tiptap/extension-list-keymap": "npm:^3.24.0"
+    "@tiptap/extension-ordered-list": "npm:^3.24.0"
+    "@tiptap/extension-paragraph": "npm:^3.24.0"
+    "@tiptap/extension-strike": "npm:^3.24.0"
+    "@tiptap/extension-text": "npm:^3.24.0"
+    "@tiptap/extension-underline": "npm:^3.24.0"
+    "@tiptap/extensions": "npm:^3.24.0"
+    "@tiptap/pm": "npm:^3.24.0"
+  checksum: 10c0/09e39d8202af2621a6f98816c588d535e066ff4abe75f3daf6830892d7d4d5c601dc004cfbced8cfe7fa77c02341d5281d4a4e006dcac0816fb56b5cf512373d
   languageName: node
   linkType: hard
 
@@ -21338,6 +21833,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkifyjs@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "linkifyjs@npm:4.3.3"
+  checksum: 10c0/0eac293927f1465d13625c8c67c83c50d7fda9137c255a4a2ff5970ea4e9ba57de4846b170326e54b9e4e82be24f3705572bc50773737be9b13af5f1e4577798
+  languageName: node
+  linkType: hard
+
 "lint-staged@npm:^15.0.2":
   version: 15.5.2
   resolution: "lint-staged@npm:15.5.2"
@@ -24692,6 +25194,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"orderedmap@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "orderedmap@npm:2.1.1"
+  checksum: 10c0/8d7d266659d1828937046e8b2a7b5f75914e0391db985da0ca75cd2246cccbf6d6f3a0886aa2034da15ee4923e8c45f95f8b588f575f535f0adecdefccc54634
+  languageName: node
+  linkType: hard
+
 "outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
   version: 1.4.3
   resolution: "outvariant@npm:1.4.3"
@@ -26684,6 +27193,145 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prosemirror-changeset@npm:^2.3.0":
+  version: 2.4.1
+  resolution: "prosemirror-changeset@npm:2.4.1"
+  dependencies:
+    prosemirror-transform: "npm:^1.0.0"
+  checksum: 10c0/ca6b6bab73809dbb8554cddc0a3af666db8bcfed57938314ce6b04b28e41ea355441eaadabcddd9c785727219ad3779534dfa6e33521f0d333e90788b8dc9e3c
+  languageName: node
+  linkType: hard
+
+"prosemirror-commands@npm:^1.6.2":
+  version: 1.7.1
+  resolution: "prosemirror-commands@npm:1.7.1"
+  dependencies:
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.10.2"
+  checksum: 10c0/4884ea7a66b79b51e72bb2ef358284d70e9a071deb4cbfab3dd8ee3449e9a0e34cb391d92f487c013d3716b823fc5568ad5e409a9444b3630ae0b87617c2fca1
+  languageName: node
+  linkType: hard
+
+"prosemirror-dropcursor@npm:^1.8.1":
+  version: 1.8.2
+  resolution: "prosemirror-dropcursor@npm:1.8.2"
+  dependencies:
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.1.0"
+    prosemirror-view: "npm:^1.1.0"
+  checksum: 10c0/c3d9e456a64fecc77a6e6a0350116598550dee8cb55f74e8b66fdb26150c48340ddd1f43184134b24d0f2e710b6879ff6ec72c215dc618a6a673320a91c90478
+  languageName: node
+  linkType: hard
+
+"prosemirror-gapcursor@npm:^1.3.2":
+  version: 1.4.1
+  resolution: "prosemirror-gapcursor@npm:1.4.1"
+  dependencies:
+    prosemirror-keymap: "npm:^1.0.0"
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-view: "npm:^1.0.0"
+  checksum: 10c0/1719ef91274d0f76f6c5e667d839aae0576e38b1fc08e178425fa076821ef3da88ebd0fe40049d7dd157aa224672270e569f032316de9de588a1baabcfe802f1
+  languageName: node
+  linkType: hard
+
+"prosemirror-history@npm:^1.4.1":
+  version: 1.5.0
+  resolution: "prosemirror-history@npm:1.5.0"
+  dependencies:
+    prosemirror-state: "npm:^1.2.2"
+    prosemirror-transform: "npm:^1.0.0"
+    prosemirror-view: "npm:^1.31.0"
+    rope-sequence: "npm:^1.3.0"
+  checksum: 10c0/9f24c99316c30a52ff40ddd59fc83b5180f1326ee6f466bfa82b847a503b0cdff234c35d5e3decb39ae1382a189ceec7462333ed7d6c34e2c95921892bb98b78
+  languageName: node
+  linkType: hard
+
+"prosemirror-inputrules@npm:^1.4.0":
+  version: 1.5.1
+  resolution: "prosemirror-inputrules@npm:1.5.1"
+  dependencies:
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.0.0"
+  checksum: 10c0/cff1ff9f7e726bf324e6cddd2c48984e6b2970cc98cd5dc59e6dbe2e9df0e01e4a2d100c77c721067804170b9607769c0fee7c98f2cfb4f3cff9af919fce31b9
+  languageName: node
+  linkType: hard
+
+"prosemirror-keymap@npm:^1.0.0, prosemirror-keymap@npm:^1.2.2, prosemirror-keymap@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "prosemirror-keymap@npm:1.2.3"
+  dependencies:
+    prosemirror-state: "npm:^1.0.0"
+    w3c-keyname: "npm:^2.2.0"
+  checksum: 10c0/0ec2f8bd9b608d0e6a0cdab1d66f9a6b41edcff0239b32ccca1018a0733e52448e4758218a2d472fb8c33c1609426dc6bad4944b28c1c3d509a83201a23035e9
+  languageName: node
+  linkType: hard
+
+"prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.20.0, prosemirror-model@npm:^1.21.0, prosemirror-model@npm:^1.24.1, prosemirror-model@npm:^1.25.4":
+  version: 1.25.7
+  resolution: "prosemirror-model@npm:1.25.7"
+  dependencies:
+    orderedmap: "npm:^2.0.0"
+  checksum: 10c0/c41b3c597a4024dc18f4117a6d3908fb0a9dd143c4d382845654bb8f574acc0445845c1707049556e592f5406654e2c5e9f9a22002f0b25859e8e44d36f52126
+  languageName: node
+  linkType: hard
+
+"prosemirror-schema-list@npm:^1.5.0":
+  version: 1.5.1
+  resolution: "prosemirror-schema-list@npm:1.5.1"
+  dependencies:
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.7.3"
+  checksum: 10c0/e6fd27446bc90556a9797f6ca0cb54e7db53cc7c20fbf633b7d0f4709c45accfa2f3a0f6575fe47aa83cb75781a9b773198d236a44db9d8eef2802a1501e4301
+  languageName: node
+  linkType: hard
+
+"prosemirror-state@npm:^1.0.0, prosemirror-state@npm:^1.2.2, prosemirror-state@npm:^1.4.3, prosemirror-state@npm:^1.4.4":
+  version: 1.4.4
+  resolution: "prosemirror-state@npm:1.4.4"
+  dependencies:
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.0.0"
+    prosemirror-view: "npm:^1.27.0"
+  checksum: 10c0/1428636a37c127afe0d11a4f4eb44d75a7f16717940405082bd16fa4c28cfeef9375d49f48e411e5f0fa26f3e5798af7f270edc9bc9b0e647df8bb79983bcd59
+  languageName: node
+  linkType: hard
+
+"prosemirror-tables@npm:^1.6.4":
+  version: 1.8.5
+  resolution: "prosemirror-tables@npm:1.8.5"
+  dependencies:
+    prosemirror-keymap: "npm:^1.2.3"
+    prosemirror-model: "npm:^1.25.4"
+    prosemirror-state: "npm:^1.4.4"
+    prosemirror-transform: "npm:^1.10.5"
+    prosemirror-view: "npm:^1.41.4"
+  checksum: 10c0/d6e8cd9d333987ce6492202d5f815b268bb9a722d81456628eff999444d44fa97e8a801a5a20a44e678892f37053f314885d5a03e1df834653e3ea455f0f9290
+  languageName: node
+  linkType: hard
+
+"prosemirror-transform@npm:^1.0.0, prosemirror-transform@npm:^1.1.0, prosemirror-transform@npm:^1.10.2, prosemirror-transform@npm:^1.10.5, prosemirror-transform@npm:^1.7.3":
+  version: 1.12.0
+  resolution: "prosemirror-transform@npm:1.12.0"
+  dependencies:
+    prosemirror-model: "npm:^1.21.0"
+  checksum: 10c0/e9e94fbb36fa53badc73d27833bac834835246f28a6176fb33c65a85c9025da0c08ac503f860898591a14fcacef58ba18a29e8df5a916cf376084bc17f324753
+  languageName: node
+  linkType: hard
+
+"prosemirror-view@npm:^1.0.0, prosemirror-view@npm:^1.1.0, prosemirror-view@npm:^1.27.0, prosemirror-view@npm:^1.31.0, prosemirror-view@npm:^1.38.1, prosemirror-view@npm:^1.41.4":
+  version: 1.41.8
+  resolution: "prosemirror-view@npm:1.41.8"
+  dependencies:
+    prosemirror-model: "npm:^1.20.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.1.0"
+  checksum: 10c0/fae3947fec39e2b274bd10e46a2f3b671708e133dc2cc1fb2af0bd97576abd941bbdcc9dc240adf8b34dd0420a020a4006293450fc9c76e2578dba65de6dd9dc
+  languageName: node
+  linkType: hard
+
 "proto-list@npm:~1.2.1":
   version: 1.2.4
   resolution: "proto-list@npm:1.2.4"
@@ -28167,6 +28815,13 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10c0/2734511579da220408eefb877b51281767d790652cee25da8fcd4936c947e3db14882b5edb1d0d5d5bf60f2a71a58ae7d5f7f46c11e3fdf33182538953886243
+  languageName: node
+  linkType: hard
+
+"rope-sequence@npm:^1.3.0":
+  version: 1.3.4
+  resolution: "rope-sequence@npm:1.3.4"
+  checksum: 10c0/caa90be3d7a7cad155fb354a4679a1280dc9819c81bd319542a0d893a64e152284abb9cc1631d4351b328016a8d6c35a48c912234edfaf5173daef44b2e3609b
   languageName: node
   linkType: hard
 
@@ -32444,6 +33099,13 @@ __metadata:
   version: 1.0.1
   resolution: "vlq@npm:1.0.1"
   checksum: 10c0/a8ec5c95d747c840198f20b4973327fa317b98397f341e7a2f352bfcf385aeb73c0eea01cc6d406c20169298375397e259efc317aec53c8ffc001ec998204aed
+  languageName: node
+  linkType: hard
+
+"w3c-keyname@npm:^2.2.0":
+  version: 2.2.8
+  resolution: "w3c-keyname@npm:2.2.8"
+  checksum: 10c0/37cf335c90efff31672ebb345577d681e2177f7ff9006a9ad47c68c5a9d265ba4a7b39d6c2599ceea639ca9315584ce4bd9c9fbf7a7217bfb7a599e71943c4c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Contributes https://github.com/carbon-design-system/carbon/issues/13462

moving to https://github.com/carbon-design-system/carbon-labs/pull/1269

A WYSIWYG editor built with the open-source Tiptap editor, extensions, and Carbon primitives. in Web Components.
Uses @carbon-element-styles for markdown styling.

[preview](https://deploy-preview-1261--carbon-labs-web-components.netlify.app/web-components/index.html?path=/story/components-wysiwyg--default)

Feature set include

- Text formatting (bold, italic, underline, strikethrough, code)
- Headings (H1, H2, H3, H4, H5, H6) and paragraphs
- Lists (bulleted and numbered)
- Text alignment (left, center, right)
- Block elements (blockquotes, code blocks)
- Tables with full editing capabilities
- Links and images
- Undo/redo functionality
- Full keyboard navigation support*

```
*
minor incompatibility with roving tab index in the toolbar. coming from carbon primitive overflow menu. 
style picker keyboard navigation overlap with roving tab index
will be fixed soon.
```

keeping close to the guidance as possible
https://carbondesignsystem.com/patterns/text-toolbar-pattern/

#### Changelog

**New**

- New component package `clabs-wysiwyg`
- More details in storybook overview docs.

#### Testing / Reviewing

planned for later. after determining the scope. including avt.
