### PR TITLE
feat(global-header): Trigger Solis logout when user clicks header logout

### DIFF
--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -246,7 +246,9 @@ export class HybridIpaasHeader extends LitElement {
       arialLabel: 'Logout',
     };
 
-    if (this.logoutCallback) {
+    if (this.solisSessionManagerEnabled) {
+      footerLink.onClickHandler = () => this.sessionManager?.performLogout(); // will do nothing if sessionManager is not yet initialized (narrow window)
+    } else if (this.logoutCallback) {
       footerLink.onClickHandler = this.logoutCallback;
     } else if (this.logoutCallbackEvent) {
       footerLink.onClickHandler = () => {

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -74,8 +74,9 @@ export class HybridIpaasHeader extends LitElement {
   @property({ type: Boolean }) addCookiePreferences = false;
   @property({ type: Boolean }) forceBackendProxy = false; // override domain check; always enable the backend proxy when true
   @property({ type: Boolean }) solisSessionManagerEnabled = false; // toggle to enable/disable the Solis session manager
-  @property({ type: Number }) solisSessionRefreshInterval = 25; // might not need Solis token refresh interval to be configurable
-  @property({ type: Number }) solisIdleTimeoutInterval = 28; // might not need Solis idle timeout interval to be configurable
+  @property({ type: Number }) solisSessionRefreshInterval = 25; // (minutes) might not need Solis token refresh interval to be configurable
+  @property({ type: Number }) solisIdleTimeoutInterval = 28; // (minutes) might not need Solis idle timeout interval to be configurable
+  @property({ type: Number }) solisSessionStatusInterval = 10; // (seconds) might not need Solis session polling interval to be configurable
   @property({ type: String }) logoutUrl = '';
 
   @state()
@@ -212,6 +213,7 @@ export class HybridIpaasHeader extends LitElement {
       this.sessionManager = new solisSessionManager({
         tokenRefreshInterval: this.solisSessionRefreshInterval,
         idleTimeoutInterval: this.solisIdleTimeoutInterval,
+        sessionStatusInterval: this.solisSessionStatusInterval,
         basePath: this.basePath,
         logoutCallback,
         logoutUrl: this.logoutUrl || undefined,

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -76,7 +76,7 @@ export class HybridIpaasHeader extends LitElement {
   @property({ type: Boolean }) solisSessionManagerEnabled = false; // toggle to enable/disable the Solis session manager
   @property({ type: Number }) solisSessionRefreshInterval = 25; // might not need Solis token refresh interval to be configurable
   @property({ type: Number }) solisIdleTimeoutInterval = 28; // might not need Solis idle timeout interval to be configurable
-  @property({ type: String }) softLogoutUrl = '';
+  @property({ type: String }) logoutUrl = '';
 
   @state()
   headerOptions: HeaderProps = {
@@ -195,11 +195,11 @@ export class HybridIpaasHeader extends LitElement {
 
   private initializeSessionManager() {
     if (!this.sessionManager) {
-      let softLogoutCallback: (() => void) | undefined;
+      let logoutCallback: (() => void) | undefined;
       if (this.logoutCallback) {
-        softLogoutCallback = this.logoutCallback;
+        logoutCallback = this.logoutCallback;
       } else if (this.logoutCallbackEvent) {
-        softLogoutCallback = () => {
+        logoutCallback = () => {
           const event = new CustomEvent(this.logoutCallbackEvent, {
             bubbles: true,
             cancelable: true,
@@ -212,8 +212,8 @@ export class HybridIpaasHeader extends LitElement {
         tokenRefreshInterval: this.solisSessionRefreshInterval,
         idleTimeoutInterval: this.solisIdleTimeoutInterval,
         basePath: this.basePath,
-        softLogoutCallback,
-        softLogoutUrl: this.softLogoutUrl || undefined,
+        logoutCallback,
+        logoutUrl: this.logoutUrl || undefined,
       });
       this.sessionManager.startRefreshSchedule();
       this.sessionManager.registerActivityListeners();

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/HybridIpaasHeader.ts
@@ -111,6 +111,7 @@ export class HybridIpaasHeader extends LitElement {
     super.disconnectedCallback();
     if (this.sessionManager) {
       this.sessionManager.stopRefreshSchedule();
+      this.sessionManager.stopSessionStatusPolling();
       this.sessionManager.unregisterActivityListeners();
       this.sessionManager = null;
     }
@@ -216,6 +217,7 @@ export class HybridIpaasHeader extends LitElement {
         logoutUrl: this.logoutUrl || undefined,
       });
       this.sessionManager.startRefreshSchedule();
+      this.sessionManager.startSessionStatusPolling();
       this.sessionManager.registerActivityListeners();
     }
   }

--- a/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__tests__/HybridIpaasHeader.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/components/HybridIpaasHeader/__tests__/HybridIpaasHeader.test.ts
@@ -288,6 +288,10 @@ describe('HybridIpaasHeader Component', () => {
       solisSessionManager.prototype,
       'startRefreshSchedule'
     );
+    const startSessionStatusPollingStub = sinon.stub(
+      solisSessionManager.prototype,
+      'startSessionStatusPolling'
+    );
     const registerActivityListenersStub = sinon.stub(
       solisSessionManager.prototype,
       'registerActivityListeners'
@@ -304,6 +308,7 @@ describe('HybridIpaasHeader Component', () => {
 
     expect(el.sessionManager).to.not.be.null;
     expect(startRefreshScheduleStub).to.have.been.calledOnce;
+    expect(startSessionStatusPollingStub).to.have.been.calledOnce;
     expect(registerActivityListenersStub).to.have.been.calledOnce;
   });
 
@@ -346,6 +351,44 @@ describe('HybridIpaasHeader Component', () => {
         text: 'Log out',
       },
     ]);
+  });
+
+  it('should call sessionManager.performLogout when the logout link is clicked and solisSessionManagerEnabled is true', async () => {
+    fetchStub.resolves(
+      new Response(JSON.stringify(fetchResp), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const performLogoutStub = sinon.stub(
+      solisSessionManager.prototype,
+      'performLogout'
+    );
+    // stub out timer and listener functions
+    sinon.stub(solisSessionManager.prototype, 'startRefreshSchedule');
+    sinon.stub(solisSessionManager.prototype, 'startSessionStatusPolling');
+    sinon.stub(solisSessionManager.prototype, 'registerActivityListeners');
+
+    const el = await fixture<HybridIpaasHeader>(
+      html`<clabs-global-header-hybrid-ipaas
+        productName="Test Product"
+        productKey="test-productKey"
+        basePath="/base"
+        solisSessionManagerEnabled="true"></clabs-global-header-hybrid-ipaas>`
+    );
+    await waitUntil(
+      () =>
+        el.headerOptions.mainSectionItems &&
+        el.headerOptions.mainSectionItems[0].text === 'Test Product',
+      'headerOptions were not updated as expected'
+    );
+
+    const logoutLink = el.headerOptions.profileFooterLinks?.find(
+      (link) => link.text === 'Log out'
+    );
+    expect(logoutLink?.onClickHandler).to.exist;
+    logoutLink?.onClickHandler?.();
+    expect(performLogoutStub).to.have.been.calledOnce;
   });
 
   describe('logoutCallbackEvent', () => {

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
@@ -518,7 +518,7 @@ describe('solisSessionManager', () => {
       clock = sinon.useFakeTimers({
         shouldAdvanceTime: false,
         shouldClearNativeTimers: true,
-        toFake: ['setInterval', 'clearInterval'],
+        toFake: ['setTimeout', 'clearTimeout'],
       });
     });
 
@@ -533,7 +533,7 @@ describe('solisSessionManager', () => {
       sessionManager.stopSessionStatusPolling();
     });
 
-    it('calls checkSessionStatus after the specified interval has passed', () => {
+    it('calls checkSessionStatus after the specified interval has passed', async () => {
       const checkSessionStatusStub = sinon
         .stub(solisSessionManager.prototype, 'checkSessionStatus')
         .resolves(true);
@@ -543,8 +543,9 @@ describe('solisSessionManager', () => {
       sessionManager.startSessionStatusPolling();
       expect(sessionManager.isPollingRunning()).to.be.true;
       clock.tick(1 * 1000);
-      expect(checkSessionStatusStub).to.have.been.calledOnce;
+      await Promise.resolve(); // flush so poll completes before we stop
       sessionManager.stopSessionStatusPolling();
+      expect(checkSessionStatusStub).to.have.been.calledOnce;
     });
 
     it('calls performLogout if the session is inactive', async () => {
@@ -569,21 +570,35 @@ describe('solisSessionManager', () => {
   });
 
   describe('stopSessionStatusPolling', () => {
-    it('does nothing if the session status polling schedule is not running', () => {
-      const clearIntervalStub = sinon.stub(window, 'clearInterval');
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({
+        shouldAdvanceTime: false,
+        shouldClearNativeTimers: true,
+        toFake: ['setTimeout', 'clearTimeout'],
+      });
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('does nothing if the session status polling is not running', () => {
+      const clearTimeoutStub = sinon.stub(window, 'clearTimeout');
       const sessionManager = new solisSessionManager({});
       sessionManager.stopSessionStatusPolling();
       expect(sessionManager.isPollingRunning()).to.be.false;
-      expect(clearIntervalStub).to.not.have.been.called;
+      expect(clearTimeoutStub).to.not.have.been.called;
     });
 
-    it('clears the interval if the session status polling schedule is running', () => {
-      const clearIntervalStub = sinon.stub(window, 'clearInterval');
+    it('clears the timeout if the session status polling is running', () => {
+      const clearTimeoutStub = sinon.stub(window, 'clearTimeout');
       const sessionManager = new solisSessionManager({});
       sessionManager.startSessionStatusPolling();
       expect(sessionManager.isPollingRunning()).to.be.true;
       sessionManager.stopSessionStatusPolling();
-      expect(clearIntervalStub).to.have.been.calledOnce;
+      expect(clearTimeoutStub).to.have.been.calledOnce;
       expect(sessionManager.isPollingRunning()).to.be.false;
     });
   });

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
@@ -555,4 +555,24 @@ describe('solisSessionManager', () => {
       sessionManager.stopSessionStatusPolling();
     });
   });
+
+  describe('stopSessionStatusPolling', () => {
+    it('does nothing if the session status polling schedule is not running', () => {
+      const clearIntervalStub = sinon.stub(window, 'clearInterval');
+      const sessionManager = new solisSessionManager({});
+      sessionManager.stopSessionStatusPolling();
+      expect(sessionManager.isPollingRunning()).to.be.false;
+      expect(clearIntervalStub).to.not.have.been.called;
+    });
+
+    it('clears the interval if the session status polling schedule is running', () => {
+      const clearIntervalStub = sinon.stub(window, 'clearInterval');
+      const sessionManager = new solisSessionManager({});
+      sessionManager.startSessionStatusPolling();
+      expect(sessionManager.isPollingRunning()).to.be.true;
+      sessionManager.stopSessionStatusPolling();
+      expect(clearIntervalStub).to.have.been.calledOnce;
+      expect(sessionManager.isPollingRunning()).to.be.false;
+    });
+  });
 });

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
@@ -145,7 +145,7 @@ describe('solisSessionManager', () => {
         })
       );
       const consoleErrorStub = sinon.stub(console, 'error');
-      sinon.stub(solisSessionManager.prototype, 'performSoftLogout');
+      sinon.stub(solisSessionManager.prototype, 'performLogout');
       const sessionManager = new solisSessionManager({});
       await sessionManager.triggerRefresh();
       expect(consoleErrorStub).to.have.been.calledWith(
@@ -162,7 +162,7 @@ describe('solisSessionManager', () => {
         })
       );
       const consoleErrorStub = sinon.stub(console, 'error');
-      sinon.stub(solisSessionManager.prototype, 'performSoftLogout');
+      sinon.stub(solisSessionManager.prototype, 'performLogout');
       const sessionManager = new solisSessionManager({});
       await sessionManager.triggerRefresh();
       expect(consoleErrorStub).to.have.been.calledWith(
@@ -315,7 +315,7 @@ describe('solisSessionManager', () => {
     });
   });
 
-  describe('performSoftLogout', () => {
+  describe('performLogout', () => {
     let redirectStub: sinon.SinonStub;
 
     beforeEach(() => {
@@ -327,7 +327,7 @@ describe('solisSessionManager', () => {
       fetchStub.resolves(new Response(null, { status: 200, statusText: 'OK' }));
       const consoleLogStub = sinon.stub(console, 'log');
       const sessionManager = new solisSessionManager({ basePath: '/api' });
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(fetchStub).to.have.been.calledWith(
         '/api/v1/solis/session/logout',
         { method: 'POST', credentials: 'same-origin' }
@@ -342,7 +342,7 @@ describe('solisSessionManager', () => {
       fetchStub.resolves(new Response(null, { status: 200, statusText: 'OK' }));
       const consoleLogStub = sinon.stub(console, 'log');
       const sessionManager = new solisSessionManager({});
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(fetchStub).to.have.been.calledWith('/v1/solis/session/logout', {
         method: 'POST',
         credentials: 'same-origin',
@@ -359,7 +359,7 @@ describe('solisSessionManager', () => {
       );
       const consoleLogStub = sinon.stub(console, 'log');
       const sessionManager = new solisSessionManager({});
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(consoleLogStub).to.have.been.calledWith(
         'Solis session logout - session already expired'
       );
@@ -372,7 +372,7 @@ describe('solisSessionManager', () => {
       );
       const consoleErrorStub = sinon.stub(console, 'error');
       const sessionManager = new solisSessionManager({});
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(consoleErrorStub).to.have.been.calledWith(
         'Solis session logout failed:',
         500
@@ -384,7 +384,7 @@ describe('solisSessionManager', () => {
       fetchStub.rejects(new Error('Network error'));
       const consoleErrorStub = sinon.stub(console, 'error');
       const sessionManager = new solisSessionManager({});
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(consoleErrorStub).to.have.been.calledWith(
         'Solis session logout error:',
         'Network error'
@@ -392,58 +392,58 @@ describe('solisSessionManager', () => {
       expect(redirectStub).to.have.been.calledWith('/logout');
     });
 
-    it('invokes softLogoutCallback if provided', async () => {
+    it('invokes logoutCallback if provided', async () => {
       const fetchStub = sinon.stub(window, 'fetch');
       fetchStub.resolves(new Response(null, { status: 200, statusText: 'OK' }));
       const callbackSpy = sinon.spy();
       const sessionManager = new solisSessionManager({
-        softLogoutCallback: callbackSpy,
+        logoutCallback: callbackSpy,
       });
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(callbackSpy).to.have.been.calledOnce;
     });
 
-    it('still redirects when softLogoutCallback throws', async () => {
+    it('still redirects when logoutCallback throws', async () => {
       const fetchStub = sinon.stub(window, 'fetch');
       fetchStub.resolves(new Response(null, { status: 200, statusText: 'OK' }));
       const consoleErrorStub = sinon.stub(console, 'error');
       const failingCallback = sinon.stub().rejects(new Error('Callback error'));
       const sessionManager = new solisSessionManager({
-        softLogoutCallback: failingCallback,
-        softLogoutUrl: '/soft-logout',
+        logoutCallback: failingCallback,
+        logoutUrl: '/soft-logout',
       });
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(consoleErrorStub).to.have.been.calledWith(
-        'Soft logout failed with error: ',
+        'Logout failed with error: ',
         'Callback error'
       );
       expect(redirectStub).to.have.been.calledWith('/soft-logout');
     });
 
-    it('redirects to softLogoutUrl when provided', async () => {
+    it('redirects to logoutUrl when provided', async () => {
       const fetchStub = sinon.stub(window, 'fetch');
       fetchStub.resolves(new Response(null, { status: 200, statusText: 'OK' }));
       const sessionManager = new solisSessionManager({
-        softLogoutUrl: '/session-expired',
+        logoutUrl: '/session-expired',
         basePath: '/api',
       });
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(redirectStub).to.have.been.calledWith('/session-expired');
     });
 
-    it('falls back to basePath + /logout when softLogoutUrl is not provided', async () => {
+    it('falls back to basePath + /logout when logoutUrl is not provided', async () => {
       const fetchStub = sinon.stub(window, 'fetch');
       fetchStub.resolves(new Response(null, { status: 200, statusText: 'OK' }));
       const sessionManager = new solisSessionManager({ basePath: '/api' });
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(redirectStub).to.have.been.calledWith('/api/logout');
     });
 
-    it('falls back to /logout when neither softLogoutUrl nor basePath is provided', async () => {
+    it('falls back to /logout when neither logoutUrl nor basePath is provided', async () => {
       const fetchStub = sinon.stub(window, 'fetch');
       fetchStub.resolves(new Response(null, { status: 200, statusText: 'OK' }));
       const sessionManager = new solisSessionManager({});
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(redirectStub).to.have.been.calledWith('/logout');
     });
 
@@ -459,17 +459,17 @@ describe('solisSessionManager', () => {
         'unregisterActivityListeners'
       );
       const sessionManager = new solisSessionManager({});
-      await sessionManager.performSoftLogout();
+      await sessionManager.performLogout();
       expect(stopScheduleSpy).to.have.been.calledOnce;
       expect(unregisterSpy).to.have.been.calledOnce;
     });
   });
 
   describe('setIdle', () => {
-    it('sets isIdle to true and calls performSoftLogout when session is inactive', async () => {
-      const performSoftLogoutStub = sinon.stub(
+    it('sets isIdle to true and calls performLogout when session is inactive', async () => {
+      const performLogoutStub = sinon.stub(
         solisSessionManager.prototype,
-        'performSoftLogout'
+        'performLogout'
       );
       sinon
         .stub(solisSessionManager.prototype, 'checkSessionStatus')
@@ -477,20 +477,20 @@ describe('solisSessionManager', () => {
       const sessionManager = new solisSessionManager({});
       await sessionManager.setIdle();
       expect(sessionManager.isTabIdle()).to.be.true;
-      expect(performSoftLogoutStub).to.have.been.calledOnce;
+      expect(performLogoutStub).to.have.been.calledOnce;
     });
 
-    it('does not call performSoftLogout when session is active', async () => {
-      const performSoftLogoutStub = sinon.stub(
+    it('does not call performLogout when session is active', async () => {
+      const performLogoutStub = sinon.stub(
         solisSessionManager.prototype,
-        'performSoftLogout'
+        'performLogout'
       );
       sinon
         .stub(solisSessionManager.prototype, 'checkSessionStatus')
         .resolves(true);
       const sessionManager = new solisSessionManager({});
       await sessionManager.setIdle();
-      expect(performSoftLogoutStub).to.not.have.been.called;
+      expect(performLogoutStub).to.not.have.been.called;
     });
   });
 });

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
@@ -493,4 +493,61 @@ describe('solisSessionManager', () => {
       expect(performLogoutStub).to.not.have.been.called;
     });
   });
+
+  describe('startSessionStatusPolling', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({
+        shouldAdvanceTime: false,
+        shouldClearNativeTimers: true,
+        toFake: ['setInterval', 'clearInterval'],
+      });
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('sets the sessionStatusIntervalId', () => {
+      const sessionManager = new solisSessionManager({});
+      sessionManager.startSessionStatusPolling();
+      expect(sessionManager.isPollingRunning()).to.be.true;
+      sessionManager.stopSessionStatusPolling();
+    });
+
+    it('calls checkSessionStatus after the specified interval has passed', () => {
+      const checkSessionStatusStub = sinon
+        .stub(solisSessionManager.prototype, 'checkSessionStatus')
+        .resolves(true);
+      const sessionManager = new solisSessionManager({
+        sessionStatusInterval: 1,
+      });
+      sessionManager.startSessionStatusPolling();
+      expect(sessionManager.isPollingRunning()).to.be.true;
+      clock.tick(1 * 1000);
+      expect(checkSessionStatusStub).to.have.been.calledOnce;
+      sessionManager.stopSessionStatusPolling();
+    });
+
+    it('calls performLogout if the session is inactive', async () => {
+      const checkSessionStatusStub = sinon
+        .stub(solisSessionManager.prototype, 'checkSessionStatus')
+        .resolves(false);
+      const performLogoutStub = sinon.stub(
+        solisSessionManager.prototype,
+        'performLogout'
+      );
+      const sessionManager = new solisSessionManager({
+        sessionStatusInterval: 1,
+      });
+      sessionManager.startSessionStatusPolling();
+      expect(sessionManager.isPollingRunning()).to.be.true;
+      clock.tick(1 * 1000);
+      await Promise.resolve(); // flush microtask queue so the async interval callback resolves
+      expect(checkSessionStatusStub).to.have.been.calledOnce;
+      expect(performLogoutStub).to.have.been.calledOnce;
+      sessionManager.stopSessionStatusPolling();
+    });
+  });
 });

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
@@ -447,12 +447,16 @@ describe('solisSessionManager', () => {
       expect(redirectStub).to.have.been.calledWith('/logout');
     });
 
-    it('stops the refresh schedule and unregisters activity listeners', async () => {
+    it('stops the refresh schedule, stops session status polling, and unregisters activity listeners', async () => {
       const fetchStub = sinon.stub(window, 'fetch');
       fetchStub.resolves(new Response(null, { status: 200, statusText: 'OK' }));
       const stopScheduleSpy = sinon.spy(
         solisSessionManager.prototype,
         'stopRefreshSchedule'
+      );
+      const stopPollingSpy = sinon.spy(
+        solisSessionManager.prototype,
+        'stopSessionStatusPolling'
       );
       const unregisterSpy = sinon.spy(
         solisSessionManager.prototype,
@@ -461,6 +465,7 @@ describe('solisSessionManager', () => {
       const sessionManager = new solisSessionManager({});
       await sessionManager.performLogout();
       expect(stopScheduleSpy).to.have.been.calledOnce;
+      expect(stopPollingSpy).to.have.been.calledOnce;
       expect(unregisterSpy).to.have.been.calledOnce;
     });
   });

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/__tests__/solisSessionManager.test.ts
@@ -468,6 +468,18 @@ describe('solisSessionManager', () => {
       expect(stopPollingSpy).to.have.been.calledOnce;
       expect(unregisterSpy).to.have.been.calledOnce;
     });
+
+    it('does not execute if a logout is already in progress', async () => {
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub.resolves(new Response(null, { status: 200, statusText: 'OK' }));
+      const sessionManager = new solisSessionManager({});
+      // kick off two concurrent calls
+      await Promise.all([
+        sessionManager.performLogout(),
+        sessionManager.performLogout(),
+      ]);
+      expect(fetchStub).to.have.been.calledOnce;
+    });
   });
 
   describe('setIdle', () => {

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -12,6 +12,7 @@ import { solisSessionManagerConfig } from '../types/Header.types';
 export default class solisSessionManager {
   private refreshIntervalId: number | null = null;
   private sessionStatusIntervalId: number | null = null;
+  private isLoggingOut = false;
   private tokenRefreshInterval: number;
   private sessionStatusInterval: number;
   private idleTimeoutInterval: number;
@@ -154,6 +155,8 @@ export default class solisSessionManager {
   }
 
   async performLogout() {
+    if (this.isLoggingOut) return;
+    this.isLoggingOut = true;
     this.stopRefreshSchedule();
     this.stopSessionStatusPolling();
     this.unregisterActivityListeners();

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -192,17 +192,26 @@ export default class solisSessionManager {
   }
 
   startSessionStatusPolling() {
-    this.sessionStatusIntervalId = window.setInterval(async () => {
+    const poll = async () => {
       const sessionActive = await this.checkSessionStatus();
       if (!sessionActive) {
         await this.performLogout();
+        return; // don't reschedule after logout
       }
-    }, this.sessionStatusInterval * 1000);
+      this.sessionStatusIntervalId = window.setTimeout(
+        poll,
+        this.sessionStatusInterval * 1000
+      );
+    };
+    this.sessionStatusIntervalId = window.setTimeout(
+      poll,
+      this.sessionStatusInterval * 1000
+    );
   }
 
   stopSessionStatusPolling() {
     if (this.sessionStatusIntervalId) {
-      clearInterval(this.sessionStatusIntervalId);
+      clearTimeout(this.sessionStatusIntervalId);
       this.sessionStatusIntervalId = null;
     }
   }

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -204,6 +204,10 @@ export default class solisSessionManager {
     }
   }
 
+  isPollingRunning(): boolean {
+    return this.sessionStatusIntervalId !== null;
+  }
+
   redirect(url: string) {
     window.location.href = url;
   }

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -11,7 +11,9 @@ import { solisSessionManagerConfig } from '../types/Header.types';
 
 export default class solisSessionManager {
   private refreshIntervalId: number | null = null;
+  private sessionStatusIntervalId: number | null = null;
   private tokenRefreshInterval: number;
+  private sessionStatusInterval: number;
   private idleTimeoutInterval: number;
   private isIdle: boolean;
   private idleTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -25,6 +27,7 @@ export default class solisSessionManager {
   constructor(config: solisSessionManagerConfig) {
     this.config = config;
     this.tokenRefreshInterval = config.tokenRefreshInterval || 25;
+    this.sessionStatusInterval = config.sessionStatusInterval || 10;
     this.idleTimeoutInterval = config.idleTimeoutInterval || 28;
     this.basePath = config.basePath;
     this.activityEvents = [
@@ -152,6 +155,7 @@ export default class solisSessionManager {
 
   async performLogout() {
     this.stopRefreshSchedule();
+    this.stopSessionStatusPolling();
     this.unregisterActivityListeners();
     const postRoute = this.basePath
       ? this.basePath + '/v1/solis/session/logout'
@@ -182,6 +186,22 @@ export default class solisSessionManager {
     this.redirect(
       this.logoutUrl ?? (this.basePath ? `${this.basePath}/logout` : '/logout')
     );
+  }
+
+  startSessionStatusPolling() {
+    this.sessionStatusIntervalId = window.setInterval(async () => {
+      const sessionActive = await this.checkSessionStatus();
+      if (!sessionActive) {
+        await this.performLogout();
+      }
+    }, this.sessionStatusInterval * 1000);
+  }
+
+  stopSessionStatusPolling() {
+    if (this.sessionStatusIntervalId) {
+      clearInterval(this.sessionStatusIntervalId);
+      this.sessionStatusIntervalId = null;
+    }
   }
 
   redirect(url: string) {

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -18,8 +18,8 @@ export default class solisSessionManager {
   private basePath: string | undefined;
   private activityEvents: string[];
   private boundSetActive: () => void;
-  private softLogoutUrl: string | undefined;
-  private softLogoutCallback: (() => void) | undefined;
+  private logoutUrl: string | undefined;
+  private logoutCallback: (() => void) | undefined;
   config: solisSessionManagerConfig;
 
   constructor(config: solisSessionManagerConfig) {
@@ -39,8 +39,8 @@ export default class solisSessionManager {
     this.isIdle = false;
     this.idleTimeout = undefined;
     this.boundSetActive = () => this.setActive();
-    this.softLogoutUrl = config.softLogoutUrl;
-    this.softLogoutCallback = config.softLogoutCallback;
+    this.logoutUrl = config.logoutUrl;
+    this.logoutCallback = config.logoutCallback;
   }
 
   startRefreshSchedule() {
@@ -80,7 +80,7 @@ export default class solisSessionManager {
         console.log('Solis token refresh skipped (too recent)'); // TODO - this response doesn't yet exist in the backend
       } else if (response.status === 401 || response.status === 403) {
         console.error('Solis token refresh unauthorized - triggering logout');
-        await this.performSoftLogout();
+        await this.performLogout();
       } else {
         console.error('Solis token refresh failed:', response.status);
       }
@@ -119,7 +119,7 @@ export default class solisSessionManager {
     this.isIdle = true;
     const isSessionActive = await this.checkSessionStatus();
     if (!isSessionActive) {
-      await this.performSoftLogout();
+      await this.performLogout();
     }
   }
 
@@ -150,7 +150,7 @@ export default class solisSessionManager {
     }
   }
 
-  async performSoftLogout() {
+  async performLogout() {
     this.stopRefreshSchedule();
     this.unregisterActivityListeners();
     const postRoute = this.basePath
@@ -172,16 +172,15 @@ export default class solisSessionManager {
     } catch (error: any) {
       console.error('Solis session logout error:', error.message);
     }
-    if (this.softLogoutCallback) {
+    if (this.logoutCallback) {
       try {
-        await this.softLogoutCallback();
+        await this.logoutCallback();
       } catch (error: any) {
-        console.error('Soft logout failed with error: ', error.message);
+        console.error('Logout failed with error: ', error.message);
       }
     }
     this.redirect(
-      this.softLogoutUrl ??
-        (this.basePath ? `${this.basePath}/logout` : '/logout')
+      this.logoutUrl ?? (this.basePath ? `${this.basePath}/logout` : '/logout')
     );
   }
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -156,7 +156,9 @@ export default class solisSessionManager {
   }
 
   async performLogout() {
-    if (this.isLoggingOut) return;
+    if (this.isLoggingOut) {
+      return;
+    }
     this.isLoggingOut = true;
     this.stopRefreshSchedule();
     this.stopSessionStatusPolling();

--- a/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/globals/solisSessionManager.ts
@@ -124,6 +124,7 @@ export default class solisSessionManager {
     const isSessionActive = await this.checkSessionStatus();
     if (!isSessionActive) {
       await this.performLogout();
+      return;
     }
   }
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
@@ -327,7 +327,7 @@ export interface ReactWrapperProps extends Omit<
   solisSessionManagerEnabled?: boolean;
   solisSessionRefreshInterval?: number;
   solisIdleTimeoutInterval?: number;
-  softLogoutUrl?: string;
+  logoutUrl?: string;
 }
 
 export enum solisDeploymentEnvironment {
@@ -400,6 +400,6 @@ export interface solisSessionManagerConfig {
   tokenRefreshInterval?: number;
   idleTimeoutInterval?: number;
   basePath?: string;
-  softLogoutUrl?: string;
-  softLogoutCallback?: (() => void) | undefined;
+  logoutUrl?: string;
+  logoutCallback?: (() => void) | undefined;
 }

--- a/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
@@ -327,6 +327,7 @@ export interface ReactWrapperProps extends Omit<
   solisSessionManagerEnabled?: boolean;
   solisSessionRefreshInterval?: number;
   solisIdleTimeoutInterval?: number;
+  solisSessionStatusInterval?: number;
   logoutUrl?: string;
 }
 

--- a/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
+++ b/packages/web-components/src/components/global-header/components/global-header/src/types/Header.types.ts
@@ -399,6 +399,7 @@ declare global {
 export interface solisSessionManagerConfig {
   tokenRefreshInterval?: number;
   idleTimeoutInterval?: number;
+  sessionStatusInterval?: number;
   basePath?: string;
   logoutUrl?: string;
   logoutCallback?: (() => void) | undefined;


### PR DESCRIPTION
#### Changelog

**New**

- Hard logout orchestration - when the user clicks the logout link in the profile menu, if the Solis session manager is enabled, the performLogout function in solisSessionManager is invoked.
- Session status polling - during Solis session manager initialization in the header, polling to the `/v1/solis/session/session-status` endpoint is started. This has a default interval of 10 seconds. This allows the current tab to detect when a different tab has ended the Solis session and can react accordingly. A cleanup function is also provided to stop the session polling during logout, tab closure etc.
- Consumer configuration - `solisSessionStatusInterval` is exposed as an additional configurable property on HybridIpaasHeader and ReactWrapperProps.

**Changed**

- Renaming of `softLogoutCallback` and `softLogoutUrl` solisSessionManager properties to `logoutCallback` and `logoutUrl` as they are used for both soft (idle) logout and hard (user) logout.
