### PR TITLE
feat(global-header): Solis token refresh logic

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -187,7 +187,7 @@ export class HybridIpaasHeader extends LitElement {
 
   private initializeSessionManager() {
     if (!this.sessionManager) {
-      this.sessionManager = new solisSessionManager({ tokenRefreshInterval: this.solisSessionRefreshInterval});
+      this.sessionManager = new solisSessionManager({ tokenRefreshInterval: this.solisSessionRefreshInterval, basePath: this.basePath });
       this.sessionManager.startRefreshSchedule();
     }
   }

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -145,7 +145,11 @@ export class HybridIpaasHeader extends LitElement {
       );
 
       this.headerOptions = this.buildHeaderOptions(serverOptions);
-      if (this.solisSessionManagerEnabled && this.headerOptions.profile !== null && this.headerOptions.profile !== undefined) {
+      if (
+        this.solisSessionManagerEnabled &&
+        this.headerOptions.profile !== null &&
+        this.headerOptions.profile !== undefined
+      ) {
         // backend is ready and user is authenticated
         this.initializeSessionManager();
       }
@@ -187,7 +191,10 @@ export class HybridIpaasHeader extends LitElement {
 
   private initializeSessionManager() {
     if (!this.sessionManager) {
-      this.sessionManager = new solisSessionManager({ tokenRefreshInterval: this.solisSessionRefreshInterval, basePath: this.basePath });
+      this.sessionManager = new solisSessionManager({
+        tokenRefreshInterval: this.solisSessionRefreshInterval,
+        basePath: this.basePath,
+      });
       this.sessionManager.startRefreshSchedule();
     }
   }

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -72,7 +72,7 @@ export class HybridIpaasHeader extends LitElement {
   capabilityProfileFooterLinks: ProfileFooterLinks[] = [];
   @property({ type: Array }) capabilityGlobalActions: GlobalActionConfig[] = [];
   @property({ type: Boolean }) addCookiePreferences = false;
-  @property({ type: Boolean }) solisSessionManagerEnabled = false;
+  @property({ type: Boolean }) solisSessionManagerEnabled = false; // TODO - only needed until we want to enable this feature
   @property({ type: Number }) solisSessionRefreshInterval = 25; // TODO - do we need to make this configurable per capability?
 
   @state()

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -72,6 +72,7 @@ export class HybridIpaasHeader extends LitElement {
   capabilityProfileFooterLinks: ProfileFooterLinks[] = [];
   @property({ type: Array }) capabilityGlobalActions: GlobalActionConfig[] = [];
   @property({ type: Boolean }) addCookiePreferences = false;
+  @property({ type: Boolean }) solisSessionManagerEnabled = false;
   @property({ type: Number }) solisSessionRefreshInterval = 25; // TODO - do we need to make this configurable per capability?
 
   @state()
@@ -144,7 +145,7 @@ export class HybridIpaasHeader extends LitElement {
       );
 
       this.headerOptions = this.buildHeaderOptions(serverOptions);
-      if (this.headerOptions.profile !== null && this.headerOptions.profile !== undefined) {
+      if (this.solisSessionManagerEnabled && this.headerOptions.profile !== null && this.headerOptions.profile !== undefined) {
         // backend is ready and user is authenticated
         this.initializeSessionManager();
       }

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -92,7 +92,7 @@ export class HybridIpaasHeader extends LitElement {
     },
   };
 
-  private sessionManager: solisSessionManager | null = null;
+  sessionManager: solisSessionManager | null = null;
 
   constructor() {
     super();

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -29,6 +29,8 @@ import '../CommonHeader/CommonHeader';
 
 import styles from '../../index.scss?inline';
 
+import solisSessionManager from '../../globals/solisSessionManager';
+
 const { stablePrefix: clabsPrefix } = settings;
 
 /**
@@ -70,6 +72,7 @@ export class HybridIpaasHeader extends LitElement {
   capabilityProfileFooterLinks: ProfileFooterLinks[] = [];
   @property({ type: Array }) capabilityGlobalActions: GlobalActionConfig[] = [];
   @property({ type: Boolean }) addCookiePreferences = false;
+  @property({ type: Number }) solisSessionRefreshInterval = 25; // TODO - do we need to make this configurable per capability?
 
   @state()
   headerOptions: HeaderProps = {
@@ -88,6 +91,8 @@ export class HybridIpaasHeader extends LitElement {
     },
   };
 
+  private sessionManager: solisSessionManager | null = null;
+
   constructor() {
     super();
     this._customEventListener = this._customEventListener.bind(this);
@@ -100,6 +105,10 @@ export class HybridIpaasHeader extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    if (this.sessionManager) {
+      this.sessionManager.stopRefreshSchedule();
+      this.sessionManager = null;
+    }
     document.removeEventListener(CUSTOM_EVENT_NAME, this._customEventListener);
   }
 
@@ -135,6 +144,10 @@ export class HybridIpaasHeader extends LitElement {
       );
 
       this.headerOptions = this.buildHeaderOptions(serverOptions);
+      if (this.headerOptions.profile !== null && this.headerOptions.profile !== undefined) {
+        // backend is ready and user is authenticated
+        this.initializeSessionManager();
+      }
     } catch (error) {
       console.error('Failed to load header options:', error);
     }
@@ -168,6 +181,13 @@ export class HybridIpaasHeader extends LitElement {
     } else {
       // backup option in case the cookie script didn't load for some reason
       window.open('https://www.ibm.com/privacy');
+    }
+  }
+
+  private initializeSessionManager() {
+    if (!this.sessionManager) {
+      this.sessionManager = new solisSessionManager({ tokenRefreshInterval: this.solisSessionRefreshInterval});
+      this.sessionManager.startRefreshSchedule();
     }
   }
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -72,8 +72,8 @@ export class HybridIpaasHeader extends LitElement {
   capabilityProfileFooterLinks: ProfileFooterLinks[] = [];
   @property({ type: Array }) capabilityGlobalActions: GlobalActionConfig[] = [];
   @property({ type: Boolean }) addCookiePreferences = false;
-  @property({ type: Boolean }) solisSessionManagerEnabled = false; // TODO - only needed until we want to enable this feature
-  @property({ type: Number }) solisSessionRefreshInterval = 25; // TODO - do we need to make this configurable per capability?
+  @property({ type: Boolean }) solisSessionManagerEnabled = false; // toggle to enable/disable the Solis session manager
+  @property({ type: Number }) solisSessionRefreshInterval = 25; // might not need Solis token refresh interval to be configurable
 
   @state()
   headerOptions: HeaderProps = {

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__codecept__/HybridIpaasHeader.spec.js
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__codecept__/HybridIpaasHeader.spec.js
@@ -173,6 +173,7 @@ Scenario('Solis components render', async ({ I }) => {
   I.seeElement(locate('#ibm-automation-cds-solis-switcher-button'));
   I.click(locate('#ibm-automation-cds-solis-switcher-button'));
   // I.see('Observability');
+  I.wait(2);
   I.see('Your products');
   I.see('Community');
   I.click(locate('#ibm-automation-cds-solis-switcher-button')); // Close the Solis switcher

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__tests__/HybridIpaasHeader.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__tests__/HybridIpaasHeader.test.ts
@@ -278,11 +278,16 @@ describe('HybridIpaasHeader Component', () => {
   });
 
   it('should initialize the solisSessionManager if solisSessionManagerEnabled is true', async () => {
-    fetchStub.resolves(new Response(JSON.stringify(fetchResp), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' }
-    }));
-    const startRefreshScheduleStub = sinon.stub(solisSessionManager.prototype, 'startRefreshSchedule');
+    fetchStub.resolves(
+      new Response(JSON.stringify(fetchResp), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const startRefreshScheduleStub = sinon.stub(
+      solisSessionManager.prototype,
+      'startRefreshSchedule'
+    );
     const el = await fixture<HybridIpaasHeader>(
       html`<clabs-global-header-hybrid-ipaas
         .fetchHeaders=${{ 'Content-Type': 'application/json' }}
@@ -291,8 +296,8 @@ describe('HybridIpaasHeader Component', () => {
         solisSessionManagerEnabled="true"></clabs-global-header-hybrid-ipaas>`
     );
     await el.updateComplete;
-    await new Promise(resolve => setTimeout(resolve, 200));
-    
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
     expect(el.sessionManager).to.not.be.null;
     expect(startRefreshScheduleStub).to.have.been.calledOnce;
   });

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__tests__/HybridIpaasHeader.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__tests__/HybridIpaasHeader.test.ts
@@ -25,6 +25,8 @@ import {
   CUSTOM_EVENT_DETAIL_REFRESH_OPTIONS,
 } from '../../../constant';
 
+import solisSessionManager from '../../../globals/solisSessionManager';
+
 describe('HybridIpaasHeader Component', () => {
   let fetchStub: sinon.SinonStub<
     [input: RequestInfo | URL, init?: RequestInit | undefined],
@@ -38,6 +40,7 @@ describe('HybridIpaasHeader Component', () => {
   });
   afterEach(() => {
     fetchStub.restore();
+    sinon.restore();
   });
 
   const fetchResp = {
@@ -272,6 +275,26 @@ describe('HybridIpaasHeader Component', () => {
       { label: 'Product', text: 'productName' },
       { label: 'Version', text: '2.0.0' },
     ]);
+  });
+
+  it('should initialize the solisSessionManager if solisSessionManagerEnabled is true', async () => {
+    fetchStub.resolves(new Response(JSON.stringify(fetchResp), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    }));
+    const startRefreshScheduleStub = sinon.stub(solisSessionManager.prototype, 'startRefreshSchedule');
+    const el = await fixture<HybridIpaasHeader>(
+      html`<clabs-global-header-hybrid-ipaas
+        .fetchHeaders=${{ 'Content-Type': 'application/json' }}
+        basePath="/api"
+        productKey="test-productKey"
+        solisSessionManagerEnabled="true"></clabs-global-header-hybrid-ipaas>`
+    );
+    await el.updateComplete;
+    await new Promise(resolve => setTimeout(resolve, 200));
+    
+    expect(el.sessionManager).to.not.be.null;
+    expect(startRefreshScheduleStub).to.have.been.calledOnce;
   });
 
   it('should handle logoutCallback passed in', async () => {

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
@@ -50,10 +50,12 @@ describe('solisSessionManager', () => {
     });
 
     describe('stopRefreshSchedule', () => {
+
         it('does nothing if the token refresh schedule is not running' , () => {
             const clearIntervalStub = sinon.stub(window, 'clearInterval');
             const sessionManager = new solisSessionManager({});
             sessionManager.stopRefreshSchedule();
+            expect(sessionManager.isScheduleRunning()).to.be.false;
             expect(clearIntervalStub).to.not.have.been.called;
         })
 
@@ -102,6 +104,42 @@ describe('solisSessionManager', () => {
             expect(consoleLogStub).to.have.been.calledWith('Solis token refresh successful');
         })
 
+        it('logs a message if the token refresh happened too recently, response status 429', async() => {
+            const fetchStub = sinon.stub(window, 'fetch');
+            fetchStub.resolves(new Response(null, {
+                status: 429,
+                statusText: 'Refresh already in progress'
+            }));
+            const consoleLogStub = sinon.stub(console, 'log');
+            const sessionManager = new solisSessionManager({});
+            await sessionManager.triggerRefresh();
+            expect(consoleLogStub).to.have.been.calledWith('Solis token refresh skipped (too recent)');
+        })
+
+        it('logs an error if the user is not authenticated, response status 401', async() => {
+            const fetchStub = sinon.stub(window, 'fetch');
+            fetchStub.resolves(new Response(null, {
+                status: 401,
+                statusText: 'Not found'
+            }));
+            const consoleErrorStub = sinon.stub(console, 'error');
+            const sessionManager = new solisSessionManager({});
+            await sessionManager.triggerRefresh();
+            expect(consoleErrorStub).to.have.been.calledWith('Solis token refresh unauthorized - triggering logout');
+        })
+
+        it('logs an error if the user is not authenticated, response status 403', async() => {
+            const fetchStub = sinon.stub(window, 'fetch');
+            fetchStub.resolves(new Response(null, {
+                status: 401,
+                statusText: 'Unauthorized'
+            }));
+            const consoleErrorStub = sinon.stub(console, 'error');
+            const sessionManager = new solisSessionManager({});
+            await sessionManager.triggerRefresh();
+            expect(consoleErrorStub).to.have.been.calledWith('Solis token refresh unauthorized - triggering logout');
+        })
+
         it('logs an error if the response status is 500', async() => {
             const fetchStub = sinon.stub(window, 'fetch');
             fetchStub.resolves(new Response(null, {
@@ -112,6 +150,15 @@ describe('solisSessionManager', () => {
             const sessionManager = new solisSessionManager({});
             await sessionManager.triggerRefresh();
             expect(consoleErrorStub).to.have.been.calledWith('Solis token refresh failed:', 500);
+        })
+
+        it('logs an error if the fetch call fails', async() => {
+            const fetchStub = sinon.stub(window, 'fetch');
+            fetchStub.rejects(new Error('Network error'));
+            const consoleErrorStub = sinon.stub(console, 'error');
+            const sessionManager = new solisSessionManager({});
+            await sessionManager.triggerRefresh();
+            expect(consoleErrorStub).to.have.been.calledWith('Solis token refresh error:', 'Network error');
         })
     });
 });

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { expect } from '@open-wc/testing';
+import solisSessionManager from '../solisSessionManager';
+import sinon from 'sinon';
+
+describe('solisSessionManager', () => {
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('startRefreshSchedule', () => {
+        let clock;
+
+        beforeEach(() => {
+            clock = sinon.useFakeTimers({
+                shouldAdvanceTime: false,
+                shouldClearNativeTimers: true,
+                toFake: ['setInterval', 'clearInterval']
+            });
+        });
+
+        afterEach(() => {
+            clock.restore();
+        });
+
+        it('sets the refreshIntervalId', () => {
+            const sessionManager = new solisSessionManager({});
+            sessionManager.startRefreshSchedule();
+            expect(sessionManager.isScheduleRunning()).to.be.true;
+            sessionManager.stopRefreshSchedule();
+        })
+
+        it('calls triggerRefresh after the specified interval has passed', () => {
+            const triggerRefreshStub = sinon.stub(solisSessionManager.prototype, 'triggerRefresh');
+            const sessionManager = new solisSessionManager({ tokenRefreshInterval: 1});
+            sessionManager.startRefreshSchedule();
+            expect(sessionManager.isScheduleRunning()).to.be.true;
+            clock.tick(1 * 60 * 1000);
+            expect(triggerRefreshStub).to.have.been.calledOnce;
+            sessionManager.stopRefreshSchedule();
+        })
+    });
+
+    describe('stopRefreshSchedule', () => {
+        it('does nothing if the token refresh schedule is not running' , () => {
+            const clearIntervalStub = sinon.stub(window, 'clearInterval');
+            const sessionManager = new solisSessionManager({});
+            sessionManager.stopRefreshSchedule();
+            expect(clearIntervalStub).to.not.have.been.called;
+        })
+
+        it('clears the interval if the token refresh schedule is running', () => {
+            const clearIntervalStub = sinon.stub(window, 'clearInterval');
+            const sessionManager = new solisSessionManager({});
+            sessionManager.startRefreshSchedule();
+            expect(sessionManager.isScheduleRunning()).to.be.true;
+            sessionManager.stopRefreshSchedule();
+            expect(clearIntervalStub).to.have.been.calledOnce;
+            expect(sessionManager.isScheduleRunning()).to.be.false;
+        })
+    });
+
+    describe('triggerRefresh', () => {
+
+        it('calls fetch with the correct URL and options', async() => {
+            const fetchStub = sinon.stub(window, 'fetch');
+            fetchStub.resolves(new Response(null, {
+                status: 200,
+                statusText: 'OK'
+            }));
+            const consoleLogStub = sinon.stub(console, 'log');
+            const sessionManager = new solisSessionManager({ basePath: '/api' });
+            await sessionManager.triggerRefresh();
+            expect(fetchStub).to.have.been.calledOnceWith('/api/v1/solis/session/refresh-token', {
+                method: 'GET',
+                credentials: 'same-origin'
+            });
+            expect(consoleLogStub).to.have.been.calledWith('Solis token refresh successful');
+        })
+
+        it('calls fetch with the correct URL and options when the basePath is undefined', async() => {
+            const fetchStub = sinon.stub(window, 'fetch');
+            fetchStub.resolves(new Response(null, {
+                status: 200,
+                statusText: 'OK'
+            }));
+            const consoleLogStub = sinon.stub(console, 'log');
+            const sessionManager = new solisSessionManager({});
+            await sessionManager.triggerRefresh();
+            expect(fetchStub).to.have.been.calledOnceWith('/v1/solis/session/refresh-token', {
+                method: 'GET',
+                credentials: 'same-origin'
+            });
+            expect(consoleLogStub).to.have.been.calledWith('Solis token refresh successful');
+        })
+
+        it('logs an error if the response status is 500', async() => {
+            const fetchStub = sinon.stub(window, 'fetch');
+            fetchStub.resolves(new Response(null, {
+                status: 500,
+                statusText: 'Internal Server Error'
+            }));
+            const consoleErrorStub = sinon.stub(console, 'error');
+            const sessionManager = new solisSessionManager({});
+            await sessionManager.triggerRefresh();
+            expect(consoleErrorStub).to.have.been.calledWith('Solis token refresh failed:', 500);
+        })
+    });
+});

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
@@ -11,154 +11,190 @@ import solisSessionManager from '../solisSessionManager';
 import sinon from 'sinon';
 
 describe('solisSessionManager', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('startRefreshSchedule', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({
+        shouldAdvanceTime: false,
+        shouldClearNativeTimers: true,
+        toFake: ['setInterval', 'clearInterval'],
+      });
+    });
 
     afterEach(() => {
-        sinon.restore();
+      clock.restore();
     });
 
-    describe('startRefreshSchedule', () => {
-        let clock;
-
-        beforeEach(() => {
-            clock = sinon.useFakeTimers({
-                shouldAdvanceTime: false,
-                shouldClearNativeTimers: true,
-                toFake: ['setInterval', 'clearInterval']
-            });
-        });
-
-        afterEach(() => {
-            clock.restore();
-        });
-
-        it('sets the refreshIntervalId', () => {
-            const sessionManager = new solisSessionManager({});
-            sessionManager.startRefreshSchedule();
-            expect(sessionManager.isScheduleRunning()).to.be.true;
-            sessionManager.stopRefreshSchedule();
-        })
-
-        it('calls triggerRefresh after the specified interval has passed', () => {
-            const triggerRefreshStub = sinon.stub(solisSessionManager.prototype, 'triggerRefresh');
-            const sessionManager = new solisSessionManager({ tokenRefreshInterval: 1});
-            sessionManager.startRefreshSchedule();
-            expect(sessionManager.isScheduleRunning()).to.be.true;
-            clock.tick(1 * 60 * 1000);
-            expect(triggerRefreshStub).to.have.been.calledOnce;
-            sessionManager.stopRefreshSchedule();
-        })
+    it('sets the refreshIntervalId', () => {
+      const sessionManager = new solisSessionManager({});
+      sessionManager.startRefreshSchedule();
+      expect(sessionManager.isScheduleRunning()).to.be.true;
+      sessionManager.stopRefreshSchedule();
     });
 
-    describe('stopRefreshSchedule', () => {
+    it('calls triggerRefresh after the specified interval has passed', () => {
+      const triggerRefreshStub = sinon.stub(
+        solisSessionManager.prototype,
+        'triggerRefresh'
+      );
+      const sessionManager = new solisSessionManager({
+        tokenRefreshInterval: 1,
+      });
+      sessionManager.startRefreshSchedule();
+      expect(sessionManager.isScheduleRunning()).to.be.true;
+      clock.tick(1 * 60 * 1000);
+      expect(triggerRefreshStub).to.have.been.calledOnce;
+      sessionManager.stopRefreshSchedule();
+    });
+  });
 
-        it('does nothing if the token refresh schedule is not running' , () => {
-            const clearIntervalStub = sinon.stub(window, 'clearInterval');
-            const sessionManager = new solisSessionManager({});
-            sessionManager.stopRefreshSchedule();
-            expect(sessionManager.isScheduleRunning()).to.be.false;
-            expect(clearIntervalStub).to.not.have.been.called;
-        })
-
-        it('clears the interval if the token refresh schedule is running', () => {
-            const clearIntervalStub = sinon.stub(window, 'clearInterval');
-            const sessionManager = new solisSessionManager({});
-            sessionManager.startRefreshSchedule();
-            expect(sessionManager.isScheduleRunning()).to.be.true;
-            sessionManager.stopRefreshSchedule();
-            expect(clearIntervalStub).to.have.been.calledOnce;
-            expect(sessionManager.isScheduleRunning()).to.be.false;
-        })
+  describe('stopRefreshSchedule', () => {
+    it('does nothing if the token refresh schedule is not running', () => {
+      const clearIntervalStub = sinon.stub(window, 'clearInterval');
+      const sessionManager = new solisSessionManager({});
+      sessionManager.stopRefreshSchedule();
+      expect(sessionManager.isScheduleRunning()).to.be.false;
+      expect(clearIntervalStub).to.not.have.been.called;
     });
 
-    describe('triggerRefresh', () => {
-
-        it('calls fetch with the correct URL and options', async() => {
-            const fetchStub = sinon.stub(window, 'fetch');
-            fetchStub.resolves(new Response(null, {
-                status: 200,
-                statusText: 'OK'
-            }));
-            const consoleLogStub = sinon.stub(console, 'log');
-            const sessionManager = new solisSessionManager({ basePath: '/api' });
-            await sessionManager.triggerRefresh();
-            expect(fetchStub).to.have.been.calledOnceWith('/api/v1/solis/session/refresh-token', {
-                method: 'GET',
-                credentials: 'same-origin'
-            });
-            expect(consoleLogStub).to.have.been.calledWith('Solis token refresh successful');
-        })
-
-        it('calls fetch with the correct URL and options when the basePath is undefined', async() => {
-            const fetchStub = sinon.stub(window, 'fetch');
-            fetchStub.resolves(new Response(null, {
-                status: 200,
-                statusText: 'OK'
-            }));
-            const consoleLogStub = sinon.stub(console, 'log');
-            const sessionManager = new solisSessionManager({});
-            await sessionManager.triggerRefresh();
-            expect(fetchStub).to.have.been.calledOnceWith('/v1/solis/session/refresh-token', {
-                method: 'GET',
-                credentials: 'same-origin'
-            });
-            expect(consoleLogStub).to.have.been.calledWith('Solis token refresh successful');
-        })
-
-        it('logs a message if the token refresh happened too recently, response status 429', async() => {
-            const fetchStub = sinon.stub(window, 'fetch');
-            fetchStub.resolves(new Response(null, {
-                status: 429,
-                statusText: 'Refresh already in progress'
-            }));
-            const consoleLogStub = sinon.stub(console, 'log');
-            const sessionManager = new solisSessionManager({});
-            await sessionManager.triggerRefresh();
-            expect(consoleLogStub).to.have.been.calledWith('Solis token refresh skipped (too recent)');
-        })
-
-        it('logs an error if the user is not authenticated, response status 401', async() => {
-            const fetchStub = sinon.stub(window, 'fetch');
-            fetchStub.resolves(new Response(null, {
-                status: 401,
-                statusText: 'Not found'
-            }));
-            const consoleErrorStub = sinon.stub(console, 'error');
-            const sessionManager = new solisSessionManager({});
-            await sessionManager.triggerRefresh();
-            expect(consoleErrorStub).to.have.been.calledWith('Solis token refresh unauthorized - triggering logout');
-        })
-
-        it('logs an error if the user is not authenticated, response status 403', async() => {
-            const fetchStub = sinon.stub(window, 'fetch');
-            fetchStub.resolves(new Response(null, {
-                status: 401,
-                statusText: 'Unauthorized'
-            }));
-            const consoleErrorStub = sinon.stub(console, 'error');
-            const sessionManager = new solisSessionManager({});
-            await sessionManager.triggerRefresh();
-            expect(consoleErrorStub).to.have.been.calledWith('Solis token refresh unauthorized - triggering logout');
-        })
-
-        it('logs an error if the response status is 500', async() => {
-            const fetchStub = sinon.stub(window, 'fetch');
-            fetchStub.resolves(new Response(null, {
-                status: 500,
-                statusText: 'Internal Server Error'
-            }));
-            const consoleErrorStub = sinon.stub(console, 'error');
-            const sessionManager = new solisSessionManager({});
-            await sessionManager.triggerRefresh();
-            expect(consoleErrorStub).to.have.been.calledWith('Solis token refresh failed:', 500);
-        })
-
-        it('logs an error if the fetch call fails', async() => {
-            const fetchStub = sinon.stub(window, 'fetch');
-            fetchStub.rejects(new Error('Network error'));
-            const consoleErrorStub = sinon.stub(console, 'error');
-            const sessionManager = new solisSessionManager({});
-            await sessionManager.triggerRefresh();
-            expect(consoleErrorStub).to.have.been.calledWith('Solis token refresh error:', 'Network error');
-        })
+    it('clears the interval if the token refresh schedule is running', () => {
+      const clearIntervalStub = sinon.stub(window, 'clearInterval');
+      const sessionManager = new solisSessionManager({});
+      sessionManager.startRefreshSchedule();
+      expect(sessionManager.isScheduleRunning()).to.be.true;
+      sessionManager.stopRefreshSchedule();
+      expect(clearIntervalStub).to.have.been.calledOnce;
+      expect(sessionManager.isScheduleRunning()).to.be.false;
     });
+  });
+
+  describe('triggerRefresh', () => {
+    it('calls fetch with the correct URL and options', async () => {
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub.resolves(
+        new Response(null, {
+          status: 200,
+          statusText: 'OK',
+        })
+      );
+      const consoleLogStub = sinon.stub(console, 'log');
+      const sessionManager = new solisSessionManager({ basePath: '/api' });
+      await sessionManager.triggerRefresh();
+      expect(fetchStub).to.have.been.calledOnceWith(
+        '/api/v1/solis/session/refresh-token',
+        {
+          method: 'GET',
+          credentials: 'same-origin',
+        }
+      );
+      expect(consoleLogStub).to.have.been.calledWith(
+        'Solis token refresh successful'
+      );
+    });
+
+    it('calls fetch with the correct URL and options when the basePath is undefined', async () => {
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub.resolves(
+        new Response(null, {
+          status: 200,
+          statusText: 'OK',
+        })
+      );
+      const consoleLogStub = sinon.stub(console, 'log');
+      const sessionManager = new solisSessionManager({});
+      await sessionManager.triggerRefresh();
+      expect(fetchStub).to.have.been.calledOnceWith(
+        '/v1/solis/session/refresh-token',
+        {
+          method: 'GET',
+          credentials: 'same-origin',
+        }
+      );
+      expect(consoleLogStub).to.have.been.calledWith(
+        'Solis token refresh successful'
+      );
+    });
+
+    it('logs a message if the token refresh happened too recently, response status 429', async () => {
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub.resolves(
+        new Response(null, {
+          status: 429,
+          statusText: 'Refresh already in progress',
+        })
+      );
+      const consoleLogStub = sinon.stub(console, 'log');
+      const sessionManager = new solisSessionManager({});
+      await sessionManager.triggerRefresh();
+      expect(consoleLogStub).to.have.been.calledWith(
+        'Solis token refresh skipped (too recent)'
+      );
+    });
+
+    it('logs an error if the user is not authenticated, response status 401', async () => {
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub.resolves(
+        new Response(null, {
+          status: 401,
+          statusText: 'Not found',
+        })
+      );
+      const consoleErrorStub = sinon.stub(console, 'error');
+      const sessionManager = new solisSessionManager({});
+      await sessionManager.triggerRefresh();
+      expect(consoleErrorStub).to.have.been.calledWith(
+        'Solis token refresh unauthorized - triggering logout'
+      );
+    });
+
+    it('logs an error if the user is not authenticated, response status 403', async () => {
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub.resolves(
+        new Response(null, {
+          status: 401,
+          statusText: 'Unauthorized',
+        })
+      );
+      const consoleErrorStub = sinon.stub(console, 'error');
+      const sessionManager = new solisSessionManager({});
+      await sessionManager.triggerRefresh();
+      expect(consoleErrorStub).to.have.been.calledWith(
+        'Solis token refresh unauthorized - triggering logout'
+      );
+    });
+
+    it('logs an error if the response status is 500', async () => {
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub.resolves(
+        new Response(null, {
+          status: 500,
+          statusText: 'Internal Server Error',
+        })
+      );
+      const consoleErrorStub = sinon.stub(console, 'error');
+      const sessionManager = new solisSessionManager({});
+      await sessionManager.triggerRefresh();
+      expect(consoleErrorStub).to.have.been.calledWith(
+        'Solis token refresh failed:',
+        500
+      );
+    });
+
+    it('logs an error if the fetch call fails', async () => {
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub.rejects(new Error('Network error'));
+      const consoleErrorStub = sinon.stub(console, 'error');
+      const sessionManager = new solisSessionManager({});
+      await sessionManager.triggerRefresh();
+      expect(consoleErrorStub).to.have.been.calledWith(
+        'Solis token refresh error:',
+        'Network error'
+      );
+    });
+  });
 });

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -39,7 +39,7 @@ export default class solisSessionManager {
       clearInterval(this.refreshIntervalId);
       this.refreshIntervalId = null;
     }
-  } // TODO - remember to call this function when implementing the logout story
+  } // TODO - call this function when implementing the logout story
 
   async triggerRefresh() {
     const fetchRoute = this.basePath

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -7,59 +7,64 @@
  * LICENSE file in the root directory of this source tree.
  */
 /* eslint jsdoc/require-jsdoc: 0 */
-import { solisSessionManagerConfig } from '../types/Header.types'
+import { solisSessionManagerConfig } from '../types/Header.types';
 
 export default class solisSessionManager {
-    private refreshIntervalId: number | null = null;
-    private tokenRefreshInterval: number;
-    private basePath: string | undefined;
-    config: solisSessionManagerConfig;
+  private refreshIntervalId: number | null = null;
+  private tokenRefreshInterval: number;
+  private basePath: string | undefined;
+  config: solisSessionManagerConfig;
 
-    constructor(config: solisSessionManagerConfig) {
-        this.config = config;
-        this.tokenRefreshInterval = config.tokenRefreshInterval || 25;
-        this.basePath = config.basePath;
+  constructor(config: solisSessionManagerConfig) {
+    this.config = config;
+    this.tokenRefreshInterval = config.tokenRefreshInterval || 25;
+    this.basePath = config.basePath;
+  }
+
+  startRefreshSchedule() {
+    this.refreshIntervalId = window.setInterval(
+      () => {
+        this.triggerRefresh();
+      },
+      this.tokenRefreshInterval * 60 * 1000
+    );
+  }
+
+  isScheduleRunning(): boolean {
+    return this.refreshIntervalId !== null;
+  }
+
+  stopRefreshSchedule() {
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId);
+      this.refreshIntervalId = null;
     }
+  } // TODO - remember to call this function when implementing the logout story
 
-    startRefreshSchedule() {
-        this.refreshIntervalId = window.setInterval(() => {
-            this.triggerRefresh();
-        }, this.tokenRefreshInterval * 60 * 1000);
+  async triggerRefresh() {
+    const fetchRoute = this.basePath
+      ? this.basePath + '/v1/solis/session/refresh-token'
+      : '/v1/solis/session/refresh-token';
+    try {
+      const response = await fetch(fetchRoute, {
+        method: 'GET',
+        credentials: 'same-origin',
+      });
+
+      if (response.ok) {
+        console.log('Solis token refresh successful');
+      } else if (response.status === 429) {
+        // refresh happened too recently
+        console.log('Solis token refresh skipped (too recent)'); // TODO - this response doesn't yet exist in the backend
+      } else if (response.status === 401 || response.status === 403) {
+        console.error('Solis token refresh unauthorized - triggering logout');
+        this.stopRefreshSchedule();
+        // TODO - trigger logout when logout story is implemented
+      } else {
+        console.error('Solis token refresh failed:', response.status);
+      }
+    } catch (error: any) {
+      console.error('Solis token refresh error:', error.message);
     }
-
-    isScheduleRunning(): boolean {
-        return this.refreshIntervalId !== null;
-    }
-
-    stopRefreshSchedule() {
-        if (this.refreshIntervalId) {
-            clearInterval(this.refreshIntervalId);
-            this.refreshIntervalId = null;
-        }
-    } // TODO - remember to call this function when implementing the logout story
-
-    async triggerRefresh() {
-        const fetchRoute = this.basePath ? this.basePath + '/v1/solis/session/refresh-token' : '/v1/solis/session/refresh-token';
-        try {
-            const response = await fetch(fetchRoute, {
-                method: 'GET',
-                credentials: 'same-origin'
-            });
-            
-            if (response.ok) {
-                console.log('Solis token refresh successful');
-            } else if (response.status === 429) { // refresh happened too recently 
-                console.log('Solis token refresh skipped (too recent)'); // TODO - this response doesn't yet exist in the backend 
-            } else if (response.status === 401 || response.status === 403) {
-                console.error('Solis token refresh unauthorized - triggering logout');
-                this.stopRefreshSchedule();
-                // TODO - trigger logout when logout story is implemented
-            } else {
-                console.error('Solis token refresh failed:', response.status)
-            }
-        } catch (error: any) {
-            console.error('Solis token refresh error:', error.message );
-        }
-    }
-
+  }
 }

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -12,11 +12,13 @@ import { solisSessionManagerConfig } from '../types/Header.types'
 export default class solisSessionManager {
     private refreshIntervalId: number | null = null;
     private tokenRefreshInterval: number;
+    private basePath: string | undefined;
     config: solisSessionManagerConfig;
 
     constructor(config: solisSessionManagerConfig) {
         this.config = config;
         this.tokenRefreshInterval = config.tokenRefreshInterval || 25;
+        this.basePath = config.basePath;
     }
 
     startRefreshSchedule() {
@@ -33,8 +35,9 @@ export default class solisSessionManager {
     } // TODO - remember to call this function when implementing the logout story
 
     async triggerRefresh() {
+        const fetchRoute = this.basePath ? this.basePath + '/v1/solis/session/refresh-token' : '/v1/solis/session/refresh-token';
         try {
-            const response = await fetch('/v1/solis/session/refresh-token', {
+            const response = await fetch(fetchRoute, {
                 method: 'GET',
                 credentials: 'same-origin'
             });

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -52,12 +52,13 @@ export default class solisSessionManager {
                 console.log('Solis token refresh skipped (too recent)'); // TODO - this response doesn't yet exist in the backend 
             } else if (response.status === 401 || response.status === 403) {
                 console.error('Solis token refresh unauthorized - triggering logout');
+                this.stopRefreshSchedule();
                 // TODO - trigger logout when logout story is implemented
             } else {
                 console.error('Solis token refresh failed:', response.status)
             }
-        } catch (error) {
-            console.error('Solis token refresh error:', error);
+        } catch (error: any) {
+            console.error('Solis token refresh error:', error.message );
         }
     }
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+/* eslint jsdoc/require-jsdoc: 0 */
+import { solisSessionManagerConfig } from '../types/Header.types'
+
+export default class solisSessionManager {
+    private refreshIntervalId: number | null = null;
+    private tokenRefreshInterval: number;
+    config: solisSessionManagerConfig;
+
+    constructor(config: solisSessionManagerConfig) {
+        this.config = config;
+        this.tokenRefreshInterval = config.tokenRefreshInterval || 25;
+    }
+
+    startRefreshSchedule() {
+        this.refreshIntervalId = window.setInterval(() => {
+            this.triggerRefresh();
+        }, this.tokenRefreshInterval * 60 * 1000);
+    }
+
+    stopRefreshSchedule() {
+        if (this.refreshIntervalId) {
+            clearInterval(this.refreshIntervalId);
+            this.refreshIntervalId = null;
+        }
+    } // TODO - remember to call this function when implementing the logout story
+
+    async triggerRefresh() {
+        try {
+            const response = await fetch('/v1/solis/session/refresh-token', {
+                method: 'GET',
+                credentials: 'same-origin'
+            });
+            
+            if (response.ok) {
+                console.log('Solis token refresh successful');
+            } else if (response.status === 429) { // refresh happened too recently 
+                console.log('Solis token refresh skipped (too recent)'); // TODO - this response doesn't yet exist in the backend 
+            } else if (response.status === 401 || response.status === 403) {
+                console.error('Solis token refresh unauthorized - triggering logout');
+                // TODO - trigger logout when logout story is implemented
+            } else {
+                console.error('Solis token refresh failed:', response.status)
+            }
+        } catch (error) {
+            console.error('Solis token refresh error:', error);
+        }
+    }
+
+}

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -27,6 +27,10 @@ export default class solisSessionManager {
         }, this.tokenRefreshInterval * 60 * 1000);
     }
 
+    isScheduleRunning(): boolean {
+        return this.refreshIntervalId !== null;
+    }
+
     stopRefreshSchedule() {
         if (this.refreshIntervalId) {
             clearInterval(this.refreshIntervalId);

--- a/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
@@ -390,3 +390,7 @@ declare global {
     _solis: solisWindowConfig;
   }
 }
+
+export interface solisSessionManagerConfig {
+  tokenRefreshInterval?: number;
+}

--- a/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
@@ -393,4 +393,5 @@ declare global {
 
 export interface solisSessionManagerConfig {
   tokenRefreshInterval?: number;
+  basePath?: string;
 }


### PR DESCRIPTION
#### Changelog

**New**

- Introduces solisSessionManager class
- solisSessionManager class handles the front end Solis token refresh logic
- solisSessionManager is controlled by the toggle `solisSessionManagerEnabled` which is currently `false` by default

**Changed**

- HybridIpaasHeader instantiates the solisSessionManager class (if `solisSessionManagerEnabled` is `true`) and triggers the token refresh interval
