### PR TITLE
feat(UIShell): expose depth on SideNavMenu button as data-depth attri…

### DIFF
--- a/packages/react/src/components/UIShell/components/SideNavMenu.tsx
+++ b/packages/react/src/components/UIShell/components/SideNavMenu.tsx
@@ -490,6 +490,7 @@ export const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
         id={uniqueId}>
         <button
           aria-expanded={isExpanded}
+          data-depth={depth}
           className={buttonClassName}
           onClick={() => {
             if (onMenuToggle) {


### PR DESCRIPTION
SideNavMenu currently consumes the depth prop internally to increment it for children, but never forwards it to the DOM. This means consumers cannot use CSS attribute selectors to target menu buttons by depth — forcing brittle nesting-chain selectors instead.

Adding data-depth={depth} to the <button> makes the depth available in CSS

```
.cds--side-nav__submenu[data-depth='1'] { padding-inline-start: 1rem; }
.cds--side-nav__submenu[data-depth='0'] > .cds--side-nav__submenu-title { font-weight: 600; }
```

This is a non-breaking additive change 

Refs: carbon-design-system/carbon-experience-platform#1796

#### Changelog

**New**
passed data-depth={depth} 


#### Testing / Reviewing

CI checks should pass
open a sidenav with nested menus and confirm no layout/spacing regressions
