### PR TITLE
chore: make workspace glob more specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "workspaces": [
     "packages/*",
-    "packages/*/**",
+    "packages/*/src/components/*",
+    "packages/*/src/v12/components/*",
     "tools/*"
   ],
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21778,12 +21778,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lib-64a98d@workspace:packages/react/src/components/AnimatedHeader/lib":
-  version: 0.0.0-use.local
-  resolution: "lib-64a98d@workspace:packages/react/src/components/AnimatedHeader/lib"
-  languageName: unknown
-  linkType: soft
-
 "libnpmaccess@npm:10.0.3":
   version: 10.0.3
   resolution: "libnpmaccess@npm:10.0.3"


### PR DESCRIPTION
Running into an issue where the `AnimatedHeader`'s `lib` folder is matched as a workspace  so yarn would register `AnimatedHeader/lib` and write it into `yarn.lock`. This causes issues as when the ci-checks run for a PR, the `yarn.lock` file sometimes gets modified - removing the `AnimatedHeader/lib` from the file.

This PR tightens up the workspace glob to not include the `AnimatedHeader/lib` directory as yarn shouldn't pick it up.

#### Changelog

**Changed**

- make workspace glob more specific

#### Testing / Reviewing

ci-checks should pass
