### PR TITLE
fix: move ref from iframe to link

### DIFF
--- a/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.stories.jsx
+++ b/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.stories.jsx
@@ -81,3 +81,53 @@ Default.args = {
   tall: false,
   lazy: false,
 };
+
+const actionableNotificationVariants = [
+  {
+    label: 'Default',
+    variant: 'components-notifications-actionable--default',
+  },
+  {
+    label: 'Low contrast',
+    variant: 'components-notifications-actionable--low-contrast',
+  },
+];
+
+/* eslint-disable react/forbid-dom-props */
+/**
+ * Scroll down to see the StorybookDemo iframe below the fold.
+ * With lazy=true the iframe src is only set once the "full demo" Link at the
+ * bottom of the component enters the viewport — by that point the page is
+ * already scrolled to the demo, so focus-stealing stories can't cause a jump.
+ */
+export const LazyLoadTest = (args) => (
+  <div>
+    <div
+      style={{
+        height: '90vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderBottom: '1px dashed #8d8d8d',
+      }}>
+      <p style={{ fontFamily: 'sans-serif', color: '#525252' }}>
+        ↓ Scroll down — the StorybookDemo iframe is below this spacer. With
+        lazy=true the iframe src should only be set once the component is fully
+        in view. Check the Network tab before scrolling to confirm.
+      </p>
+    </div>
+    <StorybookDemo
+      {...args}
+      url="https://react.carbondesignsystem.com"
+      variants={actionableNotificationVariants}
+    />
+  </div>
+);
+/* eslint-enable react/forbid-dom-props */
+LazyLoadTest.args = {
+  themeSelector: true,
+  wide: false,
+  tall: false,
+  lazy: true,
+};
+LazyLoadTest.storyName = 'Lazy load test (iframe below fold)';

--- a/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.tsx
+++ b/packages/react/src/components/MDXComponents/components/storybook-demo/storybook-demo.tsx
@@ -97,8 +97,10 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
   const iframeUrl =
     url + '/iframe.html?id=' + variant + '&globals=theme:' + theme;
 
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  // Tracks whether the iframe has entered the viewport at least once.
+  // For lazy demos, observe the Link below the iframe — once it enters the
+  // viewport the user has scrolled the whole component into view, so it's
+  // safe to load the iframe without causing a scroll jump.
+  const linkRef = useRef<HTMLAnchorElement>(null);
   const [isVisible, setIsVisible] = useState(!lazy);
 
   useEffect(() => {
@@ -110,8 +112,8 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
 
     setIsVisible(false);
 
-    const iframe = iframeRef.current;
-    if (!iframe) {
+    const link = linkRef.current;
+    if (!link) {
       return;
     }
 
@@ -122,10 +124,10 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
           observer.disconnect();
         }
       },
-      { rootMargin: '300px', threshold: 0 }
+      { rootMargin: '0px', threshold: 0 }
     );
 
-    observer.observe(iframe);
+    observer.observe(link);
     return () => {
       observer.disconnect();
     };
@@ -176,7 +178,6 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
       <Grid condensed>
         <Column sm={4} md={8} lg={columnWidth} className={demoClassNames}>
           <iframe
-            ref={iframeRef}
             title="Component demo"
             className={withPrefix('iframe')}
             src={isVisible ? iframeUrl : undefined}
@@ -191,6 +192,7 @@ export const StorybookDemo: MdxComponent<StorybookDemoProps> = ({
             This live demo contains only a preview of functionality and styles
             available for this component. View the{' '}
             <Link
+              ref={linkRef}
               href={`${url}/?path=/story/${variant}&globals=theme:${theme}`}>
               full demo
             </Link>{' '}


### PR DESCRIPTION
Closes #1307 
> [!NOTE]
> remove story before merge


Move IntersectionObserver target from `<iframe>` to `<Link>` to prevent scroll jump

#### Changelog

**Changed**

- `StorybookDemo` lazy loading now observes the `full demo` link instead of the iframe — the iframe `src` is only set once the entire component has scrolled into view, preventing focus-stealing stories from jumping the page on load

**Removed**

- `iframeRef` removed from `<iframe>` — no longer needed

#### Testing / Reviewing

- Open the **Lazy load test (iframe below fold)** story in Storybook
- Scroll down — confirm the page does **not** jump to the component on load
- Check the Network tab before scrolling to confirm no iframe request fires until the `full demo` link enters the viewport