### PR TITLE
fix(global-header): export types

### DIFF
--- a/packages/web-components/src/components/global-header/package.json
+++ b/packages/web-components/src/components/global-header/package.json
@@ -14,14 +14,15 @@
     "directory": "packages/global-header"
   },
   "exports": {
-    ".": "./es/wc-global-header.mjs",
+    ".": {
+      "import": "./es/wc-global-header.mjs",
+      "types": "./declarations.d.ts"
+    },
     "./react": "./es/wc-global-header-react.mjs",
-    "./es/*": "./es/*",
-    "./lib/*": "./lib/*"
+    "./es/*": "./es/*"
   },
   "files": [
     "es/",
-    "lib/",
     "declarations.d.ts"
   ],
   "types": "./declarations.d.ts",


### PR DESCRIPTION

**Changed**

- Export the typings via "exports" field as required by newer versions of typescript
- Remove "lib" references as we dont export CJS
