### PR TITLE
feat: new switcher component from gatsby

### DIFF
--- a/packages/react/src/components/MDXComponents/components/index.scss
+++ b/packages/react/src/components/MDXComponents/components/index.scss
@@ -27,5 +27,6 @@
 @use './page-table/page-table';
 @use './resource-card/resource-card';
 @use './storybook-demo/storybook-demo';
+@use './switcher/switcher';
 @use './tabs/tabs';
 @use './video/video';

--- a/packages/react/src/components/MDXComponents/components/switcher/_switcher.scss
+++ b/packages/react/src/components/MDXComponents/components/switcher/_switcher.scss
@@ -1,0 +1,118 @@
+/*
+ * Copyright IBM Corp. 2022, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/colors' as colors;
+@use '@carbon/react/scss/type' as type;
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/motion' as motion;
+
+@use '../utils' as *;
+
+// ----------------------------------------------------------------------------
+// Nav container
+// ----------------------------------------------------------------------------
+
+.#{with-prefix('switcher')} {
+  position: fixed;
+  z-index: 10000;
+  inset-block-start: 48px;
+  inset-inline-end: 0;
+  block-size: 100%;
+  inline-size: 16rem;
+  overflow-y: hidden;
+  max-block-size: var(--#{with-prefix('switcher-max-height')}, 0px);
+  background-color: colors.$gray-100;
+  border-inline-start: 1px solid colors.$gray-80;
+  color: colors.$white-0;
+  transform: translateX(16rem);
+  transition: all motion.$duration-fast-02 motion(exit);
+
+  @include breakpoint.breakpoint('lg') {
+    transform: translateX(0);
+    block-size: auto;
+  }
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  li:first-of-type {
+    margin-block-start: spacing.$spacing-05;
+  }
+
+  li:last-of-type {
+    margin-block-end: spacing.$spacing-05;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Open state
+// ----------------------------------------------------------------------------
+
+.#{with-prefix('switcher--open')} {
+  transform: translateX(0);
+  border-block-end: 1px solid colors.$gray-80;
+  box-shadow: -2px 2px 6px rgba(0, 0, 0, 0.2);
+  transition: all motion.$duration-moderate-01 motion(entrance);
+
+  @include breakpoint.breakpoint('lg') {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5);
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Section divider
+// ----------------------------------------------------------------------------
+
+.#{with-prefix('switcher-divider')} {
+  margin: spacing.$spacing-07 spacing.$spacing-05 spacing.$spacing-03
+    spacing.$spacing-05;
+  padding-block-end: spacing.$spacing-02;
+  border-block-end: 1px solid colors.$gray-70;
+  color: colors.$gray-70;
+
+  span {
+    @include type.type-style('label-01');
+
+    color: colors.$gray-30;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Link
+// ----------------------------------------------------------------------------
+
+.#{with-prefix('switcher-link')} {
+  @include type.type-style('heading-01');
+
+  display: flex;
+  justify-content: space-between;
+  padding: 6px spacing.$spacing-05;
+  color: colors.$gray-30;
+  text-decoration: none;
+
+  &:hover {
+    background-color: #353535;
+    color: colors.$gray-10;
+  }
+
+  &:focus {
+    outline: 2px solid colors.$white-0;
+    outline-offset: -2px;
+  }
+}
+
+.#{with-prefix('switcher-link--disabled')} {
+  @include type.type-style('heading-01');
+
+  display: block;
+  padding: 6px spacing.$spacing-05;
+  color: colors.$gray-60;
+}

--- a/packages/react/src/components/MDXComponents/components/switcher/switcher.stories.jsx
+++ b/packages/react/src/components/MDXComponents/components/switcher/switcher.stories.jsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright IBM Corp. 2022, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { Switcher, SwitcherDivider, SwitcherLink } from './switcher';
+
+export default {
+  title: 'Components/MDX Components/Switcher',
+  component: Switcher,
+  subcomponents: { SwitcherDivider, SwitcherLink },
+  argTypes: {
+    children: {
+      control: false,
+    },
+    isOpen: {
+      control: 'boolean',
+    },
+    onToggle: {
+      control: false,
+    },
+  },
+};
+
+const Template = (args) => <Switcher {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  isOpen: true,
+};
+Default.storyName = 'Default (with default links)';
+
+export const CustomLinks = (args) => (
+  <Switcher {...args}>
+    <SwitcherDivider>Design Systems</SwitcherDivider>
+    <SwitcherLink href="https://www.carbondesignsystem.com/">
+      Carbon Design System
+    </SwitcherLink>
+    <SwitcherLink href="https://ibm.com/design/language">
+      IBM Design Language
+    </SwitcherLink>
+    <SwitcherDivider>IBM Internal</SwitcherDivider>
+    <SwitcherLink href="https://ibm.com/brand" isInternal>
+      IBM Brand Center
+    </SwitcherLink>
+    <SwitcherLink href="https://w3.ibm.com/design/" isInternal>
+      IBM Design
+    </SwitcherLink>
+    <SwitcherDivider>States</SwitcherDivider>
+    <SwitcherLink disabled href="https://www.example.com">
+      Disabled link
+    </SwitcherLink>
+  </Switcher>
+);
+CustomLinks.args = {
+  isOpen: true,
+};
+CustomLinks.storyName = 'Custom links';

--- a/packages/react/src/components/MDXComponents/components/switcher/switcher.tsx
+++ b/packages/react/src/components/MDXComponents/components/switcher/switcher.tsx
@@ -1,0 +1,294 @@
+/*
+ * Copyright IBM Corp. 2022, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Locked } from '@carbon/react/icons';
+import { clsx } from 'clsx';
+import PropTypes from 'prop-types';
+import React, {
+  AnchorHTMLAttributes,
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import { MdxComponent } from '../interfaces';
+import { mediaQueries, useMatchMedia, withPrefix } from '../utils';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface SwitcherContextInterface {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+}
+
+const SwitcherContext = createContext<SwitcherContextInterface>({
+  isOpen: false,
+  setIsOpen: () => undefined,
+});
+
+// ---------------------------------------------------------------------------
+// Default children
+// ---------------------------------------------------------------------------
+
+const DefaultChildren = () => (
+  <>
+    <SwitcherDivider>Foundations</SwitcherDivider>
+    <SwitcherLink href="https://ibm.com/brand" isInternal>
+      IBM Brand Center
+    </SwitcherLink>
+    <SwitcherLink href="https://ibm.com/design/language">
+      IBM Design Language
+    </SwitcherLink>
+    <SwitcherDivider>Implementation</SwitcherDivider>
+    <SwitcherLink href="https://www.carbondesignsystem.com/">
+      Carbon Design System
+    </SwitcherLink>
+    <SwitcherLink href="http://ibm.biz/carbon4ibmproducts" isInternal>
+      Carbon for IBM Products
+    </SwitcherLink>
+    <SwitcherLink href="https://ibm.biz/carbon4cloud" isInternal>
+      Carbon for Cloud
+    </SwitcherLink>
+    <SwitcherLink href="https://www.ibm.com/standards/carbon/">
+      Carbon for IBM.com
+    </SwitcherLink>
+    <SwitcherLink href="https://www.ibm.com/design/event/">
+      IBM Event Design
+    </SwitcherLink>
+    <SwitcherLink href="https://www.ibm.com/design/workplace/">
+      IBM Workplace Design
+    </SwitcherLink>
+    <SwitcherDivider>Practices</SwitcherDivider>
+    <SwitcherLink href="https://www.ibm.com/design/thinking/">
+      Enterprise Design Thinking
+    </SwitcherLink>
+    <SwitcherLink href="https://www.ibm.com/able/">
+      IBM Accessibility
+    </SwitcherLink>
+    <SwitcherLink href="https://www.ibm.com/design/ai">
+      IBM Design for AI
+    </SwitcherLink>
+    <SwitcherLink href="https://www.ibm.com/design/research/">
+      IBM Design Research
+    </SwitcherLink>
+    <SwitcherLink
+      isInternal
+      href="https://w3.ibm.com/design/experience-standards/">
+      IBM Experience Standards
+    </SwitcherLink>
+    <SwitcherDivider>Community</SwitcherDivider>
+    <SwitcherLink href="https://w3.ibm.com/design/" isInternal>
+      IBM Design
+    </SwitcherLink>
+  </>
+);
+
+// ---------------------------------------------------------------------------
+// Switcher
+// ---------------------------------------------------------------------------
+
+interface SwitcherProps {
+  /** Content rendered inside the nav. Defaults to the IBM Design ecosystem links. */
+  children?: ReactNode;
+  /** Controls open/closed state. When omitted the component manages its own state. */
+  isOpen?: boolean | null;
+  /** Called when the switcher requests a state change (e.g. Escape key). */
+  onToggle?: (open: boolean) => void;
+}
+
+/**
+ * The `<Switcher>` component renders a fixed side-nav containing links to
+ * related IBM design system sites. Use `<SwitcherDivider>` for section
+ * headings and `<SwitcherLink>` for individual links.
+ */
+export const Switcher: MdxComponent<SwitcherProps> = ({
+  children = <DefaultChildren />,
+  isOpen: isOpenProp,
+  onToggle,
+}) => {
+  const isLg = useMatchMedia(mediaQueries.lg);
+  const [isOpenState, setIsOpenState] = useState(false);
+
+  // Prefer controlled prop when provided, otherwise use internal state.
+  // Treat null as "not provided" (same as undefined) so callers can safely
+  // pass a nullable boolean from PropTypes without breaking the boolean context.
+  const isOpen: boolean = isOpenProp != null ? isOpenProp : isOpenState;
+
+  const setIsOpen = useCallback(
+    (open: boolean) => {
+      setIsOpenState(open);
+      onToggle?.(open);
+    },
+    [onToggle]
+  );
+
+  const navRef = useRef<HTMLElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Close on Escape key.
+  useEffect(() => {
+    const handleKeyUp = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('keyup', handleKeyUp);
+    return () => {
+      document.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [setIsOpen]);
+
+  // Drive max-height via a CSS custom property to avoid the inline style prop.
+  useEffect(() => {
+    if (!navRef.current) {
+      return;
+    }
+    const value =
+      !isLg && isOpen
+        ? '100%'
+        : isOpen && listRef.current
+          ? `${listRef.current.offsetHeight + 40}px`
+          : '0px';
+    navRef.current.style.setProperty(
+      `--${withPrefix('switcher-max-height')}`,
+      value
+    );
+  }, [isOpen, isLg]);
+
+  return (
+    <SwitcherContext.Provider value={{ isOpen, setIsOpen }}>
+      <nav
+        ref={navRef}
+        aria-label="IBM Design ecosystem"
+        className={clsx(withPrefix('switcher'), {
+          [withPrefix('switcher--open')]: isOpen,
+        })}
+        tabIndex={-1}>
+        <ul ref={listRef}>{children}</ul>
+      </nav>
+    </SwitcherContext.Provider>
+  );
+};
+
+Switcher.propTypes = {
+  /**
+   * Content rendered inside the nav. Defaults to the IBM Design ecosystem links.
+   */
+  children: PropTypes.node as unknown as React.Validator<ReactNode>,
+  /**
+   * Controls open/closed state. When omitted the component manages its own state.
+   */
+  isOpen: PropTypes.bool,
+  /**
+   * Called when the switcher requests a state change (e.g. Escape key).
+   */
+  onToggle: PropTypes.func as unknown as React.Validator<
+    ((open: boolean) => void) | undefined
+  >,
+};
+
+// ---------------------------------------------------------------------------
+// SwitcherDivider
+// ---------------------------------------------------------------------------
+
+interface SwitcherDividerProps {
+  children: ReactNode;
+}
+
+/**
+ * `<SwitcherDivider>` renders a labelled section separator inside `<Switcher>`.
+ */
+export const SwitcherDivider: MdxComponent<SwitcherDividerProps> = ({
+  children,
+}) => (
+  <li className={withPrefix('switcher-divider')}>
+    <span>{children}</span>
+  </li>
+);
+
+SwitcherDivider.propTypes = {
+  /**
+   * Section label text.
+   */
+  children: PropTypes.node.isRequired as unknown as React.Validator<ReactNode>,
+};
+
+// ---------------------------------------------------------------------------
+// SwitcherLink
+// ---------------------------------------------------------------------------
+
+interface SwitcherLinkProps extends Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  'href'
+> {
+  children: ReactNode;
+  href?: string | null;
+  /** Marks the link as IBM-internal and shows a lock icon. */
+  isInternal?: boolean | null;
+  /** Renders the link in a disabled, non-interactive state. */
+  disabled?: boolean | null;
+}
+
+/**
+ * `<SwitcherLink>` renders a single navigation link inside `<Switcher>`.
+ * Pass `isInternal` to append the IBM lock icon.
+ */
+export const SwitcherLink: MdxComponent<SwitcherLinkProps> = ({
+  children,
+  disabled,
+  href: hrefProp,
+  isInternal,
+  ...rest
+}) => {
+  const { isOpen } = useContext(SwitcherContext);
+  const isDisabled = disabled ?? false;
+  const href = isDisabled || !hrefProp ? undefined : hrefProp;
+  const className = isDisabled
+    ? withPrefix('switcher-link--disabled')
+    : withPrefix('switcher-link');
+  const tabIndex = isOpen && !isDisabled ? 0 : -1;
+
+  return (
+    <li>
+      <a
+        aria-disabled={isDisabled || undefined}
+        className={className}
+        href={href}
+        role="button"
+        tabIndex={tabIndex}
+        {...rest}>
+        {children}
+        {isInternal && <Locked />}
+      </a>
+    </li>
+  );
+};
+
+SwitcherLink.propTypes = {
+  /**
+   * Link label.
+   */
+  children: PropTypes.node.isRequired as unknown as React.Validator<ReactNode>,
+  /**
+   * When true, renders the link in a non-interactive disabled state.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Destination URL.
+   */
+  href: PropTypes.string,
+  /**
+   * When true, appends a lock icon to indicate an IBM-internal destination.
+   */
+  isInternal: PropTypes.bool,
+};

--- a/packages/react/src/components/MDXComponents/index.ts
+++ b/packages/react/src/components/MDXComponents/index.ts
@@ -41,6 +41,11 @@ export { PageTable } from './components/page-table/page-table';
 export { Preview } from './components/preview/preview';
 export { ResourceCard } from './components/resource-card/resource-card';
 export { StorybookDemo } from './components/storybook-demo/storybook-demo';
+export {
+  Switcher,
+  SwitcherDivider,
+  SwitcherLink,
+} from './components/switcher/switcher';
 export { Tab } from './components/tabs/tab';
 export { Tabs } from './components/tabs/tabs';
 export { Title } from './components/title/title';


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-experience-platform/issues/1953

Adds `Switcher`, `SwitcherDivider`, and `SwitcherLink` components to the MDX Components package, ported from the Carbon Gatsby theme.

#### Changelog

**New**

- `Switcher` — fixed-position dark side-nav with open/close animation, Escape-key support, and a built-in IBM Design ecosystem link list
- `SwitcherDivider` — labelled section separator for use inside `Switcher`
- `SwitcherLink` — navigation link with `isInternal` (lock icon) and `disabled` state support
- Storybook stories: `Default (with default links)` and `Custom links`

**Changed**

- Nothing.

**Removed**

- Nothing.

#### Testing / Reviewing

- Open Storybook → **Components / MDX Components / Switcher**
- `Default (with default links)`: panel should appear on the right edge with a dark (`#161616`) background and the full IBM Design ecosystem link list
- `Custom links`: verify section dividers, internal links show the lock icon, and the disabled link is non-interactive and dimmed
- Toggle `isOpen` control to `false` — panel should slide off-screen to the right
- With `isOpen: true`, press **Escape** — panel should close
- Hover a link: background should change to `#353535`, text to `#f4f4f4`
- Focus a link via keyboard: `2px solid #ffffff` outline should appear